### PR TITLE
Clean up tmp/storage after test suite runs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
+
+  config.after(:suite) do
+    FileUtils.rm_rf(Rails.root.join('tmp/storage'))
+  end
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
Closes #1300

Adds an `after(:suite)` hook in `spec/rails_helper.rb` to delete `tmp/storage` once the test suite finishes, preventing ~5 GB of orphaned Active Storage files from accumulating per run.