### PR TITLE
Fixed Tooltip element ID error caused by the use of data-tooltip-target 

### DIFF
--- a/app/assets/stylesheets/tooltip.css
+++ b/app/assets/stylesheets/tooltip.css
@@ -31,13 +31,13 @@
   border-style: solid;
 }
 
-.tooltip[data-tooltip-target="top"] {
+.tooltip-top {
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   margin-bottom: 0.5rem;
 }
-.tooltip[data-tooltip-target="top"]::before {
+.tooltip-top::before {
   left: 50%;
   bottom: -4px;
   transform: translateX(-50%);
@@ -45,13 +45,13 @@
   border-color: grey transparent transparent;
 }
 
-.tooltip[data-tooltip-target="bottom"] {
+.tooltip-bottom {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
   margin-top: 0.5rem;
 }
-.tooltip[data-tooltip-target="bottom"]::before {
+.tooltip-bottom::before {
   left: 50%;
   top: -4px;
   transform: translateX(-50%);
@@ -59,13 +59,13 @@
   border-color: transparent transparent grey;
 }
 
-.tooltip[data-tooltip-target="left"] {
+.tooltip-left {
   right: 100%;
   top: 50%;
   transform: translateY(-50%);
   margin-right: 0.5rem;
 }
-.tooltip[data-tooltip-target="left"]::before {
+.tooltip-left::before {
   right: -4px;
   top: 50%;
   transform: translateY(-50%);
@@ -73,13 +73,13 @@
   border-color: transparent transparent transparent grey;
 }
 
-.tooltip[data-tooltip-target="right"] {
+.tooltip-right {
   left: 100%;
   top: 50%;
   transform: translateY(-50%);
   margin-left: 0.5rem;
 }
-.tooltip[data-tooltip-target="right"]::before {
+.tooltip-right::before {
   left: -4px;
   top: 50%;
   transform: translateY(-50%);

--- a/app/views/shared/components/_tooltip.html.erb
+++ b/app/views/shared/components/_tooltip.html.erb
@@ -1,7 +1,7 @@
 <% tooltip_position ||= "bottom" %>
 <div class="relative group inline-block">
   <%= yield %>
-  <span class="tooltip" data-tooltip-target="<%= tooltip_position %>">
+  <span class="tooltip tooltip-<%= tooltip_position %>">
     <%= tooltip_text %>
   </span>
 </div>


### PR DESCRIPTION
Fixes : #935
Replaced data-tooltip-target="<%= tooltip_position %>" with tooltip-<%= tooltip_position %> class to avoid JavaScript errors like The tooltip element with id "bottom" does not exist. This change also simplifies tooltip positioning logic by moving it entirely to class-based CSS selectors (e.g., .tooltip.tooltip-left).