### PR TITLE
Some missing font changes to poppins

### DIFF
--- a/app/views/course_assigns/_course_card.html.erb
+++ b/app/views/course_assigns/_course_card.html.erb
@@ -30,7 +30,7 @@
             <span class="ml-2 text-xs font-medium"><%= enroll_count(course) %></span>
           </div>
         </div>
-        <p class="max-h-[20px] overflow-hidden text-ellipsis text-sm font-medium tracking-tight">Course Description</p>
+        <p class="max-h-[20px] overflow-hidden text-ellipsis text-sm font-medium tracking-tight heading">Course Description</p>
         <div class="p-4 text-justify text-sm tracking-tight bg-primary-light-50 rounded-lg">
           <div class="h-full overflow-hidden flex items-center text-sm">
             <%= course_description(course) %>
@@ -38,7 +38,7 @@
         </div>
       </div>
       <div class="flex flex-col md:flex-row gap-2 items-end md:items-center absolute -top-24 md:top-0 -right-4 md:right-12 invisible opacity-0" data-assigns-target="durationContainer">
-        <label for="duration" class="font-medium text-sm md:text-base">Assign Duration:</label>
+        <label for="duration" class="heading font-medium text-sm md:text-base">Assign Duration:</label>
         <div class="flex flex-row items-center">
           <input type="date" id="datePicker" class="invisible w-[2px] p-0" data-action="change->assigns#datePicked" data-assigns-target="datePicker"/>            
           <%= f.select "duration[]", options_for_duration, {}, disabled: true, id: 'duration', class: "border border-line-colour-light box-shadow-small rounded focus:ring-0 p-0 px-2 h-6 w-28 text-sm", data: { assigns_target: "dateSelector", duration: 'duration' } %>

--- a/app/views/course_assigns/new.html.erb
+++ b/app/views/course_assigns/new.html.erb
@@ -1,7 +1,7 @@
 <%= render "shared/components/layout" do %>
   <%= render 'shared/components/back_button', back_link: team_path(current_user.team) %>
   <div class="flex flex-col md:flex-row  gap-4 justify-between items-start my-6">
-    <h1 class="pl-0 text-xl font-bold">Assign course</h1>
+    <h1 class="heading page-heading-medium pl-0">Assign course</h1>
     <div class="flex items-center gap-4">
       <div class="relative rounded-md shadow-sm">
         <div class="pointer-events-none absolute inset-y-0 flex items-center pl-3">

--- a/app/views/teams/_team_card.html.erb
+++ b/app/views/teams/_team_card.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag team_banner(team, 'desktop'), class: 'w-full h-[87px] object-fill rounded-t' %>
 
       <div class="flex flex-col items-start py-4 px-4">
-        <h3 class="font-medium text-primary"><%= team.name %></h3>
+        <h3 class="heading heading-medium text-primary"><%= team.name %></h3>
         <div class="flex flex-row items-center justify-between w-full">
           <div class="flex text-sm text-gray-500">
             <span class="icon-small icon icon-team bg-primary"></span>


### PR DESCRIPTION
Assign page heading and assign duration text  font changed to Poppins
Fixes  #633
![Screenshot 2025-01-29 at 1 05 06 PM](https://github.com/user-attachments/assets/e2f13dbc-b69f-4ee8-80af-4d670e7478a9)

Sub team title in the card  changed to font Poppins 
Fixes #634
![Screenshot 2025-01-29 at 1 13 37 PM](https://github.com/user-attachments/assets/312fbdeb-2bbc-4789-b8ba-51c95042752a)

