### PR TITLE
Fix on mobile view menu click issue on Partner Details page

### DIFF
--- a/app/helpers/learning_partners_helper.rb
+++ b/app/helpers/learning_partners_helper.rb
@@ -15,7 +15,7 @@ module LearningPartnersHelper
   private
 
   def edit_partner_item(learning_partner)
-    ViewComponent::MenuComponentHelper::MenuItem.new(
+    ViewComponent::MenuComponent::MenuItem.new(
       label: t('button.edit'),
       url: edit_learning_partner_path(learning_partner),
       type: :link
@@ -25,7 +25,7 @@ module LearningPartnersHelper
   def activate_partner_item(learning_partner)
     return unless policy(learning_partner).activate?
 
-    ViewComponent::MenuComponentHelper::MenuItem.new(
+    ViewComponent::MenuComponent::MenuItem.new(
       label: t('learning_partner.activate'),
       url: activate_learning_partner_path(learning_partner),
       type: :link,
@@ -46,7 +46,7 @@ module LearningPartnersHelper
         'learning_partner.payment_plan.create'
       end
 
-    ViewComponent::MenuComponentHelper::MenuItem.new(
+    ViewComponent::MenuComponent::MenuItem.new(
       label: t(label_key),
       url: edit_learning_partner_payment_plan_path(learning_partner),
       type: :link,
@@ -55,7 +55,7 @@ module LearningPartnersHelper
   end
 
   def certificate_templates_item(learning_partner)
-    ViewComponent::MenuComponentHelper::MenuItem.new(
+    ViewComponent::MenuComponent::MenuItem.new(
       label: t('learning_partner.certificate_templates', default: 'Certificate templates'),
       url: learning_partner_certificate_templates_path(learning_partner.id),
       type: :link

--- a/app/views/learning_partners/_header_banner.html.erb
+++ b/app/views/learning_partners/_header_banner.html.erb
@@ -3,14 +3,14 @@
     <%= image_tag partner_banner(learning_partner), class: 'h-full w-full object-cover rounded-lg md:rounded-xl' %>
   </div>
   <div class="absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/0 rounded-lg md:rounded-xl"></div>
-  <div class="absolute top-6 left-6 flex items-center space-x-3 z-10">
+  <div class="absolute top-6 left-6 flex flex-wrap items-center gap-3 z-10">
     <%= image_tag partner_logo(learning_partner, :large), class: 'h-6 md:h-10 w-6 md:w-10 object-cover rounded-full border-2 border-white box-shadow-medium' %>
-    <span class="heading-xl text-white"><%= learning_partner.name %> </span>
+    <span class="heading-xl text-white max-w-64 md:max-w-none"><%= learning_partner.name %> </span>
     <% unless learning_partner.first_owner_joined? %>
       <%= chip_component(text: 'Owner not joined', colorscheme: 'danger', icon_name: 'x-mark') %>
     <% end %>
   </div>
-  <div class="absolute top-3 md:top-4 right-3 md:right-4 flex">
+  <div class="absolute top-3 md:top-4 right-3 md:right-4 flex z-20 ">
     <%= menu_component(menu_items: learning_partner_menu_items(learning_partner)) %>      
   </div>
   <%= link_to 'javascript:void(0);' do %>


### PR DESCRIPTION
Fixes #1223 

- Resolved title overlay blocking menu action button on mobile by  Adjusting positioning and z-index for header elements
- Replaced deprecated MenuComponentHelper with MenuComponent in LearningPartnersHelper