### PR TITLE
[ContentStudio] Lesson Page — base layout

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ContentStudio
+  module Courses
+    class LessonsController < ApplicationController
+      def show
+        @lesson = ApiClient.get_lesson(params[:course_id], params[:id])
+        @course_id = params[:course_id]
+      end
+    end
+  end
+end

--- a/engines/content_studio/app/javascript/content_studio/controllers/lesson_name_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/lesson_name_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["display", "input"]
+  static values = { href: String }
+
+  connect() {
+    this._clickTimer = null
+  }
+
+  click() {
+    if (!this.inputTarget.classList.contains('hidden')) return
+
+    this._clickTimer = setTimeout(() => {
+      window.location.href = this.hrefValue
+    }, 250)
+  }
+
+  dblclick() {
+    clearTimeout(this._clickTimer)
+    this._clickTimer = null
+    this._startEditing()
+  }
+
+  blur() {
+    this._stopEditing()
+  }
+
+  keydown(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      this._stopEditing()
+    } else if (event.key === 'Escape') {
+      this.inputTarget.value = this.displayTarget.textContent.trim()
+      this._stopEditing()
+    }
+  }
+
+  _startEditing() {
+    this.inputTarget.value = this.displayTarget.textContent.trim()
+    this.displayTarget.classList.add('hidden')
+    this.inputTarget.classList.remove('hidden')
+    this.inputTarget.focus()
+    this.inputTarget.select()
+  }
+
+  _stopEditing() {
+    this.displayTarget.textContent = this.inputTarget.value
+    this.displayTarget.classList.remove('hidden')
+    this.inputTarget.classList.add('hidden')
+  }
+}

--- a/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
@@ -1,0 +1,121 @@
+<div class="flex flex-col gap-6 py-3">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <%= link_to course_structure_path(id: @course_id) do %>
+        <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
+          <%= icon 'arrow-left', css: 'w-4 h-4 text-letter-color' %>
+        </span>
+      <% end %>
+      <span class="main-text-lg-semibold text-letter-color">Lesson Page</span>
+    </div>
+    <div class="flex items-center gap-3">
+      <%= button_component(
+            text: 'Edit Video Style',
+            type: 'outline',
+            size: 'md',
+            colorscheme: 'primary',
+            icon_name: 'pencil'
+          ) %>
+      <%= button_component(
+            text: 'Delete Lesson',
+            type: 'outline',
+            size: 'md',
+            colorscheme: 'danger',
+            icon_name: 'trash'
+          ) %>
+    </div>
+  </div>
+
+  <div class="flex gap-6">
+    <div class="flex-1 flex flex-col gap-5 min-w-0">
+      <div class="flex flex-col gap-4">
+        <% local_content = @lesson.local_contents&.first %>
+        <div class="bg-letter-color rounded-lg overflow-hidden h-64 flex items-center justify-center">
+          <% if local_content&.video_url.present? %>
+            <video src="<%= local_content.video_url %>"
+                   controls
+                   class="w-full h-full"
+                   preload="metadata">
+            </video>
+          <% else %>
+            <%= icon 'play-circle', css: 'w-16 h-16 text-white opacity-40' %>
+          <% end %>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <div class="w-40">
+            <%= dropdown_component(
+                  name: 'language',
+                  options: @lesson.local_contents.map { |lc| [lc.lang, lc.lang] },
+                  value: local_content&.lang,
+                  size: 'md'
+                ) %>
+          </div>
+          <div class="flex items-center gap-2">
+            <%= button_component(
+                  text: 'Previous',
+                  type: 'outline',
+                  size: 'md',
+                  colorscheme: 'primary',
+                  icon_name: 'chevron-left',
+                  icon_position: 'left',
+                  disabled: true
+                ) %>
+            <%= button_component(
+                  text: 'Next',
+                  type: 'outline',
+                  size: 'md',
+                  colorscheme: 'primary',
+                  icon_name: 'chevron-right',
+                  icon_position: 'right'
+                ) %>
+            <%= button_component(
+                  text: 'Verify & Next',
+                  type: 'solid',
+                  size: 'md',
+                  colorscheme: 'secondary',
+                  icon_name: 'chevron-right',
+                  icon_position: 'right'
+                ) %>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <%= textarea_component(
+              name: 'script',
+              label: 'Script',
+              placeholder: 'Script will appear here...',
+              rows: 8
+            ) %>
+        <%= button_component(
+              text: 'Regenerate Lesson',
+              type: 'solid',
+              size: 'md',
+              colorscheme: 'primary'
+            ) %>
+      </div>
+    </div>
+
+    <div class="w-96 flex-shrink-0 flex flex-col gap-5">
+      <div class="bg-primary-light-50 rounded-lg p-5 flex flex-col gap-4">
+        <div class="flex items-center justify-between">
+          <span class="main-text-lg-semibold text-primary"><%= @lesson.title %></span>
+          <button type="button" class="p-3">
+            <%= icon 'pencil', css: 'w-4 h-4 text-letter-color' %>
+          </button>
+        </div>
+        <div class="flex flex-col gap-1">
+          <p class="main-text-sm-normal text-letter-color line-clamp-6" id="lesson-description">
+            <%= @lesson.description %>
+          </p>
+          <button type="button"
+                  class="main-text-sm-normal text-primary underline text-left"
+                  onclick="var d=document.getElementById('lesson-description');d.classList.toggle('line-clamp-6');this.textContent=d.classList.contains('line-clamp-6')?'Show more':'Show less';">
+            Show more
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -37,8 +37,18 @@
                 <span class="text-slate-grey-50 flex-shrink-0 cursor-grab">
                   <%= icon 'grip-vertical', css: 'w-5 h-5' %>
                 </span>
-                <div class="flex-1 bg-white-light border border-line-colour-light rounded px-3 py-2.5 h-10 flex items-center overflow-hidden">
-                  <span class="main-text-sm-normal text-letter-color truncate"><%= lesson.title %></span>
+                <div class="flex-1 bg-white-light border border-line-colour-light rounded px-3 py-2.5 h-10 flex items-center overflow-hidden cursor-pointer"
+                     data-controller="lesson-name"
+                     data-lesson-name-href-value="<%= course_lesson_path(course_id: @structure.id, id: lesson.id) %>"
+                     data-action="click->lesson-name#click dblclick->lesson-name#dblclick">
+                  <span class="main-text-sm-normal text-letter-color truncate flex-1"
+                        data-lesson-name-target="display">
+                    <%= lesson.title %>
+                  </span>
+                  <input type="text"
+                         class="main-text-sm-normal text-letter-color w-full bg-transparent border-0 p-0 focus:ring-0 focus:outline-none hidden"
+                         data-lesson-name-target="input"
+                         data-action="blur->lesson-name#blur keydown->lesson-name#keydown">
                 </div>
                 <%= chip_component(
                   text: lesson_status_label(lesson.status),

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -11,4 +11,5 @@ ContentStudio::Engine.routes.draw do
   get 'courses/:id/structure', to: 'courses/structure#show', as: :course_structure
   patch 'courses/:id/save', to: 'courses/structure#save', as: :save_course
   delete 'courses/:id', to: 'courses/structure#discard', as: :discard_course
+  get 'courses/:course_id/lessons/:id', to: 'courses/lessons#show', as: :course_lesson
 end

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -57,6 +57,10 @@ module ContentStudio
         client.discard_course(course_id)
       end
 
+      def get_lesson(course_id, lesson_id) # rubocop:disable Rails/Delegate
+        client.get_lesson(course_id, lesson_id)
+      end
+
       private
 
       def client

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -76,6 +76,11 @@ module ContentStudio
       connection.delete("#{BASE_PATH}/courses/#{course_id}")
     end
 
+    def get_lesson(course_id, lesson_id)
+      response = connection.get("#{BASE_PATH}/courses/#{course_id}/lessons/#{lesson_id}")
+      build_lesson(JSON.parse(response.body))
+    end
+
     private
 
     def connection

--- a/engines/content_studio/spec/dummy/app/controllers/api/internal/courses/lessons_controller.rb
+++ b/engines/content_studio/spec/dummy/app/controllers/api/internal/courses/lessons_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module Internal
+    module Courses
+      class LessonsController < ApplicationController
+        skip_before_action :verify_authenticity_token
+
+        FIXTURES_PATH = File.expand_path('../../../../../../fixtures/api', __dir__)
+
+        def show
+          render json: File.read(File.join(FIXTURES_PATH, 'lesson.json'))
+        end
+      end
+    end
+  end
+end

--- a/engines/content_studio/spec/dummy/config/routes.rb
+++ b/engines/content_studio/spec/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       get 'courses/:id/structure', to: 'courses#structure'
       patch 'courses/:id/save', to: 'courses#save'
       delete 'courses/:id', to: 'courses#discard'
+      get 'courses/:course_id/lessons/:id', to: 'courses/lessons#show'
       get 'users/me', to: 'users#me'
     end
   end

--- a/engines/content_studio/spec/fixtures/api/lesson.json
+++ b/engines/content_studio/spec/fixtures/api/lesson.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "title": "Introduction to Airport Services",
+  "description": "This lesson introduces the core concepts of airport services management including check-in procedures, baggage handling, and passenger assistance. You will learn the fundamentals of delivering excellent service in a fast-paced airport environment and understand the key touchpoints that create exceptional passenger experiences.",
+  "duration": 1800,
+  "lesson_type": "video",
+  "rating": 4.8,
+  "video_streaming_source": "youtube",
+  "local_contents": [
+    { "id": 1, "lang": "en", "status": "published", "video_url": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4", "video_published_at": null }
+  ]
+}

--- a/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative '../../../rails_helper'
+
+RSpec.describe 'ContentStudio::Courses::Lessons', type: :request do
+  let(:local_content) do
+    ContentStudio::LocalContent.new(
+      id: 1, lang: 'en', status: 'published', video_url: nil, video_published_at: nil
+    )
+  end
+
+  let(:lesson) do
+    ContentStudio::Lesson.new(
+      id: 1,
+      title: 'Introduction to Airport Services',
+      description: 'This lesson introduces the core concepts of airport services management.',
+      duration: 1800,
+      lesson_type: 'video',
+      rating: 4.8,
+      video_streaming_source: 'youtube',
+      local_contents: [local_content]
+    )
+  end
+
+  before do
+    allow(ContentStudio::ApiClient).to receive(:get_lesson).and_return(lesson)
+  end
+
+  describe 'GET /content_studio/courses/:course_id/lessons/:id' do
+    before { get '/content_studio/courses/1/lessons/1' }
+
+    it 'returns HTTP 200' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders the Lesson Page heading' do
+      expect(response.body).to include('Lesson Page')
+    end
+
+    it 'renders the lesson title in the info panel' do
+      expect(response.body).to include('Introduction to Airport Services')
+    end
+
+    it 'renders the Edit Video Style button' do
+      expect(response.body).to include('Edit Video Style')
+    end
+
+    it 'renders the Delete Lesson button' do
+      expect(response.body).to include('Delete Lesson')
+    end
+
+    it 'renders the navigation buttons' do
+      expect(response.body).to include('Previous')
+      expect(response.body).to include('Next')
+      expect(response.body).to include('Verify &amp; Next')
+    end
+
+    it 'renders the Regenerate Lesson button' do
+      expect(response.body).to include('Regenerate Lesson')
+    end
+
+    it 'renders the Show more toggle' do
+      expect(response.body).to include('Show more')
+    end
+  end
+end

--- a/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative '../../../../rails_helper'
+
+RSpec.describe 'content_studio/courses/lessons/show', type: :view do
+  let(:local_content) do
+    ContentStudio::LocalContent.new(
+      id: 1, lang: 'en', status: 'published', video_url: nil, video_published_at: nil
+    )
+  end
+
+  let(:lesson) do
+    ContentStudio::Lesson.new(
+      id: 1,
+      title: 'Introduction to Airport Services',
+      description: 'This lesson introduces the core concepts of airport services management ' \
+                   'including check-in procedures and passenger assistance.',
+      duration: 1800,
+      lesson_type: 'video',
+      rating: 4.8,
+      video_streaming_source: 'youtube',
+      local_contents: [local_content]
+    )
+  end
+
+  before do
+    view.singleton_class.include ContentStudio::Engine.routes.url_helpers
+    assign(:lesson, lesson)
+    assign(:course_id, '1')
+  end
+
+  it 'renders the Lesson Page heading' do
+    render
+    expect(rendered).to include('Lesson Page')
+  end
+
+  it 'renders the lesson title in the info panel' do
+    render
+    expect(rendered).to include('Introduction to Airport Services')
+  end
+
+  it 'renders the lesson description' do
+    render
+    expect(rendered).to include('check-in procedures and passenger assistance')
+  end
+
+  it 'renders the Show more toggle' do
+    render
+    expect(rendered).to include('Show more')
+  end
+
+  it 'renders the Edit Video Style button' do
+    render
+    expect(rendered).to include('Edit Video Style')
+  end
+
+  it 'renders the Delete Lesson button' do
+    render
+    expect(rendered).to include('Delete Lesson')
+  end
+
+  it 'renders the Previous navigation button' do
+    render
+    expect(rendered).to include('Previous')
+  end
+
+  it 'renders the Next navigation button' do
+    render
+    expect(rendered).to include('Next')
+  end
+
+  it 'renders the Verify &amp; Next navigation button' do
+    render
+    expect(rendered).to include('Verify &amp; Next')
+  end
+
+  it 'renders the language dropdown with the current language' do
+    render
+    expect(rendered).to include('en')
+  end
+
+  it 'renders the Script textarea' do
+    render
+    expect(rendered).to include('Script')
+  end
+
+  it 'renders the Regenerate Lesson button' do
+    render
+    expect(rendered).to include('Regenerate Lesson')
+  end
+
+  it 'renders the video placeholder when no video URL is present' do
+    render
+    expect(rendered).to include('opacity-40')
+    expect(rendered).not_to include('<video')
+  end
+
+  it 'renders a video element when a video URL is present' do
+    local_content_with_video = ContentStudio::LocalContent.new(
+      id: 1, lang: 'en', status: 'published',
+      video_url: 'https://example-bucket.s3.amazonaws.com/lesson-1.mp4',
+      video_published_at: nil
+    )
+    assign(:lesson, ContentStudio::Lesson.new(
+                      id: 1,
+                      title: 'Lesson with video',
+                      description: 'Description.',
+                      duration: 900,
+                      lesson_type: 'video',
+                      rating: 4.5,
+                      video_streaming_source: nil,
+                      local_contents: [local_content_with_video]
+                    ))
+    render
+    expect(rendered).to include('<video')
+    expect(rendered).to include('https://example-bucket.s3.amazonaws.com/lesson-1.mp4')
+  end
+end

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -88,4 +88,20 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     render
     expect(rendered).to include('1/2 Modules')
   end
+
+  it 'wires the lesson-name Stimulus controller on each lesson pill' do
+    render
+    expect(rendered).to include('data-controller="lesson-name"')
+  end
+
+  it 'sets the href value to the lesson show path on each lesson pill' do
+    render
+    expect(rendered).to include('data-lesson-name-href-value="/content_studio/courses/1/lessons/1"')
+    expect(rendered).to include('data-lesson-name-href-value="/content_studio/courses/1/lessons/2"')
+  end
+
+  it 'renders the inline edit input alongside each lesson title' do
+    render
+    expect(rendered).to include('data-lesson-name-target="input"')
+  end
 end


### PR DESCRIPTION
Fixes #1343

## What

Adds the Lesson Page (`GET /content_studio/courses/:course_id/lessons/:id`) with the full base layout from Figma.

**Lesson page view**
- Header: back link (→ Course Structure Editor), Edit Video Style (outline/primary), Delete Lesson (outline/danger)
- Left column: native `<video controls>` player for S3 URLs (placeholder icon when no URL), language `dropdown_component`, Previous / Next / Verify & Next nav buttons (placeholders), Script `textarea_component`, Regenerate Lesson button
- Right panel: lesson title + expandable description (Show more / Show less toggle)

**Course Structure Editor**
- Lesson name pills are now interactive: single click navigates to the lesson page, double click switches to inline edit mode (Enter/Escape to commit/cancel)

**API layer**
- `ApiClient.get_lesson(course_id, lesson_id)` → `BlackboardClient#get_lesson` hitting `GET /api/internal/courses/:course_id/lessons/:id`
- `spec/fixtures/api/lesson.json` added; dummy stub controller wired up

**Specs**
- Request spec: 8 examples covering HTTP 200 and all major rendered sections
- View spec: 14 examples covering video placeholder, video element, all buttons, dropdown, description toggle
- Structure view spec: 3 new examples covering lesson-name Stimulus controller wiring