### PR TITLE
resolve dropdown overlap with partner title using z-50

### DIFF
--- a/app/views/shared/components/_more_action.html.erb
+++ b/app/views/shared/components/_more_action.html.erb
@@ -2,7 +2,7 @@
   <label class="flex items-center cursor-pointer rounded-full <%= label_hover %>" data-action="click->more-action#toggleDropdown">
     <span class="icon icon-more-vertical icon-small <%= icon_class %>"></span>
   </label>
-  <div class="absolute right-0 bg-white rounded box-shadow-medium hidden mt-3 z-10 w-auto" data-more-action-target="moreMenu" data-user-status-confirmation-target="moreMenu">
+  <div class="absolute right-0 bg-white rounded box-shadow-medium hidden mt-3 z-50 w-auto" data-more-action-target="moreMenu" data-user-status-confirmation-target="moreMenu">
     <%= yield %>
   </div>
 </div>


### PR DESCRIPTION
Added a higher z-index to the dropdown container.
Fixes #810

![Screenshot 2025-04-06 at 8 58 49 PM](https://github.com/user-attachments/assets/bddf87b6-806b-4802-97f7-a3691db5c7af)
