### PR TITLE
Fix typo, move hard coded string values from invite modal to en.yml

### DIFF
--- a/app/views/invites/new.html.erb
+++ b/app/views/invites/new.html.erb
@@ -1,33 +1,33 @@
-<%= render "shared/components/modal", modalTitle: I18n.t('invite.modal_title') do %>
+<%= render "shared/components/modal", modalTitle: t('invite.modal_title') do %>
   <%= form_with(url: invites_path, method: :post, model: @user, class: "flex flex-col gap-6 p-6") do |form| %>
     <%= render "shared/components/form_errors", resource: @user %>
     <%= form.hidden_field :team_id %>
 
-    <%= input_field(form:, field_name: :name, label: "Name", placeholder: I18n.t('invite.placeholder_name'), type: "text", width: "w-full") %>
+    <%= input_field(form:, field_name: :name, label: t("labels.name"), placeholder: t('invite.placeholder_name'), type: "text", width: "w-full") %>
     <div class="flex flex-row gap-2">
       <%= input_field(form:, field_name: :country_code, value: get_country_code(@team.learning_partner.supported_countries), width: "w-24", html_options: { readonly: true }) %>
-      <%= input_mobile(form:, field_name: :phone, placeholder: I18n.t('invite.placeholder_phone'), html_options: { required: false }) %>
+      <%= input_mobile(form:, field_name: :phone, placeholder: t('invite.placeholder_phone'), html_options: { required: false }) %>
     </div>
-    <%= input_dropdown(form:, field_name: :role, label: "Category", options: user_role_mapping_for_partner(current_user, @team), width: "w-full") %>
+    <%= input_dropdown(form:, field_name: :role, label: t("labels.category"), options: user_role_mapping_for_partner(current_user, @team), width: "w-full") %>
 
     <!-- admin cannot bulk import users, admin invites users to the top level team.
     Inviting in bulk can be done by managers or owners of the company -->
     <% if current_user.privileged_user? %>
       <div class="my-4 flex items-center">
         <div class="flex-grow border-t border-line-colour"></div>
-        <span class="px-2 text-sm">Or invite multiple learners to the team</span>
+        <span class="px-2 text-sm"><%= t("invite.invite_multiple_learners") %></span>
         <div class="flex-grow border-t border-line-colour"></div>
       </div>
       <div>
-        <%= link_to I18n.t("invite.download_csv"), download_invites_path, class: "nav-link", target: "_blank" %>
+        <%= link_to t("invite.download_csv"), download_invites_path, class: "nav-link", target: "_blank" %>
       </div>
       <div class="flex w-full flex-col items-start justify-center gap-4">
         <%= render 'shared/components/file_select', hidden_file_field: form.file_field(:bulk_invite, class: "hidden", data: { forms_target: "fileInput" }) %>
       </div>
     <% end %>
     <div class="flex flex-col justify-between gap-6 heading">
-      <%= form.button I18n.t("invite.invite_user"), class: "bg-primary text-white p-4 rounded" %>
-      <%= link_to I18n.t('button.cancel'), 'javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
+      <%= form.button t("invite.invite_user"), class: "bg-primary text-white p-4 rounded" %>
+      <%= link_to t('button.cancel'), 'javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/invites/new.html.erb
+++ b/app/views/invites/new.html.erb
@@ -13,21 +13,21 @@
     <!-- admin cannot bulk import users, admin invites users to the top level team.
     Inviting in bulk can be done by managers or owners of the company -->
     <% if current_user.privileged_user? %>
-      <div class="flex items-center my-4">
+      <div class="my-4 flex items-center">
         <div class="flex-grow border-t border-line-colour"></div>
-        <span class="px-2 text-sm ">Or invite multiple learners to the team</span>
+        <span class="px-2 text-sm">Or invite multiple learners to the team</span>
         <div class="flex-grow border-t border-line-colour"></div>
       </div>
       <div>
         <%= link_to I18n.t("invite.download_csv"), download_invites_path, class: "nav-link", target: "_blank" %>
       </div>
-      <div class="flex flex-col gap-4 items-start justify-center w-full">
+      <div class="flex w-full flex-col items-start justify-center gap-4">
         <%= render 'shared/components/file_select', hidden_file_field: form.file_field(:bulk_invite, class: "hidden", data: { forms_target: "fileInput" }) %>
       </div>
     <% end %>
-    <div class="flex flex-col gap-6 justify-between heading">
+    <div class="flex flex-col justify-between gap-6 heading">
       <%= form.button I18n.t("invite.invite_user"), class: "bg-primary text-white p-4 rounded" %>
-      <%= link_to 'Cancel', 'javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
+      <%= link_to I18n.t('button.cancel'), 'javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/invites/new.html.erb
+++ b/app/views/invites/new.html.erb
@@ -1,14 +1,14 @@
-<%= render "shared/components/modal", modalTitle: "Invite new user" do %>
+<%= render "shared/components/modal", modalTitle: I18n.t('invite.modal_title') do %>
   <%= form_with(url: invites_path, method: :post, model: @user, class: "flex flex-col gap-6 p-6") do |form| %>
     <%= render "shared/components/form_errors", resource: @user %>
     <%= form.hidden_field :team_id %>
 
-    <%= input_field(form:, field_name: :name, label: "Name", placeholder: "Enter your name",type: "text",width:"w-full") %>
+    <%= input_field(form:, field_name: :name, label: "Name", placeholder: I18n.t('invite.placeholder_name'), type: "text", width: "w-full") %>
     <div class="flex flex-row gap-2">
       <%= input_field(form:, field_name: :country_code, value: get_country_code(@team.learning_partner.supported_countries), width: "w-24", html_options: { readonly: true }) %>
-      <%= input_mobile(form:, field_name: :phone, placeholder: "Enter your mobile number", html_options: { required: false }) %>
+      <%= input_mobile(form:, field_name: :phone, placeholder: I18n.t('invite.placeholder_phone'), html_options: { required: false }) %>
     </div>
-    <%= input_dropdown(form:, field_name: :role, label: "Category", options:user_role_mapping_for_partner(current_user, @team),width:"w-full") %>
+    <%= input_dropdown(form:, field_name: :role, label: "Category", options: user_role_mapping_for_partner(current_user, @team), width: "w-full") %>
 
     <!-- admin cannot bulk import users, admin invites users to the top level team.
     Inviting in bulk can be done by managers or owners of the company -->
@@ -19,15 +19,15 @@
         <div class="flex-grow border-t border-line-colour"></div>
       </div>
       <div>
-        <%= link_to "Download sample csv file", download_invites_path, class: "nav-link", target: "_blank" %>
+        <%= link_to I18n.t("invite.download_csv"), download_invites_path, class: "nav-link", target: "_blank" %>
       </div>
       <div class="flex flex-col gap-4 items-start justify-center w-full">
         <%= render 'shared/components/file_select', hidden_file_field: form.file_field(:bulk_invite, class: "hidden", data: { forms_target: "fileInput" }) %>
       </div>
     <% end %>
     <div class="flex flex-col gap-6 justify-between heading">
-      <%= form.button "Invite user", class: "bg-primary text-white p-4 rounded" %>
-      <%= link_to 'Cancel','javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
+      <%= form.button I18n.t("invite.invite_user"), class: "bg-primary text-white p-4 rounded" %>
+      <%= link_to 'Cancel', 'javascript:void(0);', class: 'text-center', data: { action: "click->modals#closeModal" } %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,11 @@ en:
     incorrect_phone: "Incorrect mobile number"
     incorrect_mobile_or_otp: "Incorrect mobile number or otp"
   invite:
+    placeholder_name: "Enter invitee name"
+    placeholder_phone: "Enter invitee mobile number"
+    modal_title: "Invite new user"
     invite_user: "Invite user"
+    download_csv: "Download sample csv file"
     max_user_count: "Reached maximum user count."
     bulk: "An invitation will be sent to each of the users in the input file"
     single: "Invitation sent to user."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,9 @@ en:
     not_found: "The %{resource_name} is not found."
   pundit:
     unauthorized: "Sorry you are not authorized to perform that action."
+  labels:
+    category: "Category"
+    name: "Name"
   button:
     edit: "Edit"
     delete: "Delete"
@@ -118,6 +121,7 @@ en:
     invite_sent: "Invitation sent to %{phone}"
     invalid_user: "Failed to invite user, are you sure that this user exists ?"
     exceeds_user_limit: "Can't add more than %{limit} users in your current plan."
+    invite_multiple_learners: "Or invite multiple learners to the team"
   local_content:
     video_not_found: "Video for %{lang} must exists"
     lang_exists: "%{lang} already exists"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized the invite form UI—titles, placeholders, link text, and action buttons now use translation strings.
  * Added English translations for invite modal title, name/phone placeholders, and CSV download link.

* **Style**
  * Minor markup/formatting and class ordering adjustments on the invite page; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->