### PR TITLE
Resolved an issue where the form submission failed with the error

### DIFF
--- a/app/javascript/controllers/lang_controller.js
+++ b/app/javascript/controllers/lang_controller.js
@@ -3,9 +3,20 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["radio", "otherLanguageField", "otherLanguageInput"];
 
+  connect() {
+    this.toggleOtherLanguageField();
+  }
+  
   languageSelected(event) {
-    const selectedValue = event.target.value;
-
+    this.toggleOtherLanguageField(event.target.value);
+  }
+  
+  toggleOtherLanguageField(selectedValue = null) {
+    if (!selectedValue) {
+      const selected = this.radioTargets.find(radio => radio.checked);
+      selectedValue = selected?.value;
+    }
+  
     if (selectedValue === "Other") {
       this.otherLanguageFieldTarget.classList.remove("hidden");
       this.otherLanguageInputTarget.required = true;
@@ -14,4 +25,5 @@ export default class extends Controller {
       this.otherLanguageFieldTarget.classList.add("hidden");
     }
   }
+  
 }

--- a/app/views/onboarding/welcomes/_radio_button.html.erb
+++ b/app/views/onboarding/welcomes/_radio_button.html.erb
@@ -6,7 +6,7 @@
         value: language_value(language),
         width: "w-full",
         html_options: {
-          checked: index == 0,
+          checked: current_user.preferred_local_language.blank? ? index == 0 : current_user.preferred_local_language == language,
           data: {
             lang_target: "radio",
             action: "change->lang#languageSelected"


### PR DESCRIPTION
Issue:
- Resolved an issue where the form submission failed with the error:  
  `An invalid form control with name='user[other_language]' is not focusable.`
- The error occurred because the 'Other' language input field was hidden but still marked as required.
