### PR TITLE
Missed Buttons in partners and teams view changed to button components

### DIFF
--- a/app/views/learning_partners/index.html.erb
+++ b/app/views/learning_partners/index.html.erb
@@ -1,7 +1,7 @@
   <div class="flex justify-between items-center">
     <h1 class="heading page-heading-medium mb-4">Partners List</h1>
     <%= link_to new_learning_partner_path do %>
-      <%= render 'shared/components/icon_button_primary', icon_name: 'icon-plus', label: 'Add Partner' %>
+      <%= button(label: 'Add Partner',icon_name: "plus") %>
     <% end %>
   </div>
   <ul class="w-full">

--- a/app/views/teams/_sub_teams.html.erb
+++ b/app/views/teams/_sub_teams.html.erb
@@ -3,7 +3,7 @@
     <p class="text-sm md:w-[446px]">Welcome, you can manage departments/teams under your team by adding teams for each department/team here.</p>
     <% if policy(team).new? %>
       <%= link_to new_team_path(parent_team_id: team.id), data: { turbo_frame: "modal" } do %>
-        <%= render 'shared/components/outline_icon_button_primary', label: 'Add team', icon_name: 'icon-plus' %>
+        <%= button( label: "Add sub team", icon_name: "plus") %>
       <% end %>
     <% end %>
   </div>
@@ -12,10 +12,7 @@
     <p class="heading heading-medium">Your sub teams</p>
     <% if policy(team).new? %>
       <%= link_to new_team_path(parent_team_id: team.id), data: { turbo_frame: "modal" } do %>
-        <%= button(
-      label: "Add sub team",
-      icon_name: "plus",
-    ) %>
+        <%= button( label: "Add sub team", icon_name: "plus") %>
       <% end %> 
     <% end %>
   </div>


### PR DESCRIPTION
Few Buttons were missed out to change into button components in teams page and partners page and it is replaced with button components
![Screenshot 2025-04-29 at 9 27 58 PM](https://github.com/user-attachments/assets/81952851-8c25-401a-89b3-feb5ac9eb31c)
![Screenshot 2025-04-29 at 9 28 12 PM](https://github.com/user-attachments/assets/e25a3e17-a5b7-47f6-8376-6ae7f8d1da0e)
![Screenshot 2025-04-29 at 9 28 21 PM](https://github.com/user-attachments/assets/1d2b18e1-514e-4cce-9267-fd682e41ca30)
![Screenshot 2025-04-29 at 9 28 33 PM](https://github.com/user-attachments/assets/d6dd8c16-df7a-48cb-928e-084e2fd08fe2)
