### PR TITLE
Enable landscape orientation for generated PDFs

### DIFF
--- a/app/services/courses/generate_certificate_service.rb
+++ b/app/services/courses/generate_certificate_service.rb
@@ -76,7 +76,8 @@ module Courses
         html,
         emulate_media: 'screen',
         full_page: false,
-        print_background: true
+        print_background: true,
+        landscape: true
       )
     end
 


### PR DESCRIPTION
Added  option in Grover PDF generation to render certificates in landscape orientation.

<img width="1066" height="823" alt="Screenshot 2025-09-18 at 9 28 52 PM" src="https://github.com/user-attachments/assets/1fee46d8-c3c8-4425-a0ed-e253d2cade01" />
