### PR TITLE
Fixed page width inconsistency in courses and learning partners  admin pages

### DIFF
--- a/app/views/course_modules/_form.html.erb
+++ b/app/views/course_modules/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="box">
+<div class="box md:max-w-3xl">
   <div class="my-8 text-left">
     <% url = course_module.persisted? ? course_module_path(course, course_module) : course_modules_path(course, course_module) %>
     <%= form_with(model: [course, course_module], url: url) do |form| %>

--- a/app/views/course_modules/edit.html.erb
+++ b/app/views/course_modules/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="my-4 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render 'shared/components/back_button', back_link: course_module_path(@course, @course_module) %>
   <div class="heading page-heading my-4">Edit module</div>
   <%= render "form", course: @course, course_module: @course_module %>

--- a/app/views/course_modules/new.html.erb
+++ b/app/views/course_modules/new.html.erb
@@ -1,4 +1,4 @@
-<div class="my-4 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render 'shared/components/back_button', back_link: course_path(@course) %>
   <div class="heading page-heading my-4">Add new module</div>
   <%= render "form", course: @course, course_module: @course_module %>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="w-auto">
+<div class="w-auto md:max-w-3xl">
   <%= form_with(model: course) do |form| %>
     <%= render "shared/components/form_errors", resource: course %>
     <div class="mb-8 text-sm">

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="my-4 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render 'shared/components/back_button', back_link: course_path(@course) %>
   <div class="box">
     <h1 class="heading page-heading-medium">Edit course</h1>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -1,4 +1,4 @@
-<div class="my-4 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render 'shared/components/back_button', back_link: courses_path %>
 
   <div class="box">

--- a/app/views/learning_partners/_form.html.erb
+++ b/app/views/learning_partners/_form.html.erb
@@ -1,4 +1,4 @@
-<div  data-controller="file-upload">
+<div  data-controller="file-upload" class="md:max-w-3xl">
   <%= form_with(model: learning_partner) do |form| %>
     <%= render "shared/components/form_errors", resource: learning_partner %>
 

--- a/app/views/learning_partners/edit.html.erb
+++ b/app/views/learning_partners/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="my-8 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render "shared/components/back_button", back_link: learning_partner_path(@learning_partner) %>
   <%= render "form", learning_partner: @learning_partner %>
 </div>

--- a/app/views/learning_partners/new.html.erb
+++ b/app/views/learning_partners/new.html.erb
@@ -1,4 +1,4 @@
-<div class="my-8 mx-auto w-full text-left md:max-w-3xl">
+<div class="my-4 mx-auto w-full text-left">
   <%= render "shared/components/back_button", back_link: learning_partners_path %>
   <%= render "form", learning_partner: @learning_partner %>
 </div>

--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-between items-center">
+<div class="flex justify-between items-center my-2">
   <%= render 'shared/components/back_button', back_link: learning_partners_path %>
   <div class="flex items-center gap-4">
     <% if policy(@learning_partner).destroy? %>

--- a/app/views/lessons/_form.html.erb
+++ b/app/views/lessons/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="my-8 text-left" data-controller="lessons-form" data-lessons-form-action-name="<%= action_name %>">
+<div class="my-8 text-left md:max-w-3xl" data-controller="lessons-form" data-lessons-form-action-name="<%= action_name %>">
   <% url = lesson.persisted? ? course_module_lesson_path(course, course_module, lesson) : course_module_lessons_path(course, course_module, lesson) %>
   <%= form_with(model: lesson, url: url) do |form| %>
     <%= form.hidden_field :has_error, value: @lesson.errors.any?, data: { lessons_form_target: "hasError" } %>

--- a/app/views/lessons/edit.html.erb
+++ b/app/views/lessons/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full mx-auto md:max-w-3xl text-left">
+<div class="w-full mx-auto text-left my-4">
   <%= render 'shared/components/back_button', back_link: course_module_path(@course, @course_module) %>
   <%= render "form", course: @course, course_module: @course_module, lesson: @lesson %>
 </div>

--- a/app/views/lessons/new.html.erb
+++ b/app/views/lessons/new.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full mx-auto md:max-w-3xl text-left">
+<div class="w-full mx-auto text-left my-4">
   <%= render 'shared/components/back_button', back_link: course_module_path(@course, @course_module) %>
   <%= render "form", course: @course, course_module: @course_module, lesson: @lesson %>
 </div>

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4 text-left">
+<div class="mb-4 text-left md:max-w-3xl w-full">
   <% form_url = quiz.persisted? ? course_module_quiz_path(course, course_module, quiz) :  course_module_quizzes_path(course, course_module) %>
   <%= form_with(url: form_url, model:  quiz) do |form| %>
     <%= render "shared/components/form_errors", resource: quiz %>

--- a/app/views/quizzes/edit.html.erb
+++ b/app/views/quizzes/edit.html.erb
@@ -1,5 +1,4 @@
-<div class="w-full mx-auto md:max-w-3xl text-left">
-
+<div class="w-full mx-auto text-left my-4">
   <div class="heading page-heading flex items-center gap-2 mt-4 mb-6">
     <%= link_to course_module_path(@course, @course_module), class: "nav-link" do %>
       <div class="flex gap-1 items-center ">
@@ -8,6 +7,6 @@
     <% end %>
     <span> Update quiz </span>
  </div>
-  <%= render "form", course: @course, course_module: @course_module, quiz: @quiz %>
+ <%= render "form", course: @course, course_module: @course_module, quiz: @quiz %>
 </div>
  

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full mx-auto md:max-w-3xl text-left">
+<div class="w-full mx-auto text-left my-4">
   <%= render 'shared/components/back_button', back_link: course_module_path(@course, @course_module) %>
   <div class="heading page-heading my-4">Create quiz</div>
   <%= render "form", course: @course, course_module: @course_module, quiz: @quiz %>


### PR DESCRIPTION
fixes #789

Fixed alignment of form pages while maintaining width consistency

Previously, form pages were centered with free space on both sides, while normal pages were full-width.
Now, the form pages remain the same width but are left-aligned instead of centered.
This ensures the back button stays in the same position for a more consistent user experience.
https://www.loom.com/share/b16882a1e735424185bbcb4983852aed?sid=244ad077-4b65-4ea2-b0be-fb1bb56307ff
