### PR TITLE
Preserve .keep file when cleaning tmp/storage after test suite

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,7 +61,7 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    FileUtils.rm_rf(Rails.root.join('tmp/storage'))
+    FileUtils.rm_rf(Rails.root.glob('tmp/storage/*') - [Rails.root.join('tmp/storage/.keep')])
   end
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false


### PR DESCRIPTION
Fixes #1315

## Summary
- Fixes the `after(:suite)` cleanup in `rails_helper.rb` to preserve `tmp/storage/.keep` while removing test-generated files
- Uses `Rails.root.glob` with array subtraction to exclude `.keep` from deletion