### PR TITLE
Fix Docker build failure: copy engines before bundle install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && 
     ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Install application gems
+# engines/ must be copied first — neo_component and content_studio are local path gems
 COPY Gemfile Gemfile.lock ./
+COPY engines/ engines/
 RUN bundle install
 RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 RUN bundle exec bootsnap precompile --gemfile


### PR DESCRIPTION
## Problem

Jenkins build #183 failed at `bundle install` with:

```
The path `/deploy/engines/neo_component` does not exist.
```

`neo_component` is declared as local path gems in the `Gemfile`. The Dockerfile only copied `Gemfile` and `Gemfile.lock` before running `bundle install`, so Bundler could not resolve either path gem.

## Fix

Copy `engines/` into the image before `bundle install` so any engine gems are present when Bundler resolves dependencies.