### PR TITLE
Standardized top margin for all headings

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/components/layout" do %>
-  <div class="flex items-center justify-between py-4 px-1">
+  <div class="flex items-center justify-between mb-4 px-1">
     <div class="medium-heading flex gap-1 heading">
       <span class="">Welcome</span><span class=""><%= current_user.display_name %></span>
     </div>

--- a/app/views/learning_partners/index.html.erb
+++ b/app/views/learning_partners/index.html.erb
@@ -1,10 +1,10 @@
 <%= render "shared/components/layout" do %>
-  <div class="flex justify-end text-right">
+  <div class="flex justify-between items-center">
+    <h1 class="heading page-heading-medium mb-4">Partners List</h1>
     <%= link_to new_learning_partner_path do %>
       <%= render 'shared/components/icon_button_primary', icon_name: 'icon-plus', label: 'Add Partner' %>
     <% end %>
   </div>
-  <h1 class="heading page-heading-medium my-6">Partners List</h1>
   <ul class="w-full">
     <% @learning_partners.each do |learning_partner| %>
       <li class="my-6">

--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/components/layout" do %>
-  <div class="flex justify-between pt-4 items-center">
+  <div class="flex justify-between items-center">
     <%= render 'shared/components/back_button', back_link: learning_partners_path %>
     <div class="flex items-center gap-4">
       <% if policy(@learning_partner).destroy? %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/components/layout" do %>
-  <h1 class="heading page-heading-medium my-6"><%= t("settings.label") %></h1>
+  <h1 class="heading page-heading-medium mb-4"><%= t("settings.label") %></h1>
   <div class="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 my-6">
     <% settings_list.each do |setting| %>
       <%= link_to setting[:path], class: "block" do %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -5,7 +5,7 @@
       <%= render 'shared/components/icon_button_primary', label: 'Add tag', icon_name: 'icon-plus' %>
     <% end %>
   </div>
-  <h1 class="mb-4 heading page-heading-medium pt-6">Tags</h1>
+  <h1 class="mb-4 heading page-heading-medium pt-2">Tags</h1>
   <div id="tags-count">
     <h1 class="mb-4 small-label"><%= pluralize(@tags_count, "tag") %></h1>
   </div>


### PR DESCRIPTION
All headings are aligned from the same distance from the nav bar
Fixes  #571

![Screenshot 2025-01-28 at 9 43 06 AM](https://github.com/user-attachments/assets/02d78941-76d7-4fe8-9e4a-837f65ff9bbd)
![Screenshot 2025-01-28 at 9 43 19 AM](https://github.com/user-attachments/assets/67a34b85-acf8-4e31-9dda-accf7ef984fc)
![Screenshot 2025-01-28 at 9 43 32 AM](https://github.com/user-attachments/assets/4ad7508f-5af7-4a0e-945a-7d6d4c98cf79)
![Screenshot 2025-01-28 at 9 43 43 AM](https://github.com/user-attachments/assets/6bbe4705-3f95-4ea5-9017-3c3ea5e37a10)
![Screenshot 2025-01-28 at 9 43 51 AM](https://github.com/user-attachments/assets/4f8d1ecc-fd17-4d73-83ac-2156c83a7e8d)
