### PR TITLE
Unwanted class fro edit button's icon has been removed

### DIFF
--- a/app/views/settings/_show_desktop.html.erb
+++ b/app/views/settings/_show_desktop.html.erb
@@ -22,7 +22,7 @@
           <h1 class="font-semibold text-base">Personal information</h1>
           <%= link_to edit_settings_path, data: { turbo_frame: "edit-settings-modal" }, class: "box-shadow-medium flex items-center justify-between gap-1 rounded-sm py-1 px-2" do %>
             <span class="text-secondary text-xs font-medium">Edit</span>
-            <span class="icon icon-edit h-[10px] w-[10px] items-center"></span>
+            <span class="icon icon-edit h-[10px] w-[10px]"></span>
           <% end %>
         </div>
         <div>

--- a/app/views/settings/_show_mobile.html.erb
+++ b/app/views/settings/_show_mobile.html.erb
@@ -26,7 +26,7 @@
           <h1 class="font-semibold text-base">Personal information</h1>
           <%= link_to edit_settings_path, data: { turbo_frame: "edit-settings-modal" }, class: "box-shadow-medium flex items-center justify-between gap-1 rounded-sm py-1 px-2" do %>
             <span class="text-secondary text-xs font-medium">Edit</span>
-            <span class="icon icon-edit h-[10px] w-[10px] items-center"></span>
+            <span class="icon icon-edit h-[10px] w-[10px]"></span>
           <% end %>
         </div>
         <div>

--- a/app/views/shared/components/_button_default_small.html.erb
+++ b/app/views/shared/components/_button_default_small.html.erb
@@ -1,4 +1,4 @@
 <button class="box-shadow-medium flex items-center justify-between gap-1 rounded-sm py-1 px-2">
   <span class="text-secondary text-xs font-medium">Edit</span>
-  <span class="icon icon-edit h-[10px] w-[10px] items-center"></span>
+  <span class="icon icon-edit h-[10px] w-[10px]"></span>
 </button>

--- a/app/views/shared/components/_edit_button.html.erb
+++ b/app/views/shared/components/_edit_button.html.erb
@@ -1,4 +1,4 @@
 <button class="box-shadow-medium flex items-center justify-between gap-1 rounded-sm py-1 px-2">
   <span class="text-secondary text-xs font-medium">Edit</span>
-  <span class="icon-edit h-[10px] w-[10px] items-center"></span>
+  <span class="icon icon-edit h-[10px] w-[10px]"></span>
 </button>


### PR DESCRIPTION
Edit buttons issue is resolved when we resets minimum height and width ,now just removed an unwanted class(item-center) from the span tag which is used to show the edit icon