### PR TITLE
[NeoComponent] Add wizard_steps_component

### DIFF
--- a/engines/neo_component/app/controllers/neo_components/ui/wizard_steps_controller.rb
+++ b/engines/neo_component/app/controllers/neo_components/ui/wizard_steps_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module NeoComponents
+  module Ui
+    class WizardStepsController < BaseController
+      def index; end
+    end
+  end
+end

--- a/engines/neo_component/app/helpers/ui_helper.rb
+++ b/engines/neo_component/app/helpers/ui_helper.rb
@@ -33,4 +33,5 @@ module UiHelper
   include ViewComponent::ProgressComponent
   include ViewComponent::ProfileIconComponent
   include ViewComponent::AccordionComponent
+  include ViewComponent::WizardStepsComponent
 end

--- a/engines/neo_component/app/helpers/view_component/wizard_steps_component.rb
+++ b/engines/neo_component/app/helpers/view_component/wizard_steps_component.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module WizardStepsComponent
+    class WizardStepsComponent
+      include ViewComponent::ComponentHelper
+
+      Step = Struct.new(:icon_name, :label, :state, keyword_init: true) do
+        def active?    = state == :active
+        def completed? = state == :completed
+        def upcoming?  = state == :upcoming
+      end
+
+      attr_accessor :steps
+
+      def initialize(steps:, current_step:)
+        raise ArgumentError, 'steps must be a non-empty Array' unless steps.is_a?(Array) && steps.any?
+        raise ArgumentError, 'current_step must be an Integer' unless current_step.is_a?(Integer)
+
+        self.steps = steps.each_with_index.map do |step, index|
+          state = if index == current_step
+                    :active
+                  elsif index < current_step
+                    :completed
+                  else
+                    :upcoming
+                  end
+          Step.new(icon_name: step[:icon_name], label: step[:label].to_s, state:)
+        end
+      end
+
+      def step_circle_class(step)
+        if step.active?
+          'bg-primary-light-100 border-2 border-primary text-primary'
+        elsif step.completed?
+          'bg-primary-light-100 border border-slate-grey-light text-slate-grey-50'
+        else
+          'bg-white border border-slate-grey-light text-slate-grey-50'
+        end
+      end
+
+      def step_label_class(step)
+        if step.active? || step.completed?
+          'general-text-sm-medium text-letter-color'
+        else
+          'general-text-sm-normal text-letter-color-light'
+        end
+      end
+    end
+
+    def wizard_steps_component(steps:, current_step:)
+      component = WizardStepsComponent.new(steps:, current_step:)
+      render partial: 'view_components/wizard_steps_component/wizard_steps', locals: { component: }
+    end
+  end
+end

--- a/engines/neo_component/app/javascript/neo_components/controllers/wizard_steps_controller.js
+++ b/engines/neo_component/app/javascript/neo_components/controllers/wizard_steps_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ACTIVE_CLASSES    = ["bg-primary-light-100", "border-2", "border-primary", "text-primary"]
+const COMPLETED_CLASSES = ["bg-primary-light-100", "border", "border-slate-grey-light", "text-slate-grey-50"]
+const UPCOMING_CLASSES  = ["bg-white", "border", "border-slate-grey-light", "text-slate-grey-50"]
+const ALL_STATE_CLASSES = [...new Set([...ACTIVE_CLASSES, ...COMPLETED_CLASSES, ...UPCOMING_CLASSES])]
+
+export default class extends Controller {
+  static targets = ["indicator", "panel"]
+  static values = { currentStep: Number }
+
+  connect() {
+    this.activeStep = this.currentStepValue
+    this.updateView()
+  }
+
+  goToStep({ params: { step } }) {
+    if (step > this.currentStepValue) return
+    this.activeStep = step
+    this.updateView()
+  }
+
+  updateView() {
+    this.panelTargets.forEach((panel, index) => {
+      panel.classList.toggle("hidden", index !== this.activeStep)
+    })
+
+    this.indicatorTargets.forEach((indicator, index) => {
+      const accessible = index <= this.currentStepValue
+      indicator.classList.toggle("cursor-pointer", accessible)
+      indicator.classList.toggle("cursor-default", !accessible)
+
+      indicator.classList.remove(...ALL_STATE_CLASSES)
+
+      if (index === this.activeStep) {
+        indicator.classList.add(...ACTIVE_CLASSES)
+      } else if (index < this.activeStep) {
+        indicator.classList.add(...COMPLETED_CLASSES)
+      } else {
+        indicator.classList.add(...UPCOMING_CLASSES)
+      }
+    })
+  }
+}

--- a/engines/neo_component/app/views/neo_components/ui/components/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/components/index.html.erb
@@ -13,7 +13,8 @@
   <li><%= link_component(text: 'Profile icon', url: ui_profile_icon_path) %></li>
   <li><%= link_component(text: 'Accordion', url: ui_accordions_path) %></li>
   <li><%= link_component(text: 'Carousel', url: ui_carousels_path) %></li>
-  <li><%= link_component(text: 'Cards', url: ui_cards_path) %></li> 
+  <li><%= link_component(text: 'Cards', url: ui_cards_path) %></li>
+  <li><%= link_component(text: 'Wizard Steps', url: ui_wizard_steps_path) %></li>
   <li><%= link_to "Tables", ui_tables_path, class: 'nav-link' %></li>
   <li><%= link_to "Notification bar", ui_notification_bars_path, class: 'nav-link' %></li>
 </ul>

--- a/engines/neo_component/app/views/neo_components/ui/wizard_steps/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/wizard_steps/index.html.erb
@@ -1,0 +1,76 @@
+<%= h3_component(text: 'Wizard Steps Component') %>
+
+<%= doc_section_component(title: 'Interactive — Step 1 active') do %>
+  <div data-controller="wizard-steps" data-wizard-steps-current-step-value="0">
+    <%= wizard_steps_component(
+        steps: [
+          { icon_name: 'document-text', label: 'Upload doc' },
+          { icon_name: 'camera',        label: 'Configure Video' },
+          { icon_name: 'numbered-list', label: 'Course Structure' }
+        ],
+        current_step: 0
+      ) %>
+
+    <div class="mt-6 p-4 border border-slate-grey-light rounded-lg">
+      <div data-wizard-steps-target="panel">
+        <p class="general-text-lg-normal text-letter-color">Step 1: Upload your document here.</p>
+      </div>
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 2: Configure your video settings.</p>
+      </div>
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 3: Define the course structure.</p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= doc_section_component(title: 'Interactive — Step 2 active (step 1 completed)') do %>
+  <div data-controller="wizard-steps" data-wizard-steps-current-step-value="1">
+    <%= wizard_steps_component(
+        steps: [
+          { icon_name: 'document-text', label: 'Upload doc' },
+          { icon_name: 'camera',        label: 'Configure Video' },
+          { icon_name: 'numbered-list', label: 'Course Structure' }
+        ],
+        current_step: 1
+      ) %>
+
+    <div class="mt-6 p-4 border border-slate-grey-light rounded-lg">
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 1: Upload your document here.</p>
+      </div>
+      <div data-wizard-steps-target="panel">
+        <p class="general-text-lg-normal text-letter-color">Step 2: Configure your video settings.</p>
+      </div>
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 3: Define the course structure.</p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= doc_section_component(title: 'Interactive — Step 3 active (steps 1 & 2 completed)') do %>
+  <div data-controller="wizard-steps" data-wizard-steps-current-step-value="2">
+    <%= wizard_steps_component(
+        steps: [
+          { icon_name: 'document-text', label: 'Upload doc' },
+          { icon_name: 'camera',        label: 'Configure Video' },
+          { icon_name: 'numbered-list', label: 'Course Structure' }
+        ],
+        current_step: 2
+      ) %>
+
+    <div class="mt-6 p-4 border border-slate-grey-light rounded-lg">
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 1: Upload your document here.</p>
+      </div>
+      <div data-wizard-steps-target="panel" class="hidden">
+        <p class="general-text-lg-normal text-letter-color">Step 2: Configure your video settings.</p>
+      </div>
+      <div data-wizard-steps-target="panel">
+        <p class="general-text-lg-normal text-letter-color">Step 3: Define the course structure.</p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/engines/neo_component/app/views/view_components/wizard_steps_component/_wizard_steps.html.erb
+++ b/engines/neo_component/app/views/view_components/wizard_steps_component/_wizard_steps.html.erb
@@ -1,0 +1,22 @@
+<div class="flex items-center justify-center gap-[100px]" role="list" aria-label="Progress steps">
+  <% component.steps.each_with_index do |step, index| %>
+    <div class="relative flex flex-col items-center gap-2" role="listitem">
+      <% unless index == 0 %>
+        <div class="absolute top-5 right-[calc(100%+0px)] w-[100px] h-px bg-slate-grey-light -translate-y-1/2" aria-hidden="true"></div>
+      <% end %>
+
+      <div class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 <%= component.step_circle_class(step) %>"
+           data-wizard-steps-target="indicator"
+           data-action="click->wizard-steps#goToStep"
+           data-wizard-steps-step-param="<%= index %>">
+        <% if step.icon_name.present? %>
+          <%= icon(step.icon_name, css: 'w-5 h-5') %>
+        <% end %>
+      </div>
+
+      <span class="whitespace-nowrap <%= component.step_label_class(step) %>">
+        <%= step.label %>
+      </span>
+    </div>
+  <% end %>
+</div>

--- a/engines/neo_component/app/views/view_components/wizard_steps_component/_wizard_steps.html.erb
+++ b/engines/neo_component/app/views/view_components/wizard_steps_component/_wizard_steps.html.erb
@@ -1,8 +1,8 @@
-<div class="flex items-center justify-center gap-[100px]" role="list" aria-label="Progress steps">
+<div class="flex items-center justify-center gap-24" role="list" aria-label="Progress steps">
   <% component.steps.each_with_index do |step, index| %>
     <div class="relative flex flex-col items-center gap-2" role="listitem">
       <% unless index == 0 %>
-        <div class="absolute top-5 right-[calc(100%+0px)] w-[100px] h-px bg-slate-grey-light -translate-y-1/2" aria-hidden="true"></div>
+        <div class="absolute top-5 right-full w-24 h-px bg-slate-grey-light -translate-y-1/2" aria-hidden="true"></div>
       <% end %>
 
       <div class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 <%= component.step_circle_class(step) %>"

--- a/engines/neo_component/config/routes.rb
+++ b/engines/neo_component/config/routes.rb
@@ -30,5 +30,6 @@ NeoComponents::Engine.routes.draw do
     get :accordions, to: 'accordions#index'
     get :carousels, to: 'carousels#index'
     get :cards, to: 'cards#index'
+    get :wizard_steps, to: 'wizard_steps#index'
   end
 end

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -397,6 +397,31 @@ course_carousal_component(courses:, title:, count:, load_path:)
 
 ---
 
+## Wizard Steps
+
+### `wizard_steps_component`
+```ruby
+wizard_steps_component(
+  steps:,        # Array of { icon_name: String, label: String }
+  current_step:  # Integer, 0-indexed
+)
+```
+Renders a multi-step progress header. Steps before `current_step` are styled as completed, the step at `current_step` is active, and remaining steps are upcoming. Circles are connected by horizontal lines.
+
+**Example — 3-step wizard, second step active:**
+```ruby
+wizard_steps_component(
+  steps: [
+    { icon_name: 'document-text', label: 'Upload doc' },
+    { icon_name: 'camera',        label: 'Configure Video' },
+    { icon_name: 'numbered-list', label: 'Course Structure' }
+  ],
+  current_step: 1   # 0-indexed — step 1 is active, step 0 is completed
+)
+```
+
+---
+
 ## Accordion
 
 ### `accordion_component`

--- a/spec/helpers/ui_helper_wizard_steps_spec.rb
+++ b/spec/helpers/ui_helper_wizard_steps_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UiHelper, type: :helper do
+  let(:steps) do
+    [
+      { icon_name: 'document-text', label: 'Upload doc' },
+      { icon_name: 'camera',        label: 'Configure Video' },
+      { icon_name: 'numbered-list', label: 'Course Structure' }
+    ]
+  end
+
+  def render_component(**kwargs)
+    html = helper.wizard_steps_component(steps:, **kwargs)
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  describe '#wizard_steps_component' do
+    it 'renders a step item for each step' do
+      doc = render_component(current_step: 0)
+      expect(doc.css('[role="listitem"]').count).to eq(steps.count)
+    end
+
+    it 'renders all step labels' do
+      doc = render_component(current_step: 0)
+      labels = doc.css('[role="listitem"] span.whitespace-nowrap').map(&:text).map(&:strip)
+      expect(labels).to eq(['Upload doc', 'Configure Video', 'Course Structure'])
+    end
+
+    context 'when current_step is 0' do
+      let(:doc) { render_component(current_step: 0) }
+
+      it 'applies active background and border to the first step circle' do
+        first_circle = doc.css('[role="listitem"]').first.at_css('.rounded-full')
+        expect(first_circle['class']).to include('bg-primary-light-100', 'border-2', 'border-primary', 'text-primary')
+      end
+
+      it 'applies upcoming styling to subsequent step circles' do
+        second_circle = doc.css('[role="listitem"]')[1].at_css('.rounded-full')
+        expect(second_circle['class']).to include('bg-white', 'text-slate-grey-50')
+        expect(second_circle['class']).not_to include('border-2')
+      end
+    end
+
+    context 'when current_step is 1' do
+      let(:doc) { render_component(current_step: 1) }
+
+      it 'applies completed styling to the first step (blue bg, grey border, grey icon)' do
+        first_circle = doc.css('[role="listitem"]').first.at_css('.rounded-full')
+        expect(first_circle['class']).to include('bg-primary-light-100', 'border-slate-grey-light', 'text-slate-grey-50')
+        expect(first_circle['class']).not_to include('border-2', 'border-primary')
+      end
+
+      it 'applies active styling to the second step (blue bg, blue border, blue icon)' do
+        second_circle = doc.css('[role="listitem"]')[1].at_css('.rounded-full')
+        expect(second_circle['class']).to include('bg-primary-light-100', 'border-2', 'border-primary', 'text-primary')
+      end
+
+      it 'applies upcoming styling to the third step' do
+        third_circle = doc.css('[role="listitem"]')[2].at_css('.rounded-full')
+        expect(third_circle['class']).to include('bg-white', 'text-slate-grey-50')
+        expect(third_circle['class']).not_to include('border-2')
+      end
+    end
+
+    it 'renders connector lines between steps' do
+      doc = render_component(current_step: 0)
+      connector_count = doc.css('[aria-hidden="true"]').count
+      expect(connector_count).to eq(steps.count - 1)
+    end
+
+    it 'raises ArgumentError for empty steps' do
+      expect { helper.wizard_steps_component(steps: [], current_step: 0) }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError when current_step is not an Integer' do
+      expect { helper.wizard_steps_component(steps:, current_step: '0') }
+        .to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/helpers/ui_helper_wizard_steps_spec.rb
+++ b/spec/helpers/ui_helper_wizard_steps_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe UiHelper, type: :helper do
 
       it 'applies completed styling to the first step (blue bg, grey border, grey icon)' do
         first_circle = doc.css('[role="listitem"]').first.at_css('.rounded-full')
-        expect(first_circle['class']).to include('bg-primary-light-100', 'border-slate-grey-light', 'text-slate-grey-50')
+        expect(first_circle['class']).to include('bg-primary-light-100', 'border-slate-grey-light',
+                                                 'text-slate-grey-50')
         expect(first_circle['class']).not_to include('border-2', 'border-primary')
       end
 


### PR DESCRIPTION
Fixes #1328

## Summary

- Adds `wizard_steps_component` helper rendering a multi-step progress header with three visual states (active / completed / upcoming) matching Figma
- Adds `wizard_steps_controller.js` (Stimulus) — manages panel show/hide and enforces can't-skip-ahead via `data-wizard-steps-current-step-value`
- Demo page at `/ui/wizard_steps` with interactive examples showing all three step states
- `ui_manifest.md` updated with full interface and usage example
- 10 RSpec examples covering state styling, labels, connectors, and argument validation