### PR TITLE
Fix Devise mailer failing in Sidekiq due to empty mappings

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,6 +15,13 @@ Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.credentials.dig(:redis, :url), size: 9, reconnect_attempts: 2,
                    network_timeout: 10 }
 
+  # Rails 8 uses LazyRouteSet in development — routes are never drawn in Sidekiq
+  # because it never handles HTTP requests. This causes Devise.mappings to be empty,
+  # breaking any job that calls Devise mailer (e.g. forgot password email).
+  config.on(:startup) do
+    Rails.application.routes_reloader.execute_unless_loaded
+  end
+
   schedule_file = 'config/scheduled_jobs.yml'
   if File.exist?(schedule_file)
     jobs_hash = YAML.load_file(schedule_file, aliases: true)


### PR DESCRIPTION
fixes #1266 
Rails 8 uses LazyRouteSet in development which defers route drawing until the first HTTP request. Sidekiq never handles HTTP requests, so Devise.mappings stays empty and raises RuntimeError when delivering emails via deliver_later (e.g. forgot password flow).

Force routes to be drawn at Sidekiq startup via execute_unless_loaded.