### PR TITLE
Sidebar logo strecthing issue fixed

### DIFF
--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -2,7 +2,11 @@
 <div class="bg-black fixed inset-0 z-40 hidden bg-opacity-90 peer-checked:block md:peer-checked:hidden md:hidden"></div>
 <aside class="bg-primary-light-50 side-bar peer-checked:translate-x-0 peer-checked:transition-transform peer-checked:duration-300 peer-checked:ease-in-out">
   <label for="sidebar-toggle" class="md:hidden icon icon-close bg-letter-color absolute right-6 top-6 icon-small cursor-pointer"></label>
-  <%= image_tag 'instruo_beta_logo.png', alt: 'Instruo', class: 'h-10 pe-24 ps-8 hidden md:mt-8 md:block' %>
+
+  <div class="hidden md:mt-8 md:block">
+    <%= image_tag 'instruo_beta_logo.png', alt: 'Instruo', class: 'h-10 side-bar-item' %>
+  </div>
+
   <div class="flex h-[calc(100vh-60px)] md:h-full flex-col justify-between mt-14 z-150">
     <ul class="flex flex-col gap-3">
       <% if policy(:dashboard).index? %>


### PR DESCRIPTION
In the new layout the logo is stretched and blurred 
Fixes #488

![Screenshot 2025-01-08 at 11 42 14 AM](https://github.com/user-attachments/assets/5926c6c0-3efb-4a8e-8b3f-fcdac6e84eb0)
![Screenshot 2025-01-08 at 11 42 22 AM](https://github.com/user-attachments/assets/12e2c100-0a4c-4d5f-b14b-c7b33c0f9eab)
