### PR TITLE
Team add modal upload team banner label text fixes

### DIFF
--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -14,7 +14,7 @@
       <%= render "shared/components/form_errors", resource: team %>
 
       <div class="flex flex-col gap-4 items-start justify-center w-full">
-        <label class="text-sm">Upload team banner (< 1 MB)</label>
+        <label class="text-sm flex flex-col">Upload team banner <span class="text-xs text-slate-grey font-light">(file size should be less than 1MB)</span></label>
         <!-- From component: pass the hidden file input field with data attribute forms_target: "fileInput" for this to work  -->
         <%= render "shared/components/file_select",
          hidden_file_field:  form.file_field(:banner, class: "hidden", data: { forms_target: "fileInput"}),


### PR DESCRIPTION
In Team add modal, "upload team banner" label text had some fixes with in the instruction (file size should be less than 1MB) also some styles added to it