### PR TITLE
Fix intermittent failure in user invite spec

### DIFF
--- a/spec/requests/user_invite_spec.rb
+++ b/spec/requests/user_invite_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe 'Request spec for user invites' do
     {
       user: {
         name: Faker::Name.name,
-        phone: Faker::Number.number(digits: 10),
+        phone: "9#{Faker::Number.number(digits: 9)}",
         role: 'learner',
         team_id: team.id,
         country_code: '+91'


### PR DESCRIPTION
Faker::Number.number(digits: 10) could generate numbers starting with 0-5, which fail Phonelib validation for Indian numbers (+91). Fixed by prefixing with '9' to always generate a valid Indian mobile number.