### PR TITLE
Update apis from get to post

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-class Api::ApiController < ApplicationController
-  layout false
-
-  skip_before_action :authenticate_user!
+class Api::ApiController < ActionController::API
   # this can be commented during development or local testing
   before_action :verify_auth_token!
   before_action :set_api_version

--- a/config/routes/v1_api.rb
+++ b/config/routes/v1_api.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :otps, only: [] do
         collection do
-          get :generate
-          get :verify
+          post :generate
+          post :verify
         end
       end
     end

--- a/spec/requests/api/v1/otps_spec.rb
+++ b/spec/requests/api/v1/otps_spec.rb
@@ -11,39 +11,39 @@ RSpec.describe 'Api::V1::OtpsController', type: :request do
     Rails.cache.clear
   end
 
-  describe 'GET /api/v1/otps/generate' do
+  describe 'POST /api/v1/otps/generate' do
     it 'sends unauthorized response if auth_token is missing' do
-      get '/api/v1/otps/generate', params: { phone: phone, name: name }
+      post '/api/v1/otps/generate', params: { phone: phone, name: name }
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'calls OtpService and send otp to user' do
-      get '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: }
+      post '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({ 'success' => true })
     end
 
     it 'return error response if the attempts exceeds the limit' do
-      2.times { get '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: } }
+      2.times { post '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: } }
 
-      get '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: }
+      post '/api/v1/otps/generate', params: { phone: phone, name: name, auth_token: }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ 'success' => false })
     end
   end
 
-  describe 'GET /api/v1/otps/verify' do
+  describe 'POST /api/v1/otps/verify' do
     context 'when otp is correct' do
       it 'sends unauthorized response if auth_token is missing' do
-        get '/api/v1/otps/verify', params: { phone: phone, otp: '1234' }
+        post '/api/v1/otps/verify', params: { phone: phone, otp: '1234' }
         expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns success true with 200' do
         Auth::OtpService.new(phone, name:).generate_otp
-        get '/api/v1/otps/verify', params: { phone: phone, otp: '1212', auth_token: }
+        post '/api/v1/otps/verify', params: { phone: phone, otp: '1212', auth_token: }
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to eq({ 'success' => true })
@@ -52,13 +52,13 @@ RSpec.describe 'Api::V1::OtpsController', type: :request do
 
     context 'when otp is incorrect' do
       it 'sends unauthorized response if auth_token is incorrect' do
-        get '/api/v1/otps/verify', params: { phone: phone, otp: '1234', auth_token: 'safdasfasdfsdaf' }
+        post '/api/v1/otps/verify', params: { phone: phone, otp: '1234', auth_token: 'safdasfasdfsdaf' }
         expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns success false with 400' do
         Auth::OtpService.new(phone, name:).generate_otp
-        get '/api/v1/otps/verify', params: { phone: phone, otp: '0000', auth_token: }
+        post '/api/v1/otps/verify', params: { phone: phone, otp: '0000', auth_token: }
 
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body).to eq({ 'success' => false })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - OTP endpoints now require POST instead of GET for generate and verify. Update clients to use POST. Paths remain unchanged.
- Chores
  - Core API controller streamlined to API-only behavior. No changes to authentication token verification or API version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->