### PR TITLE
On partners list arrow link was not working when clicking

### DIFF
--- a/app/views/learning_partners/index.html.erb
+++ b/app/views/learning_partners/index.html.erb
@@ -14,9 +14,9 @@
             <%= image_tag "vivanta.png",  alt: "useImage", class: "" %>
             <%= link_to learning_partner.name, learning_partner, class: "link" %>
          </div>
-         <a href="">  
-           <span class="icon icon-simple-arrow-right icon-small"></span>
-         </a>
+         <%= link_to learning_partner, class: "link" do%>
+          <span class="icon icon-simple-arrow-right icon-small"></span>
+         <% end %>
       </li>
       <% end %>
    </ul>


### PR DESCRIPTION
Arrow link was not having the link path ,so added the path .
Both clicking on arrow and the partner name will take to the partners page.

Fixes #154