### PR TITLE
Fix Filter tab positioning to align with the top right after the navbar

### DIFF
--- a/app/views/searches/_filters.html.erb
+++ b/app/views/searches/_filters.html.erb
@@ -1,4 +1,4 @@
-<div class="md:w-80 w-full bg-white box-shadow-medium fixed right-0 -mt-8 h-screen hidden z-50" data-searches-target="filters">
+<div class="md:w-80 w-full bg-white box-shadow-medium fixed right-0 top-0 md:top-20 h-screen hidden z-50" data-searches-target="filters">
   <div class="flex flex-row items-center justify-between border-b-2 border-line-colour mb-4 p-4">
     <h2 class="text-lg font-semibold">Filter by</h2>
     <span class="icon icon-close icon-small cursor-pointer bg-black" data-action="click->searches#closeFilter"></span>

--- a/app/views/searches/_filters.html.erb
+++ b/app/views/searches/_filters.html.erb
@@ -1,4 +1,4 @@
-<div class="md:w-80 w-full bg-white box-shadow-medium fixed right-0 top-0 md:top-20 h-screen hidden z-50" data-searches-target="filters">
+<div class="md:w-80 w-full bg-white box-shadow-medium fixed right-0 top-0 h-screen hidden z-50" data-searches-target="filters">
   <div class="flex flex-row items-center justify-between border-b-2 border-line-colour mb-4 p-4">
     <h2 class="text-lg font-semibold">Filter by</h2>
     <span class="icon icon-close icon-small cursor-pointer bg-black" data-action="click->searches#closeFilter"></span>

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,5 +1,7 @@
 <div data-controller="searches" class="w-full mb-4">
   <%= form_with url: search_path, method: :post, data: { action: "submit->searches#formSubmit", searches_target: "form" }, class: "w-full" do |form| %>
+    <%= render 'searches/filters', tags: tags, form: form %>
+
     <%= form.hidden_field :context, value: context %>
 
     <% if context == "team_assign" %>
@@ -25,8 +27,7 @@
       <div class="absolute inset-y-0 right-4 flex items-center cursor-pointer" data-action="click->searches#formSubmit">
         <span class="flex cursor-pointer items-center text-purple text-base">Search</span>
       </div>
-    </div>
-    <%= render 'searches/filters', tags: tags, form: form %>
+    </div> 
   <% end %>
 
   <div class="flex items-center justify-end w-full gap-4 my-4">


### PR DESCRIPTION
Filter tab not starting from the top right after the nav bar issue resolved
Fixes #659

![Screenshot 2025-02-05 at 3 02 58 PM](https://github.com/user-attachments/assets/9bd41feb-70a6-4fc6-ab9a-7821aa5f9b94)
![Screenshot 2025-02-05 at 3 03 28 PM](https://github.com/user-attachments/assets/e2cdd3f3-272c-4df5-8fe8-512199199189)
