### PR TITLE
inconsistent spacing in text while showing course card is solved

### DIFF
--- a/app/views/courses/_course_card_with_top_image.html.erb
+++ b/app/views/courses/_course_card_with_top_image.html.erb
@@ -24,7 +24,7 @@
       </div>
       <p class="my-2 overflow-hidden text-ellipsis text-sm font-medium tracking-tight text-black0 max-h-[20px]">Course
         Description</p>
-      <p class="overflow-hidden text-ellipsis text-justify text-sm tracking-tight text-letter-color-light max-h-[60px]"><%= course_description(course, 250) %></p>
+      <p class="overflow-hidden text-ellipsis text-sm tracking-tight text-letter-color-light max-h-[60px]"><%= course_description(course, 250) %></p>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
inconsistent spacing in text while showing course card.
Fixes  #419
![Screenshot 2024-12-30 at 1 02 06 PM](https://github.com/user-attachments/assets/a38b0eae-70a8-4f82-8888-d4c907ac1d1e)
