### PR TITLE
Return unauthorized response when the api_key is blank

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::ApiController < ActionController::API
+  API_TOKEN = Rails.application.credentials.dig(:api_token)
   # this can be commented during development or local testing
   before_action :verify_auth_token!
   before_action :set_api_version
@@ -12,7 +13,7 @@ class Api::ApiController < ActionController::API
   end
 
   def verify_auth_token!
-    if params[:auth_token] != Rails.application.credentials.dig(:api_token)
+    if API_TOKEN.blank? || (params[:auth_token] != API_TOKEN)
       render json: {}, status: :unauthorized
     end
   end


### PR DESCRIPTION
Improvement on issue #995 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened API authentication: requests are now rejected when the server token is missing or blank, ensuring consistent unauthorized responses for invalid tokens.

* **Refactor**
  * Improved token handling to avoid repeated lookups, making authentication more stable and slightly faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->