### PR TITLE
Document neo_components local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,15 @@ bin/dev
 If you are actively developing `neo_components` alongside this app, you can point Bundler to your local checkout so changes are picked up immediately without pushing to GitHub:
 
 ```bash
-bundle config local.neo_components /path/to/neo_components
-bundle config disable_local_branch_check true
+bundle config set --local local.neo_components /path/to/neo_components
+bundle config set --local disable_local_branch_check true
 bundle install
 ```
 
 To revert back to the GitHub version:
 
 ```bash
-bundle config --delete local.neo_components
+bundle config unset --local local.neo_components
 bundle install
 ```
 


### PR DESCRIPTION
## Summary

- Adds a section to the README explaining how to point Bundler to a local `neo_components` checkout during development
- Developers who want to work on both repos simultaneously can opt in with `bundle config local.neo_components`; those who don't are unaffected and continue using the GitHub version