### PR TITLE
Fixes hidden tag when filtering courses (#1054)

### DIFF
--- a/app/services/courses/filter_service.rb
+++ b/app/services/courses/filter_service.rb
@@ -50,10 +50,10 @@ module Courses
         #                         .where(tags: { id: levels })
         #                         .select(:id))
       elsif categories.present?
-        courses.joins(:tags)
+        courses.left_joins(:tags)
                .where(tags: { id: categories })
       elsif levels.present?
-        courses.joins(:tags)
+        courses.left_joins(:tags)
                .where(tags: { id: levels })
       else
         courses


### PR DESCRIPTION
#1054 

includes eager loads using left outer join. So to get all associated tags for courses, use left join while filtering tags. 