### PR TITLE
Hide banner on Turbo navigation as well as initial load

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,13 +62,14 @@
     <%= render "shared/components/flash" %>
     <%= turbo_frame_tag "modal" %>
 
-    <script type="module">
-      document.addEventListener("DOMContentLoaded", () => {
-        const jsWarning = document.getElementById("js-warning")
-        if (jsWarning) {
-          jsWarning.style.display = "none"
-        }
-      })
+    <script>
+      function hideJsWarning() {
+        const jsWarning = document.getElementById("js-warning");
+        if (jsWarning) jsWarning.style.display = "none";
+      }
+
+      document.addEventListener("DOMContentLoaded", hideJsWarning);
+      document.addEventListener("turbo:load", hideJsWarning);
     </script>
   </body>
 </html>


### PR DESCRIPTION
The "JS not loaded" banner was showing again when navigating via sidebar links.
This happened because Turbo only replaces <main> content without reloading the
whole page, so our script (which hid the banner) only executed on the first load.
We now listen to both `DOMContentLoaded` and `turbo:load` events to ensure the
banner is hidden on all page transitions.

https://www.loom.com/share/e608baadf4244dbcbc614e8edff332c6?sid=da57a473-907f-4a41-8b96-39a525b604e3