### PR TITLE
[ContentStudio] Course creation wizard — Step 1: Upload Documents

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/courses/wizard_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/wizard_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ContentStudio
+  module Courses
+    class WizardController < ApplicationController
+      def new
+        @metadata = ApiClient.course_metadata
+      end
+
+      def create
+        redirect_to root_path
+      end
+    end
+  end
+end

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -44,8 +44,9 @@
           </p>
         </div>
         <div class="w-fit">
-          <%= button_component(text: 'Create New Course', colorscheme: 'primary', size: 'lg',
-                               html_options: { href: '#' }) %>
+          <%= link_to new_course_path do %>
+            <%= button_component(text: 'Create New Course', colorscheme: 'primary', size: 'lg') %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
@@ -22,8 +22,8 @@
         name: 'documents[]',
         type: 'document',
         multiple: true,
-        accept: '.pdf,.png,.jpeg,.doc',
-        support_text: 'File types : pdf, png, jpeg, doc',
+        accept: '.pdf,.png,.jpeg,.doc,.docx',
+        support_text: 'File types : pdf, png, jpeg, doc, docx',
         support_text_two: 'File size : 10 mb/file'
       ) %>
     </div>

--- a/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
@@ -1,0 +1,85 @@
+<div class="flex flex-col gap-6 py-3">
+
+  <%# Wizard steps header %>
+  <div class="flex justify-center py-3">
+    <%= wizard_steps_component(
+      steps: [
+        { icon_name: 'document-text', label: 'Upload doc' },
+        { icon_name: 'camera',        label: 'Configure Video' },
+        { icon_name: 'numbered-list', label: 'Course Structure' }
+      ],
+      current_step: 0
+    ) %>
+  </div>
+
+  <%= form_with url: courses_path, method: :post, class: 'flex flex-col gap-6' do |form| %>
+
+    <%# Card 1: Document upload %>
+    <div class="bg-white border border-line-colour-light rounded-xl p-8 flex flex-col gap-3">
+      <p class="main-text-sm-medium text-letter-color">Choose Course Documents</p>
+      <%= file_selector_component(
+        form: form,
+        name: 'documents[]',
+        type: 'document',
+        multiple: true,
+        accept: '.pdf,.png,.jpeg,.doc',
+        support_text: 'File types : pdf, png, jpeg, doc',
+        support_text_two: 'File size : 10 mb/file'
+      ) %>
+    </div>
+
+    <%# Card 2: Course metadata %>
+    <div class="bg-white border border-line-colour-light rounded-xl p-8 flex flex-col gap-7">
+
+      <%= dropdown_component(
+        form: form,
+        name: :course_level,
+        label: 'Course Level',
+        options: [['Beginner', 'beginner'], ['Intermediate', 'intermediate'], ['Advanced', 'advanced']],
+        prompt: 'Choose Course difficulty level'
+      ) %>
+
+      <div class="flex gap-7 items-start">
+        <div class="flex-1 min-w-0">
+          <%= multi_select_component(
+            form: form,
+            name: :course_categories,
+            label: 'Course Category',
+            options: @metadata.categories.map { |c| [c, c] },
+            placeholder: 'Choose Categories'
+          ) %>
+        </div>
+        <div class="flex-1 min-w-0">
+          <%= multi_select_component(
+            form: form,
+            name: :languages,
+            label: 'Languages',
+            options: @metadata.languages.map { |l| [l, l] },
+            placeholder: 'Choose Languages'
+          ) %>
+        </div>
+      </div>
+
+      <%= textarea_component(
+        form: form,
+        name: :special_instructions,
+        label: 'Special Instructions if any',
+        placeholder: ''
+      ) %>
+
+    </div>
+
+    <%# Footer %>
+    <div class="flex gap-3">
+      <%= link_to root_path do %>
+        <%= button_component(text: 'Cancel', type: 'outline', colorscheme: 'primary') %>
+      <% end %>
+      <%= form.button class: 'flex-1' do %>
+        <%= button_component(text: 'Next : Configure Video Style', type: 'solid', colorscheme: 'primary',
+                             html_options: { class: 'w-full' }) %>
+      <% end %>
+    </div>
+
+  <% end %>
+
+</div>

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -2,4 +2,6 @@
 
 ContentStudio::Engine.routes.draw do
   root to: 'courses#index'
+  get 'courses/new', to: 'courses/wizard#new', as: :new_course
+  post 'courses', to: 'courses/wizard#create', as: :courses
 end

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -29,6 +29,10 @@ module ContentStudio
         client.current_user
       end
 
+      def course_metadata # rubocop:disable Rails/Delegate
+        client.course_metadata
+      end
+
       private
 
       def client

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -34,6 +34,15 @@ module ContentStudio
       build_user(JSON.parse(response.body))
     end
 
+    def course_metadata
+      response = connection.get("#{BASE_PATH}/courses/metadata")
+      data = JSON.parse(response.body)
+      CourseMetadata.new(
+        categories: data['categories'],
+        languages: data['languages']
+      )
+    end
+
     private
 
     def connection

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -56,6 +56,8 @@ module ContentStudio
 
   CourseStats = Struct.new(:created, :published, :in_progress, keyword_init: true)
 
+  CourseMetadata = Struct.new(:categories, :languages, keyword_init: true)
+
   User = Struct.new(
     :id,
     :name,

--- a/engines/content_studio/spec/dummy/app/controllers/api/internal/courses_controller.rb
+++ b/engines/content_studio/spec/dummy/app/controllers/api/internal/courses_controller.rb
@@ -23,6 +23,10 @@ module Api
           render json: []
         end
       end
+
+      def metadata
+        render json: File.read(File.join(FIXTURES_PATH, 'course_metadata.json'))
+      end
     end
   end
 end

--- a/engines/content_studio/spec/dummy/config/routes.rb
+++ b/engines/content_studio/spec/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :internal do
       get 'courses/stats', to: 'courses#stats'
+      get 'courses/metadata', to: 'courses#metadata'
       get 'courses', to: 'courses#index'
       get 'users/me', to: 'users#me'
     end

--- a/engines/content_studio/spec/fixtures/api/course_metadata.json
+++ b/engines/content_studio/spec/fixtures/api/course_metadata.json
@@ -1,0 +1,4 @@
+{
+  "categories": ["Housekeeping", "F&B", "Front Office", "Finance", "HR"],
+  "languages": ["English", "Malayalam", "Hindi", "Tamil", "Telugu"]
+}

--- a/engines/content_studio/spec/requests/content_studio/courses/wizard_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/wizard_spec.rb
@@ -3,55 +3,16 @@
 require_relative '../../../rails_helper'
 
 RSpec.describe 'ContentStudio::Courses::Wizard', type: :request do
-  let(:metadata) do
-    ContentStudio::CourseMetadata.new(
-      categories: ['Housekeeping', 'F&B'],
-      languages: %w[English Malayalam]
+  before do
+    allow(ContentStudio::ApiClient).to receive(:course_metadata).and_return(
+      ContentStudio::CourseMetadata.new(categories: [], languages: [])
     )
   end
 
-  before do
-    allow(ContentStudio::ApiClient).to receive(:course_metadata).and_return(metadata)
-  end
-
   describe 'GET /content_studio/courses/new' do
-    before { get '/content_studio/courses/new' }
-
     it 'returns HTTP 200' do
+      get '/content_studio/courses/new'
       expect(response).to have_http_status(:ok)
-    end
-
-    it 'renders the wizard steps' do
-      expect(response.body).to include('Upload doc')
-      expect(response.body).to include('Configure Video')
-      expect(response.body).to include('Course Structure')
-    end
-
-    it 'renders the file upload card' do
-      expect(response.body).to include('Choose Course Documents')
-      expect(response.body).to include('File types : pdf, png, jpeg, doc')
-    end
-
-    it 'renders the metadata form fields' do
-      expect(response.body).to include('Course Level')
-      expect(response.body).to include('Course Category')
-      expect(response.body).to include('Languages')
-      expect(response.body).to include('Special Instructions if any')
-    end
-
-    it 'renders category options from metadata' do
-      expect(response.body).to include('Housekeeping')
-      expect(response.body).to include('F&amp;B')
-    end
-
-    it 'renders language options from metadata' do
-      expect(response.body).to include('English')
-      expect(response.body).to include('Malayalam')
-    end
-
-    it 'renders the footer buttons' do
-      expect(response.body).to include('Cancel')
-      expect(response.body).to include('Next : Configure Video Style')
     end
   end
 

--- a/engines/content_studio/spec/requests/content_studio/courses/wizard_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/wizard_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../../../rails_helper'
+
+RSpec.describe 'ContentStudio::Courses::Wizard', type: :request do
+  let(:metadata) do
+    ContentStudio::CourseMetadata.new(
+      categories: ['Housekeeping', 'F&B'],
+      languages: %w[English Malayalam]
+    )
+  end
+
+  before do
+    allow(ContentStudio::ApiClient).to receive(:course_metadata).and_return(metadata)
+  end
+
+  describe 'GET /content_studio/courses/new' do
+    before { get '/content_studio/courses/new' }
+
+    it 'returns HTTP 200' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders the wizard steps' do
+      expect(response.body).to include('Upload doc')
+      expect(response.body).to include('Configure Video')
+      expect(response.body).to include('Course Structure')
+    end
+
+    it 'renders the file upload card' do
+      expect(response.body).to include('Choose Course Documents')
+      expect(response.body).to include('File types : pdf, png, jpeg, doc')
+    end
+
+    it 'renders the metadata form fields' do
+      expect(response.body).to include('Course Level')
+      expect(response.body).to include('Course Category')
+      expect(response.body).to include('Languages')
+      expect(response.body).to include('Special Instructions if any')
+    end
+
+    it 'renders category options from metadata' do
+      expect(response.body).to include('Housekeeping')
+      expect(response.body).to include('F&amp;B')
+    end
+
+    it 'renders language options from metadata' do
+      expect(response.body).to include('English')
+      expect(response.body).to include('Malayalam')
+    end
+
+    it 'renders the footer buttons' do
+      expect(response.body).to include('Cancel')
+      expect(response.body).to include('Next : Configure Video Style')
+    end
+  end
+
+  describe 'POST /content_studio/courses' do
+    it 'redirects after submission' do
+      post '/content_studio/courses'
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'content_studio/courses/index', type: :view do
   end
 
   before do
+    view.singleton_class.include ContentStudio::Engine.routes.url_helpers
     assign(:stats, stats)
     assign(:to_be_verified, [sample_course])
     assign(:verified, [])

--- a/engines/content_studio/spec/views/content_studio/courses/wizard/new.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/wizard/new.html.erb_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative '../../../../rails_helper'
+
+RSpec.describe 'content_studio/courses/wizard/new', type: :view do
+  let(:metadata) do
+    ContentStudio::CourseMetadata.new(
+      categories: ['Housekeeping', 'F&B'],
+      languages: %w[English Malayalam]
+    )
+  end
+
+  before do
+    view.singleton_class.include ContentStudio::Engine.routes.url_helpers
+    assign(:metadata, metadata)
+  end
+
+  it 'renders all three wizard step labels' do
+    render
+    expect(rendered).to include('Upload doc')
+    expect(rendered).to include('Configure Video')
+    expect(rendered).to include('Course Structure')
+  end
+
+  it 'renders the file upload card heading' do
+    render
+    expect(rendered).to include('Choose Course Documents')
+  end
+
+  it 'renders the file selector support text' do
+    render
+    expect(rendered).to include('File types : pdf, png, jpeg, doc')
+    expect(rendered).to include('File size : 10 mb/file')
+  end
+
+  it 'renders the Course Level dropdown' do
+    render
+    expect(rendered).to include('Course Level')
+    expect(rendered).to include('Choose Course difficulty level')
+  end
+
+  it 'renders Course Category multi-select with metadata options' do
+    render
+    expect(rendered).to include('Course Category')
+    expect(rendered).to include('Housekeeping')
+  end
+
+  it 'renders Languages multi-select with metadata options' do
+    render
+    expect(rendered).to include('Languages')
+    expect(rendered).to include('English')
+    expect(rendered).to include('Malayalam')
+  end
+
+  it 'renders the Special Instructions textarea' do
+    render
+    expect(rendered).to include('Special Instructions if any')
+  end
+
+  it 'renders the Cancel and Next footer buttons' do
+    render
+    expect(rendered).to include('Cancel')
+    expect(rendered).to include('Next : Configure Video Style')
+  end
+end

--- a/engines/content_studio/spec/views/content_studio/courses/wizard/new.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/wizard/new.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'content_studio/courses/wizard/new', type: :view do
 
   it 'renders the file selector support text' do
     render
-    expect(rendered).to include('File types : pdf, png, jpeg, doc')
+    expect(rendered).to include('File types : pdf, png, jpeg, doc, docx')
     expect(rendered).to include('File size : 10 mb/file')
   end
 

--- a/engines/neo_component/app/helpers/view_component/input_component.rb
+++ b/engines/neo_component/app/helpers/view_component/input_component.rb
@@ -165,9 +165,10 @@ module ViewComponent
 
     def file_selector_component(type:, form: nil, name: nil, label: nil, support_text: nil,
                                 support_text_two: nil, error: nil,
-                                disabled: false, multiple: false, html_options: {})
+                                disabled: false, multiple: false, accept: nil, html_options: {})
       file_selector = FileSelectorComponent.new(
-        form:, name:, label:, support_text:, support_text_two:, error:, disabled:, multiple:, html_options:, type:
+        form:, name:, label:, support_text:, support_text_two:, error:,
+        disabled:, multiple:, accept:, html_options:, type:
       )
 
       render partial: 'view_components/inputs/file_selector', locals: { file_selector: }

--- a/engines/neo_component/app/helpers/view_component/input_component/file_selector_component.rb
+++ b/engines/neo_component/app/helpers/view_component/input_component/file_selector_component.rb
@@ -8,11 +8,11 @@ module ViewComponent
       FILE_SELECTOR_TYPES = %w[image document video].freeze
 
       attr_accessor :form, :name, :label, :support_text,
-                    :support_text_two, :error, :disabled, :html_options, :type, :multiple
+                    :support_text_two, :error, :disabled, :html_options, :type, :multiple, :accept
 
       def initialize(type:, form: nil, name: nil, label: nil,
                      support_text: nil, support_text_two: nil, error: nil,
-                     disabled: false, multiple: false, html_options: {})
+                     disabled: false, multiple: false, accept: nil, html_options: {})
         raise "Invalid or missing file type: #{type}" unless FILE_SELECTOR_TYPES.include?(type)
 
         error_message = resolve_error(form, name, error)
@@ -25,11 +25,14 @@ module ViewComponent
         self.error = error_message
         self.disabled = disabled
         self.multiple = multiple
+        self.accept = accept
         self.html_options = html_options
         self.type = type
       end
 
       def accepted_types
+        return accept if accept.present?
+
         case type
         when 'image'
           'image/*'

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -209,6 +209,7 @@ file_selector_component(
   error: nil,
   disabled: false,
   multiple: false,        # true enables multi-file selection with a removable file list below the drop zone
+  accept: nil,            # overrides the default accepted MIME/extension list for the given type
   html_options: {}
 )
 ```


### PR DESCRIPTION
Fixes #1330

Implements the first step of the course creation wizard: document upload with metadata.

## Changes

**Content Studio**
- `GET /content_studio/courses/new` → `courses/wizard#new` — renders Step 1
- `POST /content_studio/courses` → `courses/wizard#create` — redirects to root (placeholder)
- `WizardController` fetches `CourseMetadata` (categories + languages) via `ApiClient`
- Step 1 view: wizard steps header (step 1 active), file upload card (multi-doc selector), metadata card (course level dropdown, category + language multi-selects, special instructions textarea), Cancel / Next footer
- `CourseMetadata` struct added to `types.rb`
- `course_metadata` method added to `BlackboardClient` and `ApiClient`
- Stub controller + route for `GET api/internal/courses/metadata` serving fixture JSON in dev/test

**NeoComponent**
- `file_selector_component`: new `accept: nil` param — overrides the type-based default accepted file extensions when set