### PR TITLE
Support tag at side bar not getting selected is solved

### DIFF
--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -48,7 +48,7 @@
           <% end %>
         </li>
       <% end %>
-      <li class="side-bar-item">
+      <li class="side-bar-item <%= sidebar_active('supports') %>">
         <%= link_to supports_path, class: "side-bar-item-inner" do %>
           <span class="icon icon-support bg-letter-color icon-small"></span>
           <span>Support</span>


### PR DESCRIPTION
Support tag was not getting selected when it is clicked like other tags getting selected is solved
Fixes #520

![Screenshot 2025-01-16 at 1 31 42 PM](https://github.com/user-attachments/assets/e3fd1878-6588-4549-aa3f-d7235b150c76)
