### PR TITLE
Enhance Complete and Continue button state styling and HTML options

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
   end
 
   def button(label: nil, type: 'primary', size: 'md', icon_name: nil, icon_position: 'left', tooltip_text: '',
-             tooltip_position: 'bottom', disabled: false)
+             tooltip_position: 'bottom', disabled: false, html: {})
     ApplicationController.renderer.render(
       partial: "ui/buttons/#{type}",
       locals: {
@@ -23,7 +23,8 @@ module UiHelper
         icon_position:,
         tooltip_text:,
         tooltip_position:,
-        disabled:
+        disabled:,
+        html: html || {}
       }
     )
   end

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
   end
 
   def button(label: nil, type: 'primary', size: 'md', icon_name: nil, icon_position: 'left', tooltip_text: '',
-             tooltip_position: 'bottom', disabled: false, html: {})
+             tooltip_position: 'bottom', disabled: false, html_options: {})
     ApplicationController.renderer.render(
       partial: "ui/buttons/#{type}",
       locals: {
@@ -24,7 +24,7 @@ module UiHelper
         tooltip_text:,
         tooltip_position:,
         disabled:,
-        html: html || {}
+        html_options:
       }
     )
   end

--- a/app/javascript/controllers/vimeo_controller.js
+++ b/app/javascript/controllers/vimeo_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["vimeoLoader", "vimeoPlayer", "completeButton", "completionOverlay"];
+  static targets = ["vimeoLoader", "vimeoPlayer","completeButtonForm", "completeButton", "completionOverlay"];
 
   connect() {
     // return if the vimeo player is not present, for example in local
@@ -93,17 +93,23 @@ export default class extends Controller {
   }
   enableCompleteButton() {
     if (this.hasCompleteButtonTarget) {
-      this.completeButtonTarget.classList.remove("disabled");
+      this.completeButtonFormTarget.classList.remove("disabled");
+      this.completeButtonTarget.classList.remove("bg-secondary", "hover:bg-secondary-light");
+      this.completeButtonTarget.classList.add("bg-primary", "hover:bg-primary-light");
+  
       const tooltip = this.completeButtonTarget.querySelector(".tooltip");
-      tooltip.classList.add("hidden");
+      if (tooltip) tooltip.classList.add("hidden");
     }
   }
 
   disableCompleteButton() {
     if (this.hasCompleteButtonTarget) {
-      this.completeButtonTarget.classList.add("disabled");
+      this.completeButtonFormTarget.classList.add("disabled");
+      this.completeButtonTarget.classList.remove("bg-primary", "hover:bg-primary-light");
+      this.completeButtonTarget.classList.add("bg-secondary", "hover:bg-secondary-light");
+ 
       const tooltip = this.completeButtonTarget.querySelector(".tooltip");
-      tooltip.classList.remove("hidden");
+      if (tooltip) tooltip.classList.remove("hidden");
     }
   }
 

--- a/app/javascript/controllers/vimeo_controller.js
+++ b/app/javascript/controllers/vimeo_controller.js
@@ -1,7 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["vimeoLoader", "vimeoPlayer","completeButtonForm", "completeButton", "completionOverlay"];
+  static targets = [
+    "vimeoLoader",
+    "vimeoPlayer",
+    "completeButtonForm",
+    "completeButton",
+    "completionOverlay"
+  ];
 
   connect() {
     // return if the vimeo player is not present, for example in local

--- a/app/views/lessons/_lesson.html.erb
+++ b/app/views/lessons/_lesson.html.erb
@@ -52,7 +52,7 @@
                     icon_name: "chevron-double-right",
                     icon_position: "right",
                     tooltip_text: "Complete the lesson to continue.",
-                    html: {
+                    html_options: {
                       data: { vimeo_target: "completeButton" } 
                     }
                   ) %>

--- a/app/views/lessons/_lesson.html.erb
+++ b/app/views/lessons/_lesson.html.erb
@@ -43,10 +43,20 @@
                           time_spent: 0
                         },
                         data: {
-                          vimeo_target: "completeButton",
+                          vimeo_target: "completeButtonForm",
                           turbo_method: :post
                         } do %>
-            <%= button(label: t("lesson.complete_and_continue"),size: "lg", icon_name: "chevron-double-right", icon_position: "right", tooltip_text:  "Complete the lesson to continue.") %>
+              <%= button(
+                    label: t("lesson.complete_and_continue"),
+                    size: "lg",
+                    icon_name: "chevron-double-right",
+                    icon_position: "right",
+                    tooltip_text: "Complete the lesson to continue.",
+                    html: {
+                      data: { vimeo_target: "completeButton" } 
+                    }
+                  ) %>
+
           <% end %>
         <% end %>
       </div>

--- a/app/views/ui/buttons/_danger.html.erb
+++ b/app/views/ui/buttons/_danger.html.erb
@@ -1,25 +1,25 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'pointer-events-none opacity-50 cursor-not-allowed' : '' %>
   <% if size == "xl" %>
-    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xl font-semibold font-['Poppins'] leading-7") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "lg" %>
-    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-base font-medium font-['Poppins'] leading-normal") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "md" %>
-    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-sm font-medium font-['Poppins'] leading-tight") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "sm" %>
-    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xs font-normal font-['Poppins'] leading-none") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>

--- a/app/views/ui/buttons/_danger.html.erb
+++ b/app/views/ui/buttons/_danger.html.erb
@@ -1,29 +1,30 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'pointer-events-none opacity-50 cursor-not-allowed' : '' %>
   <% if size == "xl" %>
-    <div class="inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-danger text-danger hover:border-primary hover:text-primary <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xl font-semibold font-['Poppins'] leading-7") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "lg" %>
-    <div class="inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-danger text-danger hover:border-primary hover:text-primary <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-base font-medium font-['Poppins'] leading-normal") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "md" %>
-    <div class="inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-danger text-danger hover:border-primary hover:text-primary <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-sm font-medium font-['Poppins'] leading-tight") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "sm" %>
-    <div class="inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-danger text-danger hover:border-primary hover:text-primary <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-danger text-danger hover:border-primary hover:text-primary #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xs font-normal font-['Poppins'] leading-none") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>
-<%= local_assigns[:tooltip_text].present? ? render('shared/components/tooltip', tooltip_position: , tooltip_text: ) { button_content } : button_content %>
+
+<%= local_assigns[:tooltip_text].present? ? render('shared/components/tooltip', tooltip_position: tooltip_position, tooltip_text: tooltip_text) { button_content } : button_content %>

--- a/app/views/ui/buttons/_primary.html.erb
+++ b/app/views/ui/buttons/_primary.html.erb
@@ -1,29 +1,29 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'opacity-50 cursor-not-allowed' : '' %>
   <% if size == "xl" %>
-    <div class="inline-flex h-14 items-center justify-center gap-2 rounded-sm px-6 text-white py-3.5 bg-primary hover:bg-primary-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm px-6 text-white py-3.5 bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-xl font-semibold font-['Poppins'] leading-7") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "lg" %>
-    <div class="inline-flex h-10 items-center justify-center gap-2 rounded-sm px-6 py-2 text-white bg-primary hover:bg-primary-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm px-6 py-2 text-white bg-primary hover:bg-primary-light #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-base font-medium font-['Poppins'] leading-normal") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "md" %>
-    <div class="inline-flex h-9 items-center justify-center gap-2 rounded-sm px-4 py-2 text-white bg-primary hover:bg-primary-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm px-4 py-2 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-sm font-medium font-['Poppins'] leading-tight") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "sm" %>
-    <div class="inline-flex h-6 items-center justify-center gap-2 rounded-sm px-3 py-1 text-white bg-primary hover:bg-primary-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm px-3 py-1 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-xs font-normal font-['Poppins'] leading-none") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>
 <%= local_assigns[:tooltip_text].present? ? render('shared/components/tooltip', tooltip_position: , tooltip_text: ) { button_content } : button_content %>

--- a/app/views/ui/buttons/_primary.html.erb
+++ b/app/views/ui/buttons/_primary.html.erb
@@ -1,25 +1,25 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'opacity-50 cursor-not-allowed' : '' %>
   <% if size == "xl" %>
-    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm px-6 text-white py-3.5 bg-primary hover:bg-primary-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm px-6 text-white py-3.5 bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-xl font-semibold font-['Poppins'] leading-7") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "lg" %>
-    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm px-6 py-2 text-white bg-primary hover:bg-primary-light #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm px-6 py-2 text-white bg-primary hover:bg-primary-light #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-base font-medium font-['Poppins'] leading-normal") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "md" %>
-    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm px-4 py-2 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm px-4 py-2 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-sm font-medium font-['Poppins'] leading-tight") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "sm" %>
-    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm px-3 py-1 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm px-3 py-1 text-white bg-primary hover:bg-primary-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-white text-xs font-normal font-['Poppins'] leading-none") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>

--- a/app/views/ui/buttons/_secondary.html.erb
+++ b/app/views/ui/buttons/_secondary.html.erb
@@ -1,25 +1,25 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'opacity-50 cursor-not-allowed' : 'hover:border-primary hover:text-primary' %>
   <% if size == "xl" %>
-    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-secondary text-letter-color-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xl font-semibold font-['Poppins'] leading-7 cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "lg" %>
-    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-secondary text-letter-color-light   #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-secondary text-letter-color-light   #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-base font-medium font-['Poppins'] leading-normal cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "md" %>
-    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-secondary text-letter-color-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-sm font-medium font-['Poppins'] leading-tight cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
     <% end %>
   <% elsif size == "sm" %>
-    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-secondary text-letter-color-light  #{disabled_class}") do %>
+    <%= tag.div(**html_options, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xs font-normal font-['Poppins'] leading-none cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>

--- a/app/views/ui/buttons/_secondary.html.erb
+++ b/app/views/ui/buttons/_secondary.html.erb
@@ -1,29 +1,29 @@
 <% button_content = capture do %>
   <% disabled_class = disabled ? 'opacity-50 cursor-not-allowed' : 'hover:border-primary hover:text-primary' %>
   <% if size == "xl" %>
-    <div class="inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-secondary text-letter-color-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-14 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-3.5 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xl font-semibold font-['Poppins'] leading-7 cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-base cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "lg" %>
-    <div class="inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-secondary text-letter-color-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-10 items-center justify-center gap-2 rounded-sm border bg-white px-6 py-2 border-secondary text-letter-color-light   #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-base font-medium font-['Poppins'] leading-normal cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "md" %>
-    <div class="inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-secondary text-letter-color-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-9 items-center justify-center gap-2 rounded-sm border bg-white px-4 py-2 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-sm font-medium font-['Poppins'] leading-tight cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-small cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% elsif size == "sm" %>
-    <div class="inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-secondary text-letter-color-light <%= disabled_class %>">
+    <%= tag.div(**html, class: "inline-flex h-6 items-center justify-center gap-2 rounded-sm border bg-white px-3 py-1 border-secondary text-letter-color-light  #{disabled_class}") do %>
       <% content = content_tag(:div, label, class: "text-xs font-normal font-['Poppins'] leading-none cursor-inherit") if label.present? %>
       <% icon = icon(icon_name || "adjustments-vertical", css: "icon-mini cursor-inherit") if icon_name.present? %>
       <%= label_with_icon(icon, content, icon_position) %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>
 <%= local_assigns[:tooltip_text].present? ? render('shared/components/tooltip', tooltip_position: , tooltip_text: ) { button_content } : button_content %>


### PR DESCRIPTION
- Applied conditional styling: bg-secondary when disabled, bg-primary when enabled
- Updated the `button` component to support `html:` option for passing HTML attributes


<img width="365" height="430" alt="Screenshot 2025-08-05 at 2 41 38 PM" src="https://github.com/user-attachments/assets/51284828-9c18-4b9a-a44e-c1a84c2cf580" />


<img width="435" height="932" alt="Screenshot 2025-08-05 at 2 41 52 PM" src="https://github.com/user-attachments/assets/f5ab3a8a-1b29-46ad-89c5-57ce945430df" />
