### PR TITLE
Buttons in tags page and other remaining buttons are replaced with button components

### DIFF
--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -10,11 +10,11 @@
   <td class="px-4 md:px-6 py-4 w-1/3">
     <div class="flex flex-col md:flex-row justify-end gap-4">
       <%= link_to edit_tag_path(tag), data: { turbo_frame: "modal" } do %>
-        <%= render 'shared/components/button_default_small', label: 'Edit', icon_name: 'icon-edit' %>
+        <%= button(label: 'Edit', type: "secondary",size:"sm", icon_name: "pencil") %>
       <% end %>
 
       <%= link_to tag_path(tag), data: { turbo_frame: "modal" } do %>
-        <%= render "shared/components/button_default_small", label: 'Delete', icon_name: 'icon-trash' %>
+        <%= button(label: 'Delete', type: "secondary",size:"sm", icon_name: "trash",icon_position: "right") %>
       <% end %>
     </div>
   </td>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex gap-4 justify-between">
   <%= render 'shared/components/bread_crumbs', links: [[t("settings.label"), settings_path], [t("tags.label"), nil]] %>
   <%= link_to new_tag_path, class: "nav-link", data: { turbo_frame: "modal" } do %>
-    <%= render 'shared/components/icon_button_primary', label: 'Add tag', icon_name: 'icon-plus' %>
+    <%= button(label: 'Add tag', icon_name: "plus" ) %>
   <% end %>
 </div>
 <h1 class="mb-4 heading page-heading-medium pt-2">Tags</h1>

--- a/app/views/user_settings/_page_body.html.erb
+++ b/app/views/user_settings/_page_body.html.erb
@@ -3,9 +3,8 @@
     <div class="flex w-full flex-col gap-4 md:gap-8">
       <div class="flex justify-between">
         <h1 class="text-semibold">Personal information</h1>
-        <%= link_to edit_user_settings_path, data: { turbo_frame: "modal" }, class: "box-shadow-medium flex items-center justify-between gap-1 rounded-sm py-1 px-2" do %>
-          <span class="text-xs font-medium text-secondary">Edit</span>
-          <span class="icon icon-edit bg-secondary h-[10px] w-[10px]"></span>
+        <%= link_to edit_user_settings_path, data: { turbo_frame: "modal" }, class: "flex items-center" do %>
+          <%= button(label: 'Edit', type: "secondary", size:"sm", icon_name: "pencil") %>
         <% end %>
       </div>
       <div>


### PR DESCRIPTION

Remaining buttons in tags page and user page is replaced with button components

![Screenshot 2025-04-29 at 9 35 52 PM](https://github.com/user-attachments/assets/8c7f289a-41eb-4ec4-89a5-1d9de14f52a5)
![Screenshot 2025-04-29 at 9 36 05 PM](https://github.com/user-attachments/assets/aceffba1-b78f-4145-bfdd-4abfd3370c58)
![Screenshot 2025-04-29 at 9 37 22 PM](https://github.com/user-attachments/assets/7fb7f3d3-1b3b-4a2c-9bc9-da8f499582a3)
![Screenshot 2025-04-29 at 9 37 42 PM](https://github.com/user-attachments/assets/51cbc171-3c33-467e-88e2-31e466675fd1)
