### PR TITLE
remove 'JS not loaded' banner due to poor user experience

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,6 +9,3 @@ import "chartkick";
 import "Chart.bundle";
 
 import "channels";
-
-import "utils/js_warning"
-

--- a/app/javascript/utils/js_warning.js
+++ b/app/javascript/utils/js_warning.js
@@ -1,8 +1,0 @@
-function hideJsWarning() {
-    const jsWarning = document.getElementById("js-warning");
-    if (jsWarning) jsWarning.style.display = "none";
-  }
-  
-  ["DOMContentLoaded", "turbo:load", "turbo:render", "turbo:before-render", "turbo:before-cache"]
-    .forEach(event => document.addEventListener(event, hideJsWarning));
-  

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,15 +26,6 @@
     <%= Sentry.get_trace_propagation_meta.html_safe %>
   </head>
   <body>
-    <div id="js-warning">
-      <%= notification_bar(
-            text: "JS is not loaded!",
-            text_color: "text-letter-color",
-            icon_color: "bg-letter-color",
-            bg_color: "bg-danger"
-          ) %>
-    </div>
-
     <div class="flex flex-col min-h-screen">
       <div class="sticky top-0 left-0 w-full z-50 flex flex-col">
         <div class="w-full">


### PR DESCRIPTION
Fixes #996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the “JS is not loaded!” warning banner from the layout; it no longer appears during page loads or navigation.
* **Chores**
  * Eliminated the unused script previously tied to this banner, reducing unnecessary code executed on page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->