### PR TITLE
Revert hacks

### DIFF
--- a/app/controllers/api/v1/otps_controller.rb
+++ b/app/controllers/api/v1/otps_controller.rb
@@ -5,11 +5,6 @@ module Api
     class OtpsController < ApiController
       before_action :set_phone_number
 
-      # special case added for compatibility with framer
-      def generate_or_verify
-        params[:otp].present? ? verify : generate
-      end
-
       def generate
         service = Auth::OtpService.new(@phone, name: generate_auth_params[:name])
         if service.generate_otp

--- a/config/routes/v1_api.rb
+++ b/config/routes/v1_api.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
         collection do
           post :generate
           post :verify
-          post :generate_or_verify # special case
         end
       end
     end

--- a/spec/requests/api/v1/otps_spec.rb
+++ b/spec/requests/api/v1/otps_spec.rb
@@ -67,25 +67,4 @@ RSpec.describe 'Api::V1::OtpsController', type: :request do
       end
     end
   end
-
-  describe 'POST /api/v1/otps/generate_or_verify' do
-    it 'sends unauthorized response if auth_token is missing' do
-      post '/api/v1/otps/generate_or_verify', params: { phone: phone, name: 'Deepak' }
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    it 'Generates otp when the param otp is not present' do
-      post '/api/v1/otps/generate_or_verify', params: { phone: phone, name: 'Deepak', auth_token: }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ 'success' => true })
-    end
-
-    it 'Verifies if the otp is present' do
-      mobile_no = MobileNumber.new(value: '9999999999', country_code: AVAILABLE_COUNTRIES[:india][:code])
-      Auth::OtpService.new(mobile_no, name:).generate_otp
-      post '/api/v1/otps/generate_or_verify', params: { phone: phone, otp: '1212', auth_token: }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ 'success' => true })
-    end
-  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the legacy combined OTP endpoint. Clients must now call the dedicated Generate and Verify endpoints separately. Existing Generate and Verify behaviors are unchanged. Routes updated accordingly. This is a breaking change for any clients using the combined endpoint.

* **Tests**
  * Removed request tests covering the deprecated combined OTP endpoint; tests for the separate Generate and Verify endpoints remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->