### PR TITLE
Course headline correctons

### DIFF
--- a/app/views/shared/components/_course_card_with_left_image.html.erb
+++ b/app/views/shared/components/_course_card_with_left_image.html.erb
@@ -1,5 +1,5 @@
 <%= link_to course_path(course), class: "inline-block" do %>
-  <div class="rounded border w-[472px] h-[252px] flex hover:border-primary hover:cursor-pointer">
+  <div class="rounded w-[472px] h-[252px] box-shadow-medium flex hover:border border-line-colour-light hover:cursor-pointer">
     <%= image_tag course_banner_thumbnail_vertical(course), class: "h-full w-[140px] rounded-l object-cover" %>
     <div class="p-4">
       <p class="mb-2 overflow-hidden text-ellipsis text-base font-semibold text-primary max-h-[68px]">

--- a/app/views/shared/components/_course_description_card.html.erb
+++ b/app/views/shared/components/_course_description_card.html.erb
@@ -1,7 +1,7 @@
 <div class="border-line-colour flex flex-row border-b px-6 pt-6" data-controller="course-description-card">
   <%= image_tag course_banner_thumbnail_vertical(course), class: "h-[208px] w-[140px] rounded-l object-cover" %>
   <div class="flex flex-col px-4 pt-2">
-    <p class="text-primary mb-4 overflow-hidden text-ellipsis text-2xl font-extrabold italic">
+    <p class="text-primary mb-4 overflow-hidden text-ellipsis text-2xl font-extrabold">
       <%= course.title %>
     </p>
     <div class="mb-5 flex justify-between space-x-2">


### PR DESCRIPTION
Course headline in "italic" where reverted to normal ,also course card with left image where having a border and it is replaced with box shadow and hover effect added by border border-line-color

Fixes #90