### PR TITLE
Make dashboard chart series scaling reusable with configurable max values

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -12,11 +12,11 @@ module DashboardsHelper
     Dashboard::VALID_DURATIONS[duration.to_sym] || Dashboard::VALID_DURATIONS[:last_7_days].to_s
   end
 
-  def scale_time_spent_series(series)
+  def scale_series(series, max_limit)
     return {} if series.blank?
 
     max_value = series.values.max || 0
-    scale_factor = max_value > 120 ? 120.0 / max_value : 1
+    scale_factor = max_value > max_limit ? max_limit.to_f / max_value : 1
     series.transform_values { |v| (v * scale_factor).round }
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -11,4 +11,12 @@ module DashboardsHelper
   def selected_label(duration)
     Dashboard::VALID_DURATIONS[duration.to_sym] || Dashboard::VALID_DURATIONS[:last_7_days].to_s
   end
+
+  def scale_time_spent_series(series)
+    return {} if series.blank?
+
+    max_value = series.values.max || 0
+    scale_factor = max_value > 120 ? 120.0 / max_value : 1
+    series.transform_values { |v| (v * scale_factor).round }
+  end
 end

--- a/app/value_objects/dashboard.rb
+++ b/app/value_objects/dashboard.rb
@@ -31,6 +31,15 @@ class Dashboard
     data
   end
 
+  def scaled_time_spent_series(max_limit: 120)
+    raw_series = time_spent_series || {}
+    return {} if raw_series.blank?
+
+    max_value = raw_series.values.max || 0
+    scaling_factor = max_value > max_limit ? max_limit.to_f / max_value : 1
+    raw_series.transform_values { |v| (v * scaling_factor).round(2) }
+  end
+
   def total_time_spent_metric
     events = time_spent_query.call
     events = filter_by_teams(events)

--- a/app/value_objects/dashboard.rb
+++ b/app/value_objects/dashboard.rb
@@ -31,15 +31,6 @@ class Dashboard
     data
   end
 
-  def scaled_time_spent_series(max_limit: 120)
-    raw_series = time_spent_series || {}
-    return {} if raw_series.blank?
-
-    max_value = raw_series.values.max || 0
-    scaling_factor = max_value > max_limit ? max_limit.to_f / max_value : 1
-    raw_series.transform_values { |v| (v * scaling_factor).round(2) }
-  end
-
   def total_time_spent_metric
     events = time_spent_query.call
     events = filter_by_teams(events)

--- a/app/views/dashboards/_average_time_spend_chart.html.erb
+++ b/app/views/dashboards/_average_time_spend_chart.html.erb
@@ -8,7 +8,7 @@
   <div class="w-full max-w-4xl bg-white py-6">
 
     <%= column_chart [
-      { name: "Time spent in minutes", data: scale_time_spent_series(dashboard.time_spent_series)  }
+      { name: "Time spent in minutes", data: scale_series(dashboard.time_spent_series, 120)  }
       ], height: "200px", colors: ["#0075A4"], stacked: true,
       library: {
         plugins: {

--- a/app/views/dashboards/_average_time_spend_chart.html.erb
+++ b/app/views/dashboards/_average_time_spend_chart.html.erb
@@ -6,20 +6,9 @@
   </div>
 
   <div class="w-full max-w-4xl bg-white py-6">
-    <% 
-      data = dashboard.time_spent_series || {}
-
-      if data.present?
-        max_value = data.values.max || 0
-        scaling_factor = max_value > 120 ? 120.0 / max_value : 1
-        scaled_data = data.transform_values { |v| (v * scaling_factor).round(2) }
-      else
-        scaled_data = {}
-      end
-    %>
 
     <%= column_chart [
-      { name: "Time spent in minutes", data: scaled_data }
+      { name: "Time spent in minutes", data: dashboard.scaled_time_spent_series  }
       ], height: "200px", colors: ["#0075A4"], stacked: true,
       library: {
         plugins: {

--- a/app/views/dashboards/_average_time_spend_chart.html.erb
+++ b/app/views/dashboards/_average_time_spend_chart.html.erb
@@ -6,8 +6,20 @@
   </div>
 
   <div class="w-full max-w-4xl bg-white py-6">
+    <% 
+      data = dashboard.time_spent_series || {}
+
+      if data.present?
+        max_value = data.values.max || 0
+        scaling_factor = max_value > 120 ? 120.0 / max_value : 1
+        scaled_data = data.transform_values { |v| (v * scaling_factor).round(2) }
+      else
+        scaled_data = {}
+      end
+    %>
+
     <%= column_chart [
-      { name: "Time spent in minutes", data: dashboard.time_spent_series }
+      { name: "Time spent in minutes", data: scaled_data }
       ], height: "200px", colors: ["#0075A4"], stacked: true,
       library: {
         plugins: {

--- a/app/views/dashboards/_average_time_spend_chart.html.erb
+++ b/app/views/dashboards/_average_time_spend_chart.html.erb
@@ -8,7 +8,7 @@
   <div class="w-full max-w-4xl bg-white py-6">
 
     <%= column_chart [
-      { name: "Time spent in minutes", data: dashboard.scaled_time_spent_series  }
+      { name: "Time spent in minutes", data: scale_time_spent_series(dashboard.time_spent_series)  }
       ], height: "200px", colors: ["#0075A4"], stacked: true,
       library: {
         plugins: {

--- a/app/views/dashboards/_self_enrolled_vs_assigned_chart.html.erb
+++ b/app/views/dashboards/_self_enrolled_vs_assigned_chart.html.erb
@@ -9,7 +9,7 @@
                   <span class="text-xs font-medium">Course Started</span>
                </div>
                <div class="flex items-center space-x-2">
-                  <span class="bg-primary icon-tiny"></span>
+                  <span class="bg-[#00B48D] icon-tiny"></span>
                   <span class="text-xs font-medium">Course Completed</span>
                </div>
             </div>
@@ -17,8 +17,8 @@
       </div>
       <div class="w-full max-w-4xl bg-white py-6">
          <%= column_chart [
-            { name: "Course Started", data: dashboard.course_started_series },
-            { name: "Course Completed", data: dashboard.course_completed_series }
+            { name: "Course Started", data: scale_series(dashboard.course_started_series, 100) },
+            { name: "Course Completed", data: scale_series(dashboard.course_completed_series, 100) }
             ], colors: ["#0075A4", "#00B48D"],
             height: "200px", library: {
                plugins: {

--- a/app/views/dashboards/_total_views_chart.html.erb
+++ b/app/views/dashboards/_total_views_chart.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="w-full max-w-4xl bg-white py-6">
          <%= line_chart [
-            { name: "Total Views", data: dashboard.lesson_views_series }
+            { name: "Total Views", data: scale_series(dashboard.lesson_views_series,100) }
             ], height: "200px", colors: ["#0075A4"], library: {
                plugins: {
                   legend: { display: false } 

--- a/app/views/dashboards/_users_enrolled.html.erb
+++ b/app/views/dashboards/_users_enrolled.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="w-full max-w-4xl bg-white py-6">
          <%= column_chart [
-            { name: "Users Enrolled", data: dashboard.course_enrolled_series }
+            { name: "Users Enrolled", data: scale_series(dashboard.course_enrolled_series, 100) }
             ], height: "200px", colors: ["#0075A4"], stacked: true,
             library: {
                plugins: {


### PR DESCRIPTION
Refactored the chart series scaling logic to be reusable for all dashboard charts.  

If a series exceeds its configured max value, it is scaled down proportionally so that it fits the chart area while preserving relative differences between data points.  

This now works for multiple charts, including Time Spent, Course Started, Course Completed, and Users Enrolled.
