### PR TITLE
Fix incorrect button text from 'Add Lesson' to 'Add Quiz'

### DIFF
--- a/app/views/courses/_course_lessons.html.erb
+++ b/app/views/courses/_course_lessons.html.erb
@@ -98,7 +98,7 @@
             <%= button(label: 'Add lesson', icon_name: "plus" ) %>
           <% end %>
           <%= link_to new_course_module_quiz_path(course, course_module), class: "nav-link" do %>
-            <%= button(label: 'Add lesson', icon_name: "plus" ) %>
+            <%= button(label: 'Add quiz', icon_name: "plus" ) %>
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
Fixes #926 

![Screenshot 2025-07-08 at 3 41 15 PM](https://github.com/user-attachments/assets/f03f7f6c-392a-40ab-9cdb-a7369e39e42d)
