### PR TITLE
[NeoComponent] Add multi_select_component

### DIFF
--- a/engines/neo_component/app/controllers/neo_components/ui/inputs_controller.rb
+++ b/engines/neo_component/app/controllers/neo_components/ui/inputs_controller.rb
@@ -3,32 +3,25 @@
 module NeoComponents
   module Ui
     class InputsController < BaseController
-      def index
-      end
+      def index; end
 
-      def text_field
-      end
+      def text_field; end
 
-      def radio_button
-      end
+      def radio_button; end
 
-      def checkbox
-      end
+      def checkbox; end
 
-      def file_selector
-      end
+      def file_selector; end
 
-      def mobile_inputs
-      end
+      def mobile_inputs; end
 
-      def textarea
-      end
+      def textarea; end
 
-      def dropdown
-      end
+      def dropdown; end
 
-      def date_picker
-      end
+      def date_picker; end
+
+      def multi_select; end
     end
   end
 end

--- a/engines/neo_component/app/helpers/view_component/input_component.rb
+++ b/engines/neo_component/app/helpers/view_component/input_component.rb
@@ -286,5 +286,36 @@ module ViewComponent
       render partial: 'view_components/inputs/date_picker_component/date_picker',
              locals: { date_picker: }
     end
+
+    def multi_select_component(
+      form: nil,
+      name: nil,
+      label: nil,
+      options: [],
+      value: [],
+      placeholder: nil,
+      size: 'md',
+      support_text: nil,
+      error: nil,
+      disabled: false,
+      html_options: {}
+    )
+      multi_select = MultiSelectComponent.new(
+        form:,
+        name:,
+        label:,
+        options:,
+        value:,
+        placeholder:,
+        size:,
+        support_text:,
+        error:,
+        disabled:,
+        html_options:
+      )
+
+      render partial: 'view_components/inputs/multi_select_component/multi_select',
+             locals: { multi_select: }
+    end
   end
 end

--- a/engines/neo_component/app/helpers/view_component/input_component/multi_select_component.rb
+++ b/engines/neo_component/app/helpers/view_component/input_component/multi_select_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module InputComponent
+    class MultiSelectComponent
+      include ViewComponent::ComponentHelper
+
+      SIZES = %w[md lg].freeze
+
+      TRIGGER_SIZE_STYLES = {
+        md: 'min-h-10 px-3 py-2 main-text-md-normal',
+        lg: 'min-h-12 px-4 py-3 main-text-lg-medium'
+      }.freeze
+
+      LABEL_STYLES = {
+        md: 'input-text-label-md general-text-sm-normal',
+        lg: 'input-text-label-lg general-text-md-normal'
+      }.freeze
+
+      SUPPORT_TEXT_STYLES = {
+        md: 'input-text-subtext-md general-text-sm-normal',
+        lg: 'input-text-subtext-lg general-text-md-normal'
+      }.freeze
+
+      attr_accessor :form, :name, :label, :options, :value, :size,
+                    :support_text, :error, :disabled, :placeholder, :html_options
+
+      def initialize(form:, name:, label:, options:, value:, size:, support_text:, error:,
+                     disabled:, placeholder:, html_options:)
+        raise "Incorrect multi_select size: #{size}" unless SIZES.include?(size)
+
+        error_message = resolve_error(form, name, error)
+
+        self.form = form
+        self.name = name
+        self.label = label
+        self.options = options
+        self.value = Array(value).map(&:to_s)
+        self.size = size
+        self.support_text = (error_message.presence || support_text)
+        self.error = error_message
+        self.disabled = disabled
+        self.placeholder = placeholder
+        self.html_options = html_options
+      end
+
+      def trigger_style
+        base = ['w-full flex items-center gap-2 rounded border cursor-pointer']
+        size_style = TRIGGER_SIZE_STYLES[size.to_sym]
+
+        color_style =
+          if disabled
+            'border-disabled-color cursor-not-allowed'
+          elsif error.present?
+            'border-danger'
+          else
+            'border-slate-grey-50'
+          end
+
+        class_list(base, size_style, color_style)
+      end
+
+      def label_style
+        base = []
+        size_style = LABEL_STYLES[size.to_sym]
+
+        color_style =
+          if disabled
+            'text-disabled-color'
+          elsif error.present?
+            'text-danger-dark'
+          else
+            'text-letter-color-light group-focus-within:text-primary'
+          end
+
+        class_list(base, size_style, color_style)
+      end
+
+      def support_text_style
+        base = []
+        size_style = SUPPORT_TEXT_STYLES[size.to_sym]
+
+        color_style =
+          if disabled
+            'text-disabled-color'
+          elsif error.present?
+            'text-danger-dark'
+          else
+            'text-letter-color-light'
+          end
+
+        class_list(base, size_style, color_style)
+      end
+
+      def input_name
+        return "#{name}[]" unless form
+
+        "#{form.object_name}[#{name}][]"
+      end
+
+      def selected?(option_value)
+        value.include?(option_value.to_s)
+      end
+    end
+  end
+end

--- a/engines/neo_component/app/helpers/view_component/input_component/multi_select_component.rb
+++ b/engines/neo_component/app/helpers/view_component/input_component/multi_select_component.rb
@@ -42,6 +42,10 @@ module ViewComponent
         self.disabled = disabled
         self.placeholder = placeholder
         self.html_options = html_options
+        self.html_options[:class] = [
+          'w-full flex flex-col gap-1',
+          self.html_options[:class]
+        ].compact.join(' ')
       end
 
       def trigger_style

--- a/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
@@ -56,15 +56,15 @@ export default class extends Controller {
   }
 
   _chip(value) {
-    return this.chipTargets.find((el) => el.dataset.value == value);
+    return this.chipTargets.find((el) => el.dataset.value === value);
   }
 
   _option(value) {
-    return this.optionTargets.find((el) => el.dataset.value == value);
+    return this.optionTargets.find((el) => el.dataset.value === value);
   }
 
   _hiddenInput(value) {
-    return this.hiddenInputTargets.find((el) => el.dataset.value == value);
+    return this.hiddenInputTargets.find((el) => el.dataset.value === value);
   }
 
   _syncChipsContainer() {

--- a/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
@@ -28,7 +28,6 @@ export default class extends Controller {
   selectOption(event) {
     event.stopPropagation();
     this._activate(event.currentTarget.dataset.value);
-    this.dropdownTarget.classList.add("hidden");
   }
 
   removeChip(event) {

--- a/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
@@ -1,0 +1,90 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [
+    "chip",
+    "chipsContainer",
+    "option",
+    "hiddenInput",
+    "placeholder",
+    "dropdown",
+  ];
+  static values = { disabled: Boolean };
+
+  connect() {
+    this._closeHandler = this._handleOutsideClick.bind(this);
+    document.addEventListener("click", this._closeHandler);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._closeHandler);
+  }
+
+  toggleDropdown() {
+    if (this.disabledValue) return;
+    this.dropdownTarget.classList.toggle("hidden");
+  }
+
+  selectOption(event) {
+    event.stopPropagation();
+    this._activate(event.currentTarget.dataset.value);
+    this.dropdownTarget.classList.add("hidden");
+  }
+
+  removeChip(event) {
+    event.stopPropagation();
+    this._deactivate(event.currentTarget.dataset.value);
+  }
+
+  _activate(value) {
+    this._chip(value)?.classList.remove("hidden");
+    this._option(value)?.classList.add("hidden");
+    const input = this._hiddenInput(value);
+    if (input) input.disabled = false;
+    this._syncChipsContainer();
+    this._syncPlaceholder();
+  }
+
+  _deactivate(value) {
+    this._chip(value)?.classList.add("hidden");
+    this._option(value)?.classList.remove("hidden");
+    const input = this._hiddenInput(value);
+    if (input) input.disabled = true;
+    this._syncChipsContainer();
+    this._syncPlaceholder();
+  }
+
+  _chip(value) {
+    return this.chipTargets.find((el) => el.dataset.value == value);
+  }
+
+  _option(value) {
+    return this.optionTargets.find((el) => el.dataset.value == value);
+  }
+
+  _hiddenInput(value) {
+    return this.hiddenInputTargets.find((el) => el.dataset.value == value);
+  }
+
+  _syncChipsContainer() {
+    if (!this.hasChipsContainerTarget) return;
+    const hasSelected = this.chipTargets.some(
+      (el) => !el.classList.contains("hidden")
+    );
+    this.chipsContainerTarget.classList.toggle("hidden", !hasSelected);
+  }
+
+  _syncPlaceholder() {
+    if (!this.hasPlaceholderTarget) return;
+    const hasSelected = this.chipTargets.some(
+      (el) => !el.classList.contains("hidden")
+    );
+    this.placeholderTarget.classList.toggle("hidden", hasSelected);
+  }
+
+  _handleOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.dropdownTarget.classList.add("hidden");
+    }
+  }
+}

--- a/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/multi_select_controller.js
@@ -27,11 +27,13 @@ export default class extends Controller {
 
   selectOption(event) {
     event.stopPropagation();
+    if (this.disabledValue) return;
     this._activate(event.currentTarget.dataset.value);
   }
 
   removeChip(event) {
     event.stopPropagation();
+    if (this.disabledValue) return;
     this._deactivate(event.currentTarget.dataset.value);
   }
 

--- a/engines/neo_component/app/views/neo_components/ui/inputs/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/inputs/index.html.erb
@@ -11,6 +11,7 @@
   <li><%= link_component(text: 'Text area', url: ui_inputs_textarea_path) %></li>
   <li><%= link_component(text: 'Dropdown', url: ui_inputs_dropdown_path) %></li>
   <li><%= link_component(text: 'Date picker', url: ui_inputs_date_picker_path) %></li>
+  <li><%= link_component(text: 'Multi select', url: ui_inputs_multi_select_path) %></li>
 </ul>
 
 <hr>

--- a/engines/neo_component/app/views/neo_components/ui/inputs/multi_select.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/inputs/multi_select.html.erb
@@ -105,3 +105,17 @@
         ) %>
   <% end %>
 <% end %>
+
+<%= form_with url: "#", method: :post do |form| %>
+  <%= doc_section_component(title: "Multi select disabled") do %>
+    <%= multi_select_component(
+        form: form,
+        name: :category_ids,
+        label: "Categories",
+        disabled: true,
+        options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+        value: [2],
+        placeholder: "Select categories"
+        ) %>
+  <% end %>
+<% end %>

--- a/engines/neo_component/app/views/neo_components/ui/inputs/multi_select.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/inputs/multi_select.html.erb
@@ -1,0 +1,107 @@
+<div class="my-6">
+  <%= render "shared/components/back_button", back_link: ui_inputs_path %>
+</div>
+<%= h3_component(text: "Multi Select Component") %>
+
+<%= doc_section_component(title: "Multi select without label") do %>
+  <%= multi_select_component(
+      name: :categories,
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      placeholder: "Select categories",
+      support_text: "Pick one or more categories"
+      ) %>
+<% end %>
+
+<%= doc_section_component(title: "Multi select medium size") do %>
+  <%= multi_select_component(
+      name: :categories,
+      label: "Categories",
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      placeholder: "Select categories",
+      support_text: "Pick one or more categories"
+      ) %>
+<% end %>
+
+<%= doc_section_component(title: "Multi select large size") do %>
+  <%= multi_select_component(
+      name: :categories,
+      label: "Categories",
+      size: 'lg',
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      placeholder: "Select categories",
+      support_text: "Pick one or more categories"
+      ) %>
+<% end %>
+
+<%= doc_section_component(title: "Multi select with pre-selected values") do %>
+  <%= multi_select_component(
+      name: :categories,
+      label: "Categories",
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      value: [1, 3],
+      placeholder: "Select categories"
+      ) %>
+<% end %>
+
+<%= doc_section_component(title: "Multi select error") do %>
+  <%= multi_select_component(
+      name: :categories,
+      label: "Categories",
+      error: "Please select at least one category",
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      placeholder: "Select categories"
+      ) %>
+<% end %>
+
+<%= doc_section_component(title: "Multi select disabled") do %>
+  <%= multi_select_component(
+      name: :categories,
+      label: "Categories",
+      disabled: true,
+      options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+      value: [2],
+      placeholder: "Select categories"
+      ) %>
+<% end %>
+
+<%= h3_component(text: "Form with Multi Select") %>
+
+<%= form_with url: "#", method: :post do |form| %>
+  <%= doc_section_component(title: "Multi select medium size") do %>
+    <%= multi_select_component(
+        form: form,
+        name: :category_ids,
+        label: "Categories",
+        options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+        placeholder: "Select categories",
+        support_text: "Pick one or more categories"
+        ) %>
+  <% end %>
+<% end %>
+
+<%= form_with url: "#", method: :post do |form| %>
+  <%= doc_section_component(title: "Multi select large size") do %>
+    <%= multi_select_component(
+        form: form,
+        name: :category_ids,
+        label: "Categories",
+        size: 'lg',
+        options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+        placeholder: "Select categories",
+        support_text: "Pick one or more categories"
+        ) %>
+  <% end %>
+<% end %>
+
+<%= form_with url: "#", method: :post do |form| %>
+  <%= doc_section_component(title: "Multi select error") do %>
+    <%= multi_select_component(
+        form: form,
+        name: :category_ids,
+        label: "Categories",
+        error: "Please select at least one category",
+        options: [["Option 1", 1], ["Option 2", 2], ["Option 3", 3]],
+        placeholder: "Select categories"
+        ) %>
+  <% end %>
+<% end %>

--- a/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
+++ b/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
@@ -3,7 +3,7 @@
      <%= tag.attributes(multi_select.html_options) %>>
   <% if multi_select.label.present? %>
     <label class="group">
-      <span class="<%= multi_select.label_style %> inline-block mb-1"><%= multi_select.label %></span>
+      <span class="<%= multi_select.label_style %> inline-block mb-3"><%= multi_select.label %></span>
       <%= render 'view_components/inputs/multi_select_component/select_box', { multi_select: } %>
     </label>
   <% else %>

--- a/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
+++ b/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
@@ -1,6 +1,6 @@
-<div class="w-full flex flex-col gap-1"
-     data-controller="multi-select"
-     data-multi-select-disabled-value="<%= multi_select.disabled %>">
+<div data-controller="multi-select"
+     data-multi-select-disabled-value="<%= multi_select.disabled %>"
+     <%= tag.attributes(multi_select.html_options) %>>
   <% if multi_select.label.present? %>
     <label class="group">
       <span class="<%= multi_select.label_style %> inline-block mb-1"><%= multi_select.label %></span>

--- a/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
+++ b/engines/neo_component/app/views/view_components/inputs/multi_select_component/_multi_select.html.erb
@@ -1,0 +1,18 @@
+<div class="w-full flex flex-col gap-1"
+     data-controller="multi-select"
+     data-multi-select-disabled-value="<%= multi_select.disabled %>">
+  <% if multi_select.label.present? %>
+    <label class="group">
+      <span class="<%= multi_select.label_style %> inline-block mb-1"><%= multi_select.label %></span>
+      <%= render 'view_components/inputs/multi_select_component/select_box', { multi_select: } %>
+    </label>
+  <% else %>
+    <%= render 'view_components/inputs/multi_select_component/select_box', { multi_select: } %>
+  <% end %>
+
+  <% if multi_select.support_text.present? %>
+    <span class="<%= multi_select.support_text_style %>">
+      <%= multi_select.support_text %>
+    </span>
+  <% end %>
+</div>

--- a/engines/neo_component/app/views/view_components/inputs/multi_select_component/_select_box.html.erb
+++ b/engines/neo_component/app/views/view_components/inputs/multi_select_component/_select_box.html.erb
@@ -1,18 +1,19 @@
 <%# Chips row — rendered above the trigger, hidden when no values selected %>
-<div class="flex flex-wrap gap-2 <%= 'hidden' if multi_select.value.empty? %>"
-     data-multi-select-target="chipsContainer">
-  <% multi_select.options.each do |opt_label, opt_value| %>
-    <div class="<%= 'hidden' unless multi_select.selected?(opt_value) %>"
-         data-multi-select-target="chip"
-         data-value="<%= opt_value %>"
-         data-action="click->multi-select#removeChip">
-      <%= chip_component(text: opt_label.to_s, close: true, colorscheme: 'input') %>
-    </div>
-  <% end %>
-</div>
+<div class="flex flex-col gap-3">
+  <div class="flex flex-wrap gap-2 <%= 'hidden' if multi_select.value.empty? %>"
+       data-multi-select-target="chipsContainer">
+    <% multi_select.options.each do |opt_label, opt_value| %>
+      <div class="<%= 'hidden' unless multi_select.selected?(opt_value) %>"
+           data-multi-select-target="chip"
+           data-value="<%= opt_value %>"
+           data-action="click->multi-select#removeChip">
+        <%= chip_component(text: opt_label.to_s, close: true, colorscheme: 'input') %>
+      </div>
+    <% end %>
+  </div>
 
-<%# Trigger button + dropdown positioned relative to it %>
-<div class="relative">
+  <%# Trigger button + dropdown positioned relative to it %>
+  <div class="relative">
   <div class="<%= multi_select.trigger_style %>"
        data-action="click->multi-select#toggleDropdown">
 
@@ -55,5 +56,6 @@
             data: { multi_select_target: 'hiddenInput', value: opt_value }
           ) %>
     <% end %>
+  </div>
   </div>
 </div>

--- a/engines/neo_component/app/views/view_components/inputs/multi_select_component/_select_box.html.erb
+++ b/engines/neo_component/app/views/view_components/inputs/multi_select_component/_select_box.html.erb
@@ -1,0 +1,59 @@
+<%# Chips row — rendered above the trigger, hidden when no values selected %>
+<div class="flex flex-wrap gap-2 <%= 'hidden' if multi_select.value.empty? %>"
+     data-multi-select-target="chipsContainer">
+  <% multi_select.options.each do |opt_label, opt_value| %>
+    <div class="<%= 'hidden' unless multi_select.selected?(opt_value) %>"
+         data-multi-select-target="chip"
+         data-value="<%= opt_value %>"
+         data-action="click->multi-select#removeChip">
+      <%= chip_component(text: opt_label.to_s, close: true, colorscheme: 'input') %>
+    </div>
+  <% end %>
+</div>
+
+<%# Trigger button + dropdown positioned relative to it %>
+<div class="relative">
+  <div class="<%= multi_select.trigger_style %>"
+       data-action="click->multi-select#toggleDropdown">
+
+    <%# Placeholder — hidden once any value is selected %>
+    <% if multi_select.placeholder.present? %>
+      <span class="flex-1 text-disabled-color <%= 'hidden' if multi_select.value.any? %>"
+            data-multi-select-target="placeholder">
+        <%= multi_select.placeholder %>
+      </span>
+    <% end %>
+
+    <%# Chevron %>
+    <span class="ml-auto flex-shrink-0 flex items-center text-letter-color-light">
+      <%= icon('chevron-down', css: 'w-4 h-4') %>
+    </span>
+  </div>
+
+  <%# Options dropdown panel — hidden by default %>
+  <div class="hidden absolute top-full left-0 right-0 mt-1 bg-white border border-slate-grey-50 rounded shadow-lg z-50 max-h-48 overflow-y-auto"
+       data-multi-select-target="dropdown">
+    <% multi_select.options.each do |opt_label, opt_value| %>
+      <div class="<%= 'hidden' if multi_select.selected?(opt_value) %> px-3 py-2 cursor-pointer hover:bg-primary-light-50 text-letter-color-light main-text-md-normal"
+           data-multi-select-target="option"
+           data-value="<%= opt_value %>"
+           data-label="<%= opt_label %>"
+           data-action="click->multi-select#selectOption">
+        <%= opt_label %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Hidden inputs — enabled for selected values, disabled for unselected %>
+  <div>
+    <% multi_select.options.each do |_opt_label, opt_value| %>
+      <%= tag.input(
+            type: 'hidden',
+            name: multi_select.input_name,
+            value: opt_value,
+            disabled: !multi_select.selected?(opt_value),
+            data: { multi_select_target: 'hiddenInput', value: opt_value }
+          ) %>
+    <% end %>
+  </div>
+</div>

--- a/engines/neo_component/config/routes.rb
+++ b/engines/neo_component/config/routes.rb
@@ -15,6 +15,7 @@ NeoComponents::Engine.routes.draw do
     get 'inputs/textarea', to: 'inputs#textarea'
     get 'inputs/dropdown', to: 'inputs#dropdown'
     get 'inputs/date_picker', to: 'inputs#date_picker'
+    get 'inputs/multi_select', to: 'inputs#multi_select'
     get :tables, to: 'tables#index'
     get :notification_bars, to: 'notification_bars#index'
     get :menu_component, to: 'menu_component#index'

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -177,6 +177,26 @@ date_picker_component(
 )
 ```
 
+### `multi_select_component`
+```ruby
+multi_select_component(
+  form: nil,
+  name: nil,
+  label: nil,
+  options: [],            # Array of [label, value] pairs
+  value: [],              # Array of selected values
+  placeholder: nil,
+  size: 'md',             # md | lg
+  support_text: nil,
+  error: nil,
+  disabled: false,
+  html_options: {}
+)
+```
+# Selected values render as removable chips (chip_component, colorscheme: 'input').
+# Dropdown lists only unselected options. Managed by the multi-select Stimulus controller.
+# Form submission sends selected values as an array param via hidden inputs.
+
 ### `file_selector_component`
 ```ruby
 file_selector_component(

--- a/spec/helpers/ui_helper_multi_select_spec.rb
+++ b/spec/helpers/ui_helper_multi_select_spec.rb
@@ -107,6 +107,28 @@ RSpec.describe UiHelper, type: :helper do
       end
     end
 
+    describe 'html_options' do
+      it 'applies the base wrapper class by default' do
+        doc = render_component
+        wrapper = doc.at_css('[data-controller="multi-select"]')
+        expect(wrapper['class']).to eq('w-full flex flex-col gap-1')
+      end
+
+      it 'merges a caller-supplied class with the base wrapper class' do
+        doc = render_component(html_options: { class: 'extra-class' })
+        wrapper = doc.at_css('[data-controller="multi-select"]')
+        expect(wrapper['class']).to include('w-full flex flex-col gap-1')
+        expect(wrapper['class']).to include('extra-class')
+      end
+
+      it 'applies extra attributes to the wrapper div' do
+        doc = render_component(html_options: { id: 'my-select', data: { foo: 'bar' } })
+        wrapper = doc.at_css('[data-controller="multi-select"]')
+        expect(wrapper['id']).to eq('my-select')
+        expect(wrapper['data-foo']).to eq('bar')
+      end
+    end
+
     context 'when disabled' do
       it 'sets the disabled value on the stimulus controller' do
         doc = render_component(disabled: true)

--- a/spec/helpers/ui_helper_multi_select_spec.rb
+++ b/spec/helpers/ui_helper_multi_select_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UiHelper, type: :helper do
+  let(:options) { [%w[Ruby ruby], %w[Python python], %w[Go go]] }
+
+  def render_component(**kwargs)
+    html = helper.multi_select_component(name: :languages, options:, **kwargs)
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  describe '#multi_select_component' do
+    it 'renders the stimulus controller wrapper' do
+      doc = render_component
+      expect(doc.at_css('[data-controller="multi-select"]')).to be_present
+    end
+
+    describe 'label' do
+      it 'renders a label element when label is provided' do
+        doc = render_component(label: 'Languages')
+        expect(doc.at_css('label span').text.strip).to eq('Languages')
+      end
+
+      it 'omits the label element when label is not provided' do
+        doc = render_component
+        expect(doc.at_css('label')).to be_nil
+      end
+    end
+
+    describe 'support text' do
+      it 'renders support text when provided' do
+        doc = render_component(support_text: 'Pick at least one')
+        expect(doc.text).to include('Pick at least one')
+      end
+
+      it 'renders the error message as support text when error is provided' do
+        doc = render_component(error: 'Required')
+        expect(doc.text).to include('Required')
+      end
+    end
+
+    describe 'placeholder' do
+      it 'is visible when no values are selected' do
+        doc = render_component(placeholder: 'Select languages')
+        placeholder = doc.at_css('[data-multi-select-target="placeholder"]')
+        expect(placeholder).to be_present
+        expect(placeholder.text.strip).to eq('Select languages')
+        expect(placeholder['class']).not_to include('hidden')
+      end
+
+      it 'is hidden when values are pre-selected' do
+        doc = render_component(placeholder: 'Select languages', value: ['ruby'])
+        placeholder = doc.at_css('[data-multi-select-target="placeholder"]')
+        expect(placeholder['class']).to include('hidden')
+      end
+
+      it 'is absent when no placeholder is provided' do
+        doc = render_component
+        expect(doc.at_css('[data-multi-select-target="placeholder"]')).to be_nil
+      end
+    end
+
+    describe 'chips and options' do
+      it 'renders one chip wrapper per option' do
+        doc = render_component
+        expect(doc.css('[data-multi-select-target="chip"]').count).to eq(options.count)
+      end
+
+      it 'renders one option row per option' do
+        doc = render_component
+        expect(doc.css('[data-multi-select-target="option"]').count).to eq(options.count)
+      end
+    end
+
+    context 'with pre-selected values' do
+      let(:doc) { render_component(value: ['ruby']) }
+
+      it 'shows the chip for the selected value' do
+        chip = doc.css('[data-multi-select-target="chip"]').find { |el| el['data-value'] == 'ruby' }
+        expect(chip['class']).not_to include('hidden')
+      end
+
+      it 'hides chips for unselected values' do
+        chip = doc.css('[data-multi-select-target="chip"]').find { |el| el['data-value'] == 'python' }
+        expect(chip['class']).to include('hidden')
+      end
+
+      it 'hides the selected value from the options dropdown' do
+        option = doc.css('[data-multi-select-target="option"]').find { |el| el['data-value'] == 'ruby' }
+        expect(option['class']).to include('hidden')
+      end
+
+      it 'shows unselected values in the options dropdown' do
+        option = doc.css('[data-multi-select-target="option"]').find { |el| el['data-value'] == 'python' }
+        expect(option['class']).not_to include('hidden')
+      end
+
+      it 'enables the hidden input for the selected value' do
+        input = doc.css('[data-multi-select-target="hiddenInput"]').find { |el| el['data-value'] == 'ruby' }
+        expect(input['disabled']).to be_nil
+      end
+
+      it 'disables hidden inputs for unselected values' do
+        input = doc.css('[data-multi-select-target="hiddenInput"]').find { |el| el['data-value'] == 'python' }
+        expect(input['disabled']).to be_present
+      end
+    end
+
+    context 'when disabled' do
+      it 'sets the disabled value on the stimulus controller' do
+        doc = render_component(disabled: true)
+        wrapper = doc.at_css('[data-controller="multi-select"]')
+        expect(wrapper['data-multi-select-disabled-value']).to eq('true')
+      end
+    end
+
+    context 'with a form object' do
+      it 'uses the Rails array param convention for hidden input names' do
+        form = instance_double(ActionView::Helpers::FormBuilder, object_name: 'course', object: nil)
+        html = helper.multi_select_component(form:, name: :language_ids, options:)
+        doc = Nokogiri::HTML::DocumentFragment.parse(html)
+        input = doc.css('[data-multi-select-target="hiddenInput"]').first
+        expect(input['name']).to eq('course[language_ids][]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1327

## Summary

- `MultiSelectComponent` class with style methods for trigger, label, and support text states (normal / error / disabled / sizes)
- Partials: outer wrapper with label + support text, select box with chips row above trigger, options dropdown panel, and hidden inputs for form submission
- Chips rendered above the trigger button (matching Figma), hidden when no values are selected
- Stimulus controller manages chip/option show-hide, enables/disables hidden inputs on select/deselect, closes dropdown on outside click, and shows/hides the chips row container
- UI examples page covering no-label, md/lg sizes, pre-selected values, error, disabled, and form variants
- Helper method in `input_component.rb`; route, controller action, and inputs index link wired up
- `ui_manifest.md` updated
- 18 rendering specs