### PR TITLE
Fix N+1 query on courses pages for active storage blob

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,7 @@ class CoursesController < ApplicationController
     authorize :course
     if current_user.is_admin?
       search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term], type: params[:type])
-      @courses = Courses::FilterService.new(current_user, search_context).filter.records.includes(:tags, :banner_attachment)
+      @courses = Courses::FilterService.new(current_user, search_context).filter.records.includes(:tags, banner_attachment: :blob)
       @courses = @courses.page(filter_params[:page])
     else
       @data = HomePageService.instance.build_data_for(current_user)
@@ -28,11 +28,11 @@ class CoursesController < ApplicationController
     @courses = {}
     search_context = build_search_context type: SearchContext::INCOMPLETE
     @courses[:continue] = Courses::FilterService.new(current_user, search_context).filter.records
-                                               .preload(:tags, :banner_attachment).limit(12)
+                                               .preload(:tags, banner_attachment: :blob).limit(12)
 
     search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term], type: params[:type])
     @courses[:explore] = Courses::FilterService.new(current_user, search_context).filter.records
-                                               .preload(:tags, :banner_attachment).page(filter_params[:page])
+                                               .preload(:tags, banner_attachment: :blob).page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses[:explore])
 
     @tags = Tag.load_tags
@@ -43,7 +43,7 @@ class CoursesController < ApplicationController
 
     search_context = build_search_context type: SearchContext::INCOMPLETE
     @courses = Courses::FilterService.new(current_user, search_context).filter.records
-                                    .preload(:tags, :banner_attachment).page(filter_params[:page])
+                                    .preload(:tags, banner_attachment: :blob).page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses)
     @tags = Tag.load_tags
   end
@@ -52,7 +52,7 @@ class CoursesController < ApplicationController
     authorize :course
     search_context = build_search_context type: SearchContext::COMPLETE
     @courses = Courses::FilterService.new(current_user, search_context).filter.records
-                                    .preload(:tags, :banner_attachment)
+                                    .preload(:tags, banner_attachment: :blob)
                                     .page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses)
     @tags = Tag.load_tags

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -13,24 +13,27 @@ class CoursesController < ApplicationController
   def index
     authorize :course
     if current_user.is_admin?
-      search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term], type: params[:type])
-      @courses = Courses::FilterService.new(current_user, search_context).filter.records.includes(:tags, banner_attachment: :blob)
+      search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term],
+                                         type: params[:type])
+      @courses = Courses::FilterService.new(current_user, search_context).filter.records
+                                       .includes(:tags, banner_attachment: :blob)
       @courses = @courses.page(filter_params[:page])
     else
       @data = HomePageService.instance.build_data_for(current_user)
     end
     @tags = Tag.load_tags
   end
-   
+
   def explore
     authorize :course
 
     @courses = {}
     search_context = build_search_context type: SearchContext::INCOMPLETE
     @courses[:continue] = Courses::FilterService.new(current_user, search_context).filter.records
-                                               .preload(:tags, banner_attachment: :blob).limit(12)
+                                                .preload(:tags, banner_attachment: :blob).limit(12)
 
-    search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term], type: params[:type])
+    search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term],
+                                       type: params[:type])
     @courses[:explore] = Courses::FilterService.new(current_user, search_context).filter.records
                                                .preload(:tags, banner_attachment: :blob).page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses[:explore])
@@ -43,7 +46,7 @@ class CoursesController < ApplicationController
 
     search_context = build_search_context type: SearchContext::INCOMPLETE
     @courses = Courses::FilterService.new(current_user, search_context).filter.records
-                                    .preload(:tags, banner_attachment: :blob).page(filter_params[:page])
+                                     .preload(:tags, banner_attachment: :blob).page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses)
     @tags = Tag.load_tags
   end
@@ -52,8 +55,8 @@ class CoursesController < ApplicationController
     authorize :course
     search_context = build_search_context type: SearchContext::COMPLETE
     @courses = Courses::FilterService.new(current_user, search_context).filter.records
-                                    .preload(:tags, banner_attachment: :blob)
-                                    .page(filter_params[:page])
+                                     .preload(:tags, banner_attachment: :blob)
+                                     .page(filter_params[:page])
     @enrollments_by_course_id = current_user.enrollments.indexed_by_course(@courses)
     @tags = Tag.load_tags
   end
@@ -64,10 +67,10 @@ class CoursesController < ApplicationController
     @course_modules = @course.modules_in_order
     @enrollment = current_user.get_enrollment_for(@course)
 
-    if @enrollment.present?
-      EVENT_LOGGER.publish_course_viewed(current_user, @course.id)
-      @assessment = Assessment.find_by(user: current_user, course: @course)
-    end
+    return if @enrollment.blank?
+
+    EVENT_LOGGER.publish_course_viewed(current_user, @course.id)
+    @assessment = Assessment.find_by(user: current_user, course: @course)
   end
 
   # GET /courses/new
@@ -99,8 +102,8 @@ class CoursesController < ApplicationController
       @error_step = Courses::CourseFormSteps.error_step_for(@course)
 
       render :new,
-            status: :unprocessable_content,
-            locals: { error_step: @error_step }
+             status: :unprocessable_content,
+             locals: { error_step: @error_step }
     end
   end
 
@@ -118,8 +121,8 @@ class CoursesController < ApplicationController
       @error_step = Courses::CourseFormSteps.error_step_for(@course)
 
       render :edit,
-            status: :unprocessable_content,
-            locals: { error_step: @error_step }
+             status: :unprocessable_content,
+             locals: { error_step: @error_step }
     end
   end
 
@@ -217,7 +220,7 @@ class CoursesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def course_params
-    params.require(:course).permit(:title, :description, :banner, :category_id, :level_id, :visibility)
+    params.expect(course: %i[title description banner category_id level_id visibility])
   end
 
   def filter_params
@@ -241,6 +244,6 @@ class CoursesController < ApplicationController
   def build_search_context(type: nil, tags: [])
     SearchContext.new(context: SearchContext::HOME_PAGE,
                       type:,
-                      tags:,)
+                      tags:)
   end
 end

--- a/app/services/home_page_service.rb
+++ b/app/services/home_page_service.rb
@@ -30,13 +30,13 @@ class HomePageService
 
   def build_continue(user)
     ctx = SearchContext.new(context: SearchContext::HOME_PAGE, type: SearchContext::INCOMPLETE)
-    Courses::FilterService.new(user, ctx).filter.records.preload(:tags, :banner_attachment)
+    Courses::FilterService.new(user, ctx).filter.records.preload(:tags, banner_attachment: :blob)
   end
 
   def build_categories(user)
     ctx = SearchContext.new(context: SearchContext::HOME_PAGE, tags: CONFIG[:categories][:tags])
     courses_in_categories = Courses::FilterService.new(user, ctx).filter.records
-                                                  .preload(:tags, :banner_attachment)
+                                                  .preload(:tags, banner_attachment: :blob)
     courses = {}
 
     courses_in_categories.each do |course|

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -13,5 +13,5 @@ if Rails.env.local? && defined?(Bullet)
 
   # Locally courses have no banners so blob appears unused, but in production
   # all courses have banners and blob is accessed for the S3 service name check.
-  Bullet.add_safelist(type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob)
+  Bullet.add_safelist(type: :unused_eager_loading, class_name: 'ActiveStorage::Attachment', association: :blob)
 end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -5,9 +5,13 @@ if Rails.env.local? && defined?(Bullet)
   Bullet.bullet_logger = true
 
   Bullet.rails_logger = true
-  Bullet.raise = true if Rails.env.test?
+  Bullet.raise = true
 
   Bullet.n_plus_one_query_enable = true
   Bullet.unused_eager_loading_enable = true
   Bullet.counter_cache_enable = true
+
+  # Locally courses have no banners so blob appears unused, but in production
+  # all courses have banners and blob is accessed for the S3 service name check.
+  Bullet.add_safelist(type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob)
 end


### PR DESCRIPTION
Fixes #1282

Sentry issue: https://openvitae-technologies-pvt-ltd.sentry.io/issues/108645163/

## What

Preloading `banner_attachment` without its associated `blob` caused a separate `active_storage_blobs` query per course when rendering banners (50 queries per request on the courses index page).

Changed all course list queries across `CoursesController` and `HomePageService` to preload `banner_attachment: :blob` instead of just `:banner_attachment`.

Also added a Bullet safelist for `ActiveStorage::Attachment => :blob` in local environments — locally courses have no banners so the blob preload appears unused to Bullet, but in production all courses have banners and the blob is accessed for the S3 service name check in `courses_helper.rb`.