### PR TITLE
ensure JS not loaded banner is hidden on all Turbo navigations

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,3 +9,6 @@ import "chartkick";
 import "Chart.bundle";
 
 import "channels";
+
+import "./utils/js_warning"
+

--- a/app/javascript/utils/js_warning.js
+++ b/app/javascript/utils/js_warning.js
@@ -1,0 +1,8 @@
+function hideJsWarning() {
+    const jsWarning = document.getElementById("js-warning");
+    if (jsWarning) jsWarning.style.display = "none";
+  }
+  
+  ["DOMContentLoaded", "turbo:load", "turbo:render", "turbo:before-render", "turbo:before-cache"]
+    .forEach(event => document.addEventListener(event, hideJsWarning));
+  

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,8 +68,8 @@
         if (jsWarning) jsWarning.style.display = "none";
       }
 
-      document.addEventListener("DOMContentLoaded", hideJsWarning);
-      document.addEventListener("turbo:load", hideJsWarning);
+      ["DOMContentLoaded", "turbo:load", "turbo:render", "turbo:before-render", "turbo:before-cache"]
+        .forEach(event => document.addEventListener(event, hideJsWarning));
     </script>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,14 +62,5 @@
     <%= render "shared/components/flash" %>
     <%= turbo_frame_tag "modal" %>
 
-    <script>
-      function hideJsWarning() {
-        const jsWarning = document.getElementById("js-warning");
-        if (jsWarning) jsWarning.style.display = "none";
-      }
-
-      ["DOMContentLoaded", "turbo:load", "turbo:render", "turbo:before-render", "turbo:before-cache"]
-        .forEach(event => document.addEventListener(event, hideJsWarning));
-    </script>
   </body>
 </html>


### PR DESCRIPTION
- Added event listeners for `turbo:load` and `turbo:render` in addition to `DOMContentLoaded`.  
- This ensures the banner is always hidden, both on initial load and during subsequent Turbo navigations or form submissions.

https://www.loom.com/share/6df7720ed4b045d3aac5020e75d85d7a?sid=7bb47d88-a577-4e14-a0e9-b60f92c9933b

https://www.loom.com/share/12979c1122f6451895ac12c590f9d79a?sid=9de90d1b-1033-4a1f-a077-ca0ceca8a3d2