### PR TITLE
Fix course card image and Continue button alignment

### DIFF
--- a/app/views/courses/_course_description_card.html.erb
+++ b/app/views/courses/_course_description_card.html.erb
@@ -67,7 +67,7 @@
             <% end %>
           </div>  
           
-          <div class="flex flex-wrap gap-2 h-[24px] overflow-x-auto overflow-y-hidden whitespace-nowrap">
+          <div class="flex flex-wrap gap-2 md:h-[24px] overflow-x-hidden overflow-y-auto whitespace-nowrap">
             <% course.tags.each do |tag| %>
               <% if tag.tag_type == "category" %>
                 <%= chip_component(text: tag.name , colorscheme: 'primary', icon_name: 'check') %>


### PR DESCRIPTION
Fix course card layout: image positioning and Continue button alignment
fixes#1230
<img width="1210" height="182" alt="Screenshot 2026-01-23 at 2 33 51 PM" src="https://github.com/user-attachments/assets/387322c6-0527-4c4f-b21c-8124ae61be18" />
<img width="1209" height="168" alt="Screenshot 2026-01-23 at 2 35 36 PM" src="https://github.com/user-attachments/assets/def5d1bc-e88a-463a-86f8-ef631649d5a5" />
<img width="342" height="411" alt="Screenshot 2026-01-23 at 2 36 16 PM" src="https://github.com/user-attachments/assets/06b6540d-1b40-42b0-9d4a-14743d0780a3" />
