### PR TITLE
Hide carousel controls when items fit viewport

### DIFF
--- a/app/views/courses/explore.html.erb
+++ b/app/views/courses/explore.html.erb
@@ -68,7 +68,7 @@
     <div class="flex items-center gap-3 justify-between">
       <h2 class="main-text-lg-semibold">Continue Your Learning</h2>
       
-      <%= link_to continue_courses_path do %>
+      <%= link_to continue_courses_path, data: { carousel_view_more: true } do %>
         <div class="hidden md:inline">
           <%= button_component text: 'View More',
                                size: 'sm',

--- a/app/views/courses/list/_non_admin.html.erb
+++ b/app/views/courses/list/_non_admin.html.erb
@@ -15,7 +15,7 @@
         <div class="flex items-center justify-center gap-3 md:justify-between">
           <h2 class="main-text-lg-semibold">Explore Our Programmes</h2>
 
-          <%= link_to explore_programs_path do %>
+          <%= link_to explore_programs_path, data: { carousel_view_more: true } do %>
             <div class="hidden md:inline">
             <%= button_component text: "View More",
                                  size: 'sm',
@@ -36,7 +36,7 @@
         <div class="flex items-center gap-3 justify-between">
           <h2 class="main-text-lg-semibold">Continue Your Learning</h2>
 
-          <%= link_to continue_courses_path do %>
+          <%= link_to continue_courses_path, data: { carousel_view_more: true } do %>
             <div class="hidden md:inline">
               <%= button_component text: 'View More',
                                    size: 'sm',
@@ -76,7 +76,7 @@
                 <% section_data.each do |name, courses| %>
                   <div data-tabs-target="panelItem" class="space-y-4">
                     <%= carousel_component cards: course_cards(courses), loop: false, enable_in_small_devices: false %>
-                    <%= link_to explore_courses_path("tags[]": name), class: 'block w-fit' do %>
+                    <%= link_to explore_courses_path("tags[]": name), class: 'block w-fit', data: { carousel_view_more: true } do %>
                       <%= button_component text: "Show all Courses on #{name}",
                                           size: 'sm',
                                           type: 'outline',

--- a/app/views/my_profiles/show.html.erb
+++ b/app/views/my_profiles/show.html.erb
@@ -8,7 +8,7 @@
     <section class="bg-white py-5 md:px-5 md:pt-4 md:rounded-xl md:border md:border-line-colour-light space-y-5">
       <div class="flex items-center gap-3 justify-between">
         <h2 class="main-text-lg-semibold"><%= t("my_profile.my_certificates.label") %></h2>
-        <%= link_to certificates_profile_path do %>
+        <%= link_to certificates_profile_path, data: { carousel_view_more: true } do %>
           <div class="hidden md:inline">
             <%= button_component text: t("button.view_more"),
                                  size: 'sm',
@@ -66,7 +66,7 @@
                 <% view_all_path = status == ongoing_label ? continue_courses_path(from: 'my_profile') : complete_courses_path(from: 'my_profile') %>
                 <div data-tabs-target="panelItem" class="space-y-4">
                   <%= carousel_component cards: all_cards, loop: false, enable_in_small_devices: false %>
-                  <%= link_to view_all_path, class: 'block w-fit' do %>
+                  <%= link_to view_all_path, class: 'block w-fit', data: { carousel_view_more: true } do %>
                     <%= button_component text: t("my_profile.my_courses.show_all", status: status),
                                         size: 'sm',
                                         type: 'outline',

--- a/app/views/programs/explore.html.erb
+++ b/app/views/programs/explore.html.erb
@@ -55,7 +55,7 @@
     <div class="flex items-center gap-3 justify-between">
       <h2 class="main-text-lg-semibold"><%= t("programs.continue_learning") %></h2>
       
-      <%= link_to explore_courses_path do %>
+      <%= link_to explore_courses_path, data: { carousel_view_more: true } do %>
         <div class="hidden md:inline">
           <%= button_component text: t("button.view_more"),
                                size: 'sm',

--- a/engines/neo_component/app/javascript/neo_components/controllers/carousel_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/carousel_controller.js
@@ -33,6 +33,18 @@ export default class extends Controller {
         }
       },
     })
+
+    this.toggleControls()
+    this.swiper.on('resize', () => this.toggleControls())
+  }
+
+  toggleControls() {
+    const locked = this.swiper.isLocked
+    this.prevTarget.classList.toggle('hidden', locked)
+    this.nextTarget.classList.toggle('hidden', locked)
+
+    const viewMore = this.element.parentElement?.querySelector('[data-carousel-view-more]')
+    if (viewMore) viewMore.classList.toggle('hidden', locked)
   }
 
   disconnect() {


### PR DESCRIPTION
Fixes #1302

## Summary
- Use Swiper's `isLocked` property in the carousel controller to detect when all slides fit the viewport, and hide navigation arrows and "View More" links accordingly
- Added `data-carousel-view-more` attribute to "View More" links across learner home, explore, and profile pages so the carousel controller can locate and toggle them
- Controls reappear on window resize when the viewport shrinks enough that cards no longer fit