### PR TITLE
Remove fixed height from input fields

### DIFF
--- a/app/views/view_components/inputs/_dropdown_field.html.erb
+++ b/app/views/view_components/inputs/_dropdown_field.html.erb
@@ -1,12 +1,12 @@
 <div class="flex flex-col gap-4 <%= width %>">
   <% if label.present? %>
-    <label class="text-letter-color-light text-sm md:text-base h-9 leading-tight">
+    <label class="text-letter-color-light text-sm md:text-base leading-tight">
       <%= label %>
     </label>
   <% end %>
 
   <% merged_html_options = (html_options || {}).merge(
-    class: "px-4 py-2 rounded border border-line-colour w-full text-letter-color-light text-sm h-9 focus:border-primary focus:ring-0 #{width}"
+    class: "px-4 py-3 rounded border border-line-colour w-full text-letter-color-light text-base focus:border-primary focus:ring-0 #{width}"
   ) %>
 
   <% if form.present? %>

--- a/app/views/view_components/inputs/_mobile_field.html.erb
+++ b/app/views/view_components/inputs/_mobile_field.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <div class="bg-white justify-between items-center flex rounded border border-line-colour">
     <% if flag.present? %>
-      <div class="flex items-center justify-center border-r h-9 w-16 border-line-colour focus-within:border-primary">
+      <div class="flex items-center justify-center border-r h-[52px] w-[96px] border-line-colour focus-within:border-primary">
         <%= image_tag flag, alt: "IN", class: "h-8 w-8 rounded-full flag-box-shadow" %>
       </div>
     <% end %>
@@ -23,7 +23,7 @@
           pattern: "[0-9]{10}",
           value: value,
           title: "Enter exactly 10 digits",
-          class: "w-full text-letter-color-light text-base px-4 py-2 h-9 border-none rounded focus:ring-0 focus:outline-none",
+          class: "w-full text-letter-color-light text-base px-4 py-3 border-none rounded focus:ring-0 focus:outline-none",
           required: true,
           data: merged_data
         }.merge(html_options_without_data) %>

--- a/app/views/view_components/inputs/_text_field.html.erb
+++ b/app/views/view_components/inputs/_text_field.html.erb
@@ -1,11 +1,12 @@
 <div class="flex flex-col gap-4 <%= width %> ">
   <% if label.present? %>
-    <label class="text-letter-color-light text-sm md:text-base h-9 leading-tight">
+    <label class="text-letter-color-light text-sm md:text-base leading-tight">
       <%= label %>
     </label>
   <% end %>
 
-  <% input_classes = "w-full text-letter-color-light h-9 text-base px-4 py-2 border-none rounded" %>
+  <% input_classes = "w-full text-letter-color-light text-base px-4 py-3 border-none rounded" %>
+  <% input_classes += " #{height}" if height.present? %>
   <% input_classes += (left_icon.present? || right_icon.present?) ? " focus:ring-0 focus:outline-none" : " focus:border focus:border-primary" %>
   <% html_options[:class] = [input_classes, html_options[:class]].compact.join(" ") %>
   <% is_text_area = type == "text_area" %>

--- a/app/views/view_components/member_list/_member_search.html.erb
+++ b/app/views/view_components/member_list/_member_search.html.erb
@@ -3,7 +3,7 @@
     <%= form.hidden_field :team_id, value: team.id %>
     <%= form.hidden_field :all_members, value: all_members %>
     <div class="flex gap-1">
-      <%= input_field form:, field_name: :term, placeholder: 'Search members' %>
+      <%= input_field form:, field_name: :term, placeholder: 'Search members', height: "h-9" %>
       <%= button_tag do %>
         <%= button icon_name: 'magnifying-glass', type: 'secondary' %>
       <% end %>


### PR DESCRIPTION
Previously, text inputs had a fixed height (`h-9`), and even after removing 
it the default padding (`py-2`) enforced a minimum height. This made it 
difficult to align inputs with other components. 

Now the fixed height has been removed, and custom height classes (e.g. `h-9`) 
can be passed to control the input height when needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased input heights and padding across dropdown, text, and mobile number fields for improved readability and touch targets.
  * Enlarged font size on dropdowns and removed fixed heights on labels for better alignment and accessibility.
  * Expanded flag area in the mobile number field for clearer country indicators.
  * Made the member search input taller for visual consistency across forms.

* **New Features**
  * Input fields now support configurable heights, enabling more consistent sizing throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->