### PR TITLE
Hack for otp coming as a hash in the first request

### DIFF
--- a/app/controllers/api/v1/otps_controller.rb
+++ b/app/controllers/api/v1/otps_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       # special case added for compatibility with framer
       def generate_or_verify
-        params[:otp].present? ? verify : generate
+        (params[:otp].present? && params[:otp].is_a?(String)) ? verify : generate
       end
 
       def generate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTP verification now runs only when the otp parameter is present and a valid string. Missing or non-string values trigger OTP generation instead of verification, preventing unintended verification from malformed inputs and improving reliability across edge cases. No changes to public endpoints, parameters, or response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->