### PR TITLE
complete and incomplete icons style changed

### DIFF
--- a/app/assets/stylesheets/icons.css.erb
+++ b/app/assets/stylesheets/icons.css.erb
@@ -124,8 +124,8 @@
 }
 
 .icon-check {
-    background-image: url("<%= asset_url('check.svg') %>");
-    background-repeat: no-repeat;
+    -webkit-mask:  url("<%= asset_url('check.svg') %>") no-repeat;
+    mask: url("<%= asset_url('check.svg') %>") no-repeat;
 }
 
 .icon-winner {

--- a/app/views/courses/_course_lessons.html.erb
+++ b/app/views/courses/_course_lessons.html.erb
@@ -1,72 +1,73 @@
 <% modules_in_order(course).each do |course_module| %>
   <details
     <% if current_module?(course_module, enrollment) %>
-       class="border-line-colour md:mx-4 rounded border highlighted" open="open"
+      class="border-line-colour md:mx-4 rounded border highlighted"
+      open="open"
     <% else %>
-       class="border-line-colour md:mx-4 rounded border"
+      class="border-line-colour md:mx-4 rounded border"
     <% end %>
-    >
-      <summary class="flex items-center justify-between p-4 cursor-pointer focus:outline-none md:p-6">
-        <h2 class="text-black0 font-semibold text-sm justify-start md:text-base">
-          <% if policy(course_module).show? %>
-            <%= link_to course_module.title, course_module_path(course, course_module), class: "nav-link" %>
-          <% else %>
-            <%= course_module.title %>
-          <% end %>
-          <span class="text-primary text-xs font-normal md:pl-5 md:text-sm md:font-medium">(<%= lessons_count(course_module) %>)</span>
-        </h2>
-        <div class="flex gap-4 items-center">
-          <% if policy(@course).edit? %>
-            <%= link_to course_module_path(course, course_module) do %>
-              <%= render 'shared/components/button_default_small', label: 'Edit', icon_name: 'icon-edit' %>
-            <% end %>
-          <% end %>
-          <div class="flex flex-col items-center">
-            <% if policy(:course_module).moveup? %>
-              <%= link_to moveup_course_module_path(course, course_module), data: { turbo_method: :put } do %>
-                <span class="icon icon-arrow-up icon-small block"></span>
-              <% end %>
-            <% end %>
-            <% if policy(:course_module).movedown? %>
-              <%= link_to movedown_course_module_path(course, course_module), data: { turbo_method: :put } do %>
-                <span class="icon icon-arrow-down icon-small block"></span>
-              <% end %>
-            <% end %>
-          </div>
-          <div class="flex items-center">
-            <span class="icon icon-down icon-small down-arrow"></span>
-            <span class="icon icon-up icon-small hidden up-arrow"></span>
-          </div>
-        </div>
-      </summary>
-      <ul>
-        <% lessons_in_order(course_module).each do |lesson| %>
-          <li class="flex items-center justify-between border-t border-line-colour px-4 py-4 text-sm md:px-6 <%= 'highlighted' if current_lesson?(lesson, enrollment) %>">
-            <div class="flex items-center gap-4">
-              <% if enrollment && lesson_completed?(enrollment, lesson) %>
-                <div class="flex items-center gap-4">
-                  <span class="icon bg-primary-light border-slate-grey icon-complete h-5 w-5 items-center border"></span>
-                </div>
-              <% end %>
-              <% if enrollment && !lesson_completed?(enrollment, lesson) %>
-                <div class="flex items-center gap-4">
-                  <span class="icon bg-gold border-slate-grey icon-incomplete h-5 w-5 items-center border"></span>
-                </div>
-              <% end %>
-              <span><%= lesson.title %></span>
-            </div>
-            <div class="flex gap-6 items-center">
-              <% if policy(@course).edit? %>
-                <%= link_to edit_course_module_lesson_path(course, course_module, lesson), class: "link-text" do %>
-                  <%= render 'shared/components/button_default_small', label: 'Edit', icon_name: 'icon-edit' %>
-                <% end %>
-              <% end %>
-              <%= link_to course_module_lesson_path(course, course_module, lesson), class: "hover:cursor-pointer" do %>
-                <span class="icon icon-play-lite icon-small md:h-5 md:w-5 "></span>
-              <% end %>
-            </div>
-          </li>
+  >
+    <summary class="flex items-center justify-between p-4 cursor-pointer focus:outline-none md:p-6">
+      <h2 class="text-black0 font-semibold text-sm justify-start md:text-base">
+        <% if policy(course_module).show? %>
+          <%= link_to course_module.title, course_module_path(course, course_module), class: 'nav-link' %>
+        <% else %>
+          <%= course_module.title %>
         <% end %>
-      </ul>
+        <span class="text-primary text-xs font-normal md:pl-5 md:text-sm md:font-medium">(<%= lessons_count(course_module) %>)</span>
+      </h2>
+      <div class="flex gap-4 items-center">
+        <% if policy(@course).edit? %>
+          <%= link_to course_module_path(course, course_module) do %>
+            <%= render 'shared/components/button_default_small', label: 'Edit', icon_name: 'icon-edit' %>
+          <% end %>
+        <% end %>
+        <div class="flex flex-col items-center">
+          <% if policy(:course_module).moveup? %>
+            <%= link_to moveup_course_module_path(course, course_module), data: { turbo_method: :put } do %>
+              <span class="icon icon-arrow-up icon-small block"></span>
+            <% end %>
+          <% end %>
+          <% if policy(:course_module).movedown? %>
+            <%= link_to movedown_course_module_path(course, course_module), data: { turbo_method: :put } do %>
+              <span class="icon icon-arrow-down icon-small block"></span>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="flex items-center">
+          <span class="icon icon-down icon-small down-arrow"></span>
+          <span class="icon icon-up icon-small hidden up-arrow"></span>
+        </div>
+      </div>
+    </summary>
+    <ul>
+      <% lessons_in_order(course_module).each do |lesson| %>
+        <li class="flex items-center justify-between border-t border-line-colour px-4 py-4 text-sm md:px-6 <%= 'highlighted' if current_lesson?(lesson, enrollment) %>">
+          <div class="flex items-center gap-4">
+            <% if enrollment && lesson_completed?(enrollment, lesson) %>
+              <div class="flex items-center bg-primary-light-50 border border-primary-light p-1">
+                <span class="icon icon-check h-[14px] w-[14px] bg-primary"></span>
+              </div>
+            <% end %>
+            <% if enrollment && !lesson_completed?(enrollment, lesson) %>
+              <div class="flex items-center bg-gold-light border border-gold p-1">
+                <span class="icon icon-incomplete h-[14px] w-[14px]"></span>
+              </div>
+            <% end %>
+            <span><%= lesson.title %></span>
+          </div>
+          <div class="flex gap-6 items-center">
+            <% if policy(@course).edit? %>
+              <%= link_to edit_course_module_lesson_path(course, course_module, lesson), class: "link-text" do %>
+                <%= render 'shared/components/button_default_small', label: 'Edit', icon_name: 'icon-edit' %>
+              <% end %>
+            <% end %>
+            <%= link_to course_module_lesson_path(course, course_module, lesson), class: "hover:cursor-pointer" do %>
+              <span class="icon icon-play-lite icon-small md:h-5 md:w-5 "></span>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
   </details>
 <% end %>

--- a/app/views/lessons/_play_list.html.erb
+++ b/app/views/lessons/_play_list.html.erb
@@ -33,7 +33,9 @@
             <li class="flex gap-4 items-center justify-between border-t border-line-colour px-4 py-4 text-sm <%= 'highlighted' if current_lesson?(lesson, enrollment) %>">
               <div class="flex items-center gap-4">
                 <% if enrollment && lesson_completed?(enrollment, lesson) %>
-                  <span class="icon bg-primary-light border-primary-light-50 icon-check h-5 w-5 flex-shrink-0 items-center border"></span>
+                  <div class="flex items-center bg-primary-light-50 border border-primary-light p-1">
+                    <span class="icon icon-check h-[14px] w-[14px] bg-primary"></span>
+                  </div>
                 <% end %>
                 <p class="flex flex-col md:flex-row md:gap-4 items-start">
                   <span class="text-letter-color-light text-sm md:text-base">


### PR DESCRIPTION
complete and incomplete indicators are not the same as the design 
Fixes #347
![Screenshot 2024-12-04 at 2 31 14 PM](https://github.com/user-attachments/assets/9ada1434-0ea0-4f5d-9ce3-f2365fce2b6d)
![Screenshot 2024-12-04 at 2 33 03 PM](https://github.com/user-attachments/assets/5f36da51-808c-4f3e-90dd-4b174d2d8a43)
![Screenshot 2024-12-04 at 2 33 12 PM](https://github.com/user-attachments/assets/ff849e3a-3247-4fb0-88eb-ac99522201ad)
![Screenshot 2024-12-04 at 2 33 25 PM](https://github.com/user-attachments/assets/1b2445e4-cb16-4bb5-b23c-ffd8466b4a40)
