### PR TITLE
extend "Time spent by the users" to 120 min and update y-axis config to Chart.js v3

### DIFF
--- a/app/views/dashboards/_average_time_spend_chart.html.erb
+++ b/app/views/dashboards/_average_time_spend_chart.html.erb
@@ -7,15 +7,15 @@
 
   <div class="w-full max-w-4xl bg-white py-6">
     <%= column_chart [
-                       { name: "Time spent in minutes", data: dashboard.time_spent_series }
-                     ], height: "200px", colors: ["#0075A4"], stacked: true, max: 60,
-                     library: {
-                       plugins: {
-                         legend: { display: false }
-                       },
-                       scales: {
-                         yAxes: [{ ticks: { beginAtZero: true, max: 100 } }]
-                       }
-                     } %>
+      { name: "Time spent in minutes", data: dashboard.time_spent_series }
+      ], height: "200px", colors: ["#0075A4"], stacked: true,
+      library: {
+        plugins: {
+          legend: { display: false }
+        },
+        scales: {
+          y: { min: 0, max: 120, ticks: { stepSize: 30 } }
+        }
+      } %>
   </div>
 </div>

--- a/app/views/dashboards/_self_enrolled_vs_assigned_chart.html.erb
+++ b/app/views/dashboards/_self_enrolled_vs_assigned_chart.html.erb
@@ -23,8 +23,8 @@
             height: "200px", library: {
                plugins: {
                   legend: { display: false } 
-                },scales: {
-               yAxes: [{ ticks: { beginAtZero: true, max: 100 } }]
+               },scales: {
+               y: { min: 0, max: 100,ticks: { beginAtZero: true } }
             }
             } %>
       </div>

--- a/app/views/dashboards/_total_views_chart.html.erb
+++ b/app/views/dashboards/_total_views_chart.html.erb
@@ -1,4 +1,4 @@
-<div class="box-shadow-medium p-4 md:basis-1/2 md:p-6 ">
+<div class="box-shadow-medium p-4 md:basis-1/2 md:p-6">
    <div class="flex w-full flex-col">
       <div class="flex flex-row justify-between">
          <div class="flex flex-col gap-2">
@@ -11,10 +11,10 @@
             ], height: "200px", colors: ["#0075A4"], library: {
                plugins: {
                   legend: { display: false } 
-                },scales: {
-               yAxes: [{ ticks: { beginAtZero: true, max: 100, stepSize: 25 } }],
-               xAxes: [{ ticks: { autoSkip: false } }]
-            }
+               },scales: {
+                  y: { min: 0, max: 100, ticks: { beginAtZero: true, stepSize: 25 } },
+                  x: { ticks: { autoSkip: false } } 
+               }
             } %>
       </div>
    </div>

--- a/app/views/dashboards/_users_enrolled.html.erb
+++ b/app/views/dashboards/_users_enrolled.html.erb
@@ -5,17 +5,17 @@
             <h3 class="heading heading-semibold">Number of courses enrolled per day</h3>
          </div>
       </div>
-      <div class="w-full max-w-4xl bg-white py-6">                
+      <div class="w-full max-w-4xl bg-white py-6">
          <%= column_chart [
             { name: "Users Enrolled", data: dashboard.course_enrolled_series }
-            ], height: "200px", colors: ["#0075A4"],stacked: true, max: 100,
+            ], height: "200px", colors: ["#0075A4"], stacked: true,
             library: {
                plugins: {
-                  legend: { display: false } 
-                },
-            scales: {
-               yAxes: [{ ticks: { beginAtZero: true, max: 100 } }]
-            }
+                  legend: { display: false }
+               },
+               scales: {
+                  y: { min: 0, max: 100, ticks: { beginAtZero: true } }
+               }
             } %>
       </div>
    </div>


### PR DESCRIPTION

Fixes #968

- Resolved `Invalid scale configuration for scale: yAxes` error caused by outdated axis config
- Replaced deprecated `yAxes` / `xAxes` syntax with Chart.js v3+ `scales: { y: {...}, x: {...} }` format
- Increased "Time spent by the users" chart max y-axis value to 120 minutes
