### PR TITLE
Enabled retry upload button if uploaded video vimeo url is not found in blob metadata

### DIFF
--- a/app/controllers/local_contents_controller.rb
+++ b/app/controllers/local_contents_controller.rb
@@ -13,11 +13,10 @@ class LocalContentsController < ApplicationController
 
     blob = @local_content.video.blob
     vimeo_url = blob.metadata['url']
+    @local_content.update!(status: :pending, updated_at: Time.now)
 
     UploadVideoToVimeoJob.perform_async(blob.id, @local_content.id)
     DeleteVideoFromVimeoJob.perform_async(vimeo_url)
-
-    @local_content.update!(updated_at: Time.now)
 
     redirect_to course_module_lesson_path(@course, @course_module, @lesson, lang: @local_content.lang)
   end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -12,7 +12,11 @@ module LessonsHelper
   end
 
   def is_upload_pending(local_content)
-    local_content.status == "pending" && local_content.updated_at < 30.minutes.ago
+    if local_content.video.blob.metadata['url'].nil? && local_content.status == "complete"
+      true
+    else
+      local_content.status == "pending" && local_content.updated_at < 30.minutes.ago
+    end
   end
 
   def get_local_content_lang(lesson)

--- a/app/services/vimeo/upload_video_service.rb
+++ b/app/services/vimeo/upload_video_service.rb
@@ -29,8 +29,8 @@ class Vimeo::UploadVideoService
       return
     end
 
-    local_content.update!(status: :complete)
     file.update!(metadata: file.metadata.merge(url: vimeo_link))
+    local_content.update!(status: :complete)
     upload_response
   end
 

--- a/app/views/lessons/_video_frame.html.erb
+++ b/app/views/lessons/_video_frame.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col md:basis-3/5">
   <div class="embed-container border-line-colour-light rounded border p-2 xl:h-[226px]">
     <% if @local_content.video.attached? %>
-      <% if is_upload_pending(@local_content) && current_user.is_admin? %>
+      <% if Rails.env.production? && is_upload_pending(@local_content) && current_user.is_admin? %>
         <div class="flex justify-center items-center">
           <%= link_to retry_course_module_lesson_local_content_path(course, course_module, lesson, lang: get_local_content_lang(lesson)),
               data: { turbo_method: :put } do %>


### PR DESCRIPTION
Fixes #472 
This will enable the `retry upload` button even if the Vimeo public URL is not found in the blob metadata.