### PR TITLE
Refactor member_list partial to support scrollable layout via outer height wrapper

### DIFF
--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -85,6 +85,6 @@
     </div>
   </div>
 </div>
-<div class="max-h-[400px] overflow-hidden p-1 mt-5 shadow rounded">
+<div class="max-h-[400px] overflow-hidden p-1 mt-5 md:shadow rounded">
   <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members %>
 </div>

--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -85,6 +85,12 @@
     </div>
   </div>
 </div>
-<div class="max-h-[500px] overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members.page(params[:page]).per(10) %>
-</div>
+<% if @learning_partner.parent_team.members.any? %>
+  <div class="max-h-[520px] overflow-hidden p-1 mt-5 md:shadow rounded">
+    <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members.page(params[:page]).per(5) %>
+  </div>
+<% else %>
+  <div class="text-center text-sm mt-6">
+    No users available.
+  </div>
+<% end %>

--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -85,6 +85,6 @@
     </div>
   </div>
 </div>
-<div class="max-h-[400px] overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members %>
+<div class="max-h-[500px] overflow-hidden p-1 mt-5 md:shadow rounded">
+  <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members.page(params[:page]).per(10) %>
 </div>

--- a/app/views/learning_partners/show.html.erb
+++ b/app/views/learning_partners/show.html.erb
@@ -85,4 +85,6 @@
     </div>
   </div>
 </div>
-<%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members %>
+<div class="max-h-[400px] overflow-hidden p-1 mt-5 shadow rounded">
+  <%= render 'teams/member_list', team: @learning_partner.parent_team, members: @learning_partner.parent_team.members %>
+</div>

--- a/app/views/teams/_member_list.erb
+++ b/app/views/teams/_member_list.erb
@@ -1,6 +1,6 @@
 
 <div class="h-full flex flex-col">
-  <div id="teams-list" class="flex-shrink-0 py-4 md:px-6 border-b border-line-colour-light">
+  <div id="teams-list" class="flex-shrink-0 md:py-4 md:px-6 md:border-b border-line-colour-light">
     <div class="hidden md:grid grid-cols-12 gap-4 text-left text-sm font-medium  w-full">
       <div class="col-span-4 flex justify-start">Name</div>
       <div class="col-span-3 flex justify-start">Email</div>
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <div id="team-member-list" class="flex-1 overflow-y-auto p-1 md:divide-y md:divide-slate-grey-light">
+  <div id="team-member-list" class="flex-1 overflow-y-auto p-2 md:divide-y md:divide-slate-grey-light">
     <% members.each do |member| %>
       <%= render "teams/member_list_items", team: team, member: member %>
     <% end %>

--- a/app/views/teams/_member_list.erb
+++ b/app/views/teams/_member_list.erb
@@ -1,6 +1,7 @@
-<div class="mt-5">
-  <div id="teams-list" class="flex flex-col py-4 md:px-6 md:shadow-[0px_0px_4px_0px_#33333329] rounded">
-    <div class="hidden md:grid grid-cols-12 gap-4 text-left text-sm font-medium px-6 py-4 border-b border-line-colour-light w-full">
+
+<div class="h-full flex flex-col">
+  <div id="teams-list" class="flex-shrink-0 py-4 md:px-6 border-b border-line-colour-light">
+    <div class="hidden md:grid grid-cols-12 gap-4 text-left text-sm font-medium  w-full">
       <div class="col-span-4 flex justify-start">Name</div>
       <div class="col-span-3 flex justify-start">Email</div>
       <div class="col-span-2 flex justify-start">Phone</div>
@@ -11,10 +12,11 @@
         </div>
       </div>
     </div>
-    <div id="team-member-list" class="bg-white md:divide-y md:divide-slate-grey-light flex flex-col gap-4 md:gap-0  <%= 'max-h-[350px]' if limited_height %> overflow-y-auto p-1">
-      <% members.each do |member| %>
-        <%= render "teams/member_list_items", team: team, member: member %>
-      <% end %>
-    </div>
+  </div>
+
+  <div id="team-member-list" class="flex-1 overflow-y-auto p-1 md:divide-y md:divide-slate-grey-light">
+    <% members.each do |member| %>
+      <%= render "teams/member_list_items", team: team, member: member %>
+    <% end %>
   </div>
 </div>

--- a/app/views/teams/_member_list.erb
+++ b/app/views/teams/_member_list.erb
@@ -18,6 +18,8 @@
     <% members.each do |member| %>
       <%= render "teams/member_list_items", team: team, member: member %>
     <% end %>
-    <%= paginate members %>
+    <% if members.total_pages > 1 %>
+      <%= paginate members %>
+    <% end %>
   </div>
 </div>

--- a/app/views/teams/_member_list.erb
+++ b/app/views/teams/_member_list.erb
@@ -18,5 +18,6 @@
     <% members.each do |member| %>
       <%= render "teams/member_list_items", team: team, member: member %>
     <% end %>
+    <%= paginate members %>
   </div>
 </div>

--- a/app/views/teams/_member_list_items.html.erb
+++ b/app/views/teams/_member_list_items.html.erb
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-center py-4 md:px-4 shadow-[0px_0px_4px_0px_#33333329] rounded md:shadow-none">
+<div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-center py-4 md:px-4 shadow-[0px_0px_4px_0px_#33333329] md:shadow-none">
   <div class="col-span-1 flex flex-wrap items-center justify-between gap-2 border-b pb-2 pl-4 border-line-colour md:col-span-4 md:border-none md:pb-0 md:pl-0">
     <% link = policy(member).show? ? member_path(member) : "javascript:void(0);" %>
 

--- a/app/views/teams/_member_list_items.html.erb
+++ b/app/views/teams/_member_list_items.html.erb
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-center py-4 md:px-4 shadow-[0px_0px_4px_0px_#33333329] md:shadow-none">
+<div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-center py-4 md:px-4 shadow-[0px_0px_4px_0px_#33333329] md:shadow-none mt-2 md:mt-0">
   <div class="col-span-1 flex flex-wrap items-center justify-between gap-2 border-b pb-2 pl-4 border-line-colour md:col-span-4 md:border-none md:pb-0 md:pl-0">
     <% link = policy(member).show? ? member_path(member) : "javascript:void(0);" %>
 

--- a/app/views/teams/all_users.html.erb
+++ b/app/views/teams/all_users.html.erb
@@ -29,6 +29,12 @@
   </div>
 </div>
 
-<div class="overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(20) %> 
-</div>
+<% if @members.any? %>
+  <div class="overflow-hidden p-1 mt-5 md:shadow rounded">
+    <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(20) %> 
+  </div>
+<% else %>
+  <div class="text-center text-sm mt-6">
+    No users available.
+  </div>
+<% end %>

--- a/app/views/teams/all_users.html.erb
+++ b/app/views/teams/all_users.html.erb
@@ -29,6 +29,6 @@
   </div>
 </div>
 
-<div class="max-h-[750px] overflow-hidden p-1 mt-5 shadow rounded">
+<div class="max-h-[750px] overflow-hidden p-1 mt-5 md:shadow rounded">
   <%= render 'teams/member_list', team: @team, members: @members %>
 </div>

--- a/app/views/teams/all_users.html.erb
+++ b/app/views/teams/all_users.html.erb
@@ -29,4 +29,6 @@
   </div>
 </div>
 
-<%= render 'teams/member_list', team: @team , members: @members, limited_height: false %>
+<div class="max-h-[750px] overflow-hidden p-1 mt-5 shadow rounded">
+  <%= render 'teams/member_list', team: @team, members: @members %>
+</div>

--- a/app/views/teams/all_users.html.erb
+++ b/app/views/teams/all_users.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/components/back_button', back_link: @back_link %>
+<%= render 'shared/components/back_button', back_link: team_path(current_user.team) %>
 <div class="flex flex-col md:flex-row  gap-4 justify-between items-start my-6">
   <h1 class="heading page-heading-medium pl-0">My team</h1>
 </div>
@@ -29,6 +29,6 @@
   </div>
 </div>
 
-<div class="max-h-[750px] overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @team, members: @members %>
+<div class="overflow-hidden p-1 mt-5 md:shadow rounded">
+  <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(20) %> 
 </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -5,7 +5,14 @@
   <%= render "commons/payment_plan_details", learning_partner: @learning_partner, payment_plan: @learning_partner.payment_plan, users_count: @learning_partner.users_count  %>
 </div>
 
-<div class="max-h-[500px] overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(10) %>
-</div>
+<% if @members.any? %>
+  <div class="max-h-[520px] overflow-hidden p-1 mt-5 md:shadow rounded">
+    <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(5) %>
+  </div>
+<% else %>
+  <div class="text-center text-sm mt-6">
+    No users available.
+  </div>
+<% end %>
+
 <%= render 'teams/sub_teams', team: @team, sub_teams: @team.sub_teams.includes(:banner_attachment) %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -5,5 +5,7 @@
   <%= render "commons/payment_plan_details", learning_partner: @learning_partner, payment_plan: @learning_partner.payment_plan, users_count: @learning_partner.users_count  %>
 </div>
 
-<%= render 'teams/member_list', team: @team, members: @members, limited_height: true %>
+<div class="max-h-[400px] overflow-hidden p-1 mt-5 shadow rounded">
+  <%= render 'teams/member_list', team: @team, members: @members %>
+</div>
 <%= render 'teams/sub_teams', team: @team, sub_teams: @team.sub_teams.includes(:banner_attachment) %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -5,7 +5,7 @@
   <%= render "commons/payment_plan_details", learning_partner: @learning_partner, payment_plan: @learning_partner.payment_plan, users_count: @learning_partner.users_count  %>
 </div>
 
-<div class="max-h-[400px] overflow-hidden p-1 mt-5 md:shadow rounded">
-  <%= render 'teams/member_list', team: @team, members: @members %>
+<div class="max-h-[500px] overflow-hidden p-1 mt-5 md:shadow rounded">
+  <%= render 'teams/member_list', team: @team, members: @members.page(params[:page]).per(10) %>
 </div>
 <%= render 'teams/sub_teams', team: @team, sub_teams: @team.sub_teams.includes(:banner_attachment) %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -5,7 +5,7 @@
   <%= render "commons/payment_plan_details", learning_partner: @learning_partner, payment_plan: @learning_partner.payment_plan, users_count: @learning_partner.users_count  %>
 </div>
 
-<div class="max-h-[400px] overflow-hidden p-1 mt-5 shadow rounded">
+<div class="max-h-[400px] overflow-hidden p-1 mt-5 md:shadow rounded">
   <%= render 'teams/member_list', team: @team, members: @members %>
 </div>
 <%= render 'teams/sub_teams', team: @team, sub_teams: @team.sub_teams.includes(:banner_attachment) %>


### PR DESCRIPTION
Removed conditional height_class logic from the partial.
Applied a flex flex-col layout structure.
Header section is now fixed using flex-shrink-0.
Member list content scrolls using flex-1 overflow-y-auto.
Height is now fully controlled from the calling view (e.g. max-h-[400px], max-h-[750px]).

Fixes #813

![Screenshot 2025-04-21 at 11 13 05 AM](https://github.com/user-attachments/assets/8479555c-f8bf-4dd0-bf28-139615e8b17f)
![Screenshot 2025-04-21 at 11 14 21 AM](https://github.com/user-attachments/assets/e1b6cffb-bd08-45e8-9fa3-d1c14fb81168)
