### PR TITLE
Fix progress bar contrast in highlighted lesson modules

### DIFF
--- a/app/views/lessons/_play_list.html.erb
+++ b/app/views/lessons/_play_list.html.erb
@@ -14,7 +14,7 @@
             <span class=""><%= course_module.title %></span>
             <div class="md:flex md:items-center md:gap-4">
               <% if enrollment.present? && enrollment.module_progress(course_module) > 0 %>
-                <div class="bg-primary-light-50 h-1 w-[252px] rounded-full">
+                <div class="bg-primary-light-100 h-1 w-[252px] rounded-full">
                   <div class="bg-slate-grey-50 h-1 rounded-full" style="width: <%= enrollment.module_progress(course_module) %>%"></div>
                 </div>
                 <span class="text-slate-grey-50 label-small"><%= enrollment.module_progress(course_module) %>%</span>


### PR DESCRIPTION
Fixes: #1069 

<img width="542" height="285" alt="Screenshot 2025-09-24 at 2 34 09 PM" src="https://github.com/user-attachments/assets/1fa2c872-ab27-4337-9d15-b9c62679c52e" />
