### PR TITLE
Fixed `no_console` script fails if no JS files found in the staged files

### DIFF
--- a/.husky/helpers/no_console.sh
+++ b/.husky/helpers/no_console.sh
@@ -1,6 +1,10 @@
-if git diff --cached --name-only | grep -E '^app/javascript/.*\.js$' | xargs grep -nE 'console\.(log|warn|error)'; then
-  echo "❌ Commit rejected! Remove console statements from JavaScript files."
-  exit 1
+echo "Running no console pre-commit hook"
+
+if js_files=$(git diff --cached --name-only | grep -E '^app/javascript/.*\.js$'); then
+  if echo "$js_files" | xargs grep -nE 'console\.(log|warn|error)'; then
+    echo "❌ Commit rejected! Remove console statements from JavaScript files."
+    exit 1
+  fi
 fi
 
 exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@ echo "Running precommit hooks"
 bundle exec rubocop -A
 
 . "$(dirname "$0")/helpers/no_console.sh"
-no_console


### PR DESCRIPTION
Fixes #660 