### PR TITLE
[ContentStudio] Add lesson verification flow with status-driven UI

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
@@ -3,6 +3,16 @@
 module ContentStudio
   module Courses
     class LessonsController < ApplicationController
+      def verify
+        ApiClient.verify_lesson(params[:id])
+        next_id = params[:next_lesson_id]
+        if next_id.present?
+          redirect_to course_lesson_path(params[:course_id], next_id)
+        else
+          redirect_to course_structure_path(id: params[:course_id])
+        end
+      end
+
       def scene_status
         lesson = ApiClient.get_lesson(params[:course_id], params[:id])
         scenes = lesson.scenes.map do |s|

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -18,7 +18,7 @@ module ContentStudio
     def studio_course_card(course, status)
       course_card_component(
         title: course.title,
-        banner_url: course.thumbnail_url.presence || image_path('placeholder.gif'),
+        banner_url: course.thumbnail_url.presence,
         duration: format_duration(course.duration),
         modules_count: course.course_modules_count,
         enroll_count: course.enrollments_count || 0,

--- a/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
@@ -245,15 +245,27 @@
               disabled: @next_lesson_id.nil?
             ) %>
       <% end %>
-      <%= link_to @next_lesson_id ? course_lesson_path(@course_id, @next_lesson_id) : '#' do %>
-        <%= button_component(
-              text: 'Verify & Next',
-              type: 'solid',
-              size: 'md',
-              colorscheme: 'secondary',
-              icon_name: 'chevron-right',
-              icon_position: 'right'
-            ) %>
+      <% if @lesson.status == 'VERIFIED' %>
+        <div class="flex items-center gap-2">
+          <%= icon 'check-badge-solid', css: 'w-8 h-8 text-secondary' %>
+          <span class="main-text-lg-semibold text-secondary">Verified</span>
+        </div>
+      <% else %>
+        <%= form_with url: verify_lesson_path(@course_id, @lesson.id), method: :post,
+                      data: { turbo_frame: '_top' } do |f| %>
+          <%= f.hidden_field :next_lesson_id, value: @next_lesson_id %>
+          <%= f.button disabled: @lesson.status != 'VIDEO_READY' do %>
+            <%= button_component(
+                  text: 'Verify & Next',
+                  type: 'solid',
+                  size: 'md',
+                  colorscheme: 'secondary',
+                  icon_name: 'chevron-right',
+                  icon_position: 'right',
+                  disabled: @lesson.status != 'VIDEO_READY'
+                ) %>
+          <% end %>
+        <% end %>
       <% end %>
     </div>
     <span></span>

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -56,14 +56,10 @@
                   <div class="w-6 h-6 rounded-full border-2 border-primary-light-100 border-t-primary animate-spin flex-shrink-0"></div>
                 <% elsif lesson.status == 'WAITING' %>
                   <%= icon 'clock', css: 'w-6 h-6 text-primary flex-shrink-0' %>
-                <% elsif lesson.status == 'COMPLETED' %>
+                <% elsif lesson.status == 'VIDEO_READY' %>
+                  <%= icon 'play-circle', css: 'w-6 h-6 text-primary flex-shrink-0' %>
+                <% elsif lesson.status == 'VERIFIED' %>
                   <%= icon 'check-badge-solid', css: 'w-6 h-6 text-secondary flex-shrink-0' %>
-                <% else %>
-                  <%= chip_component(
-                    text: lesson_status_label(lesson.status),
-                    icon_name: lesson.status == 'verified' ? 'check' : nil,
-                    colorscheme: lesson_status_colorscheme(lesson.status)
-                  ) %>
                 <% end %>
               </div>
             <% end %>
@@ -131,8 +127,9 @@
         <div class="bg-white-light rounded-lg p-3 flex flex-col gap-3">
           <span class="main-text-sm-medium text-letter-color">Thumbnail</span>
           <div class="relative border border-line-colour-light rounded-lg overflow-hidden h-40">
-            <%= image_tag @structure.thumbnail_url.presence || image_path('placeholder.gif'),
-                         class: 'w-full h-full object-cover', alt: 'Course thumbnail' %>
+            <% thumb = @structure.thumbnail_url.presence %>
+            <%= image_tag thumb || image_path('video_film.gif'),
+                         class: "w-full h-full #{thumb ? 'object-cover' : 'object-contain'}", alt: 'Course thumbnail' %>
             <button type="button" class="absolute bottom-3 right-3 bg-white border border-letter-color rounded-full p-1.5 opacity-70">
               <%= icon 'pencil', css: 'w-4 h-4' %>
             </button>

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -13,6 +13,7 @@ ContentStudio::Engine.routes.draw do
   patch 'courses/:id/save', to: 'courses/structure#save', as: :save_course
   delete 'courses/:id', to: 'courses/structure#discard', as: :discard_course
   get 'courses/:course_id/lessons/:id', to: 'courses/lessons#show', as: :course_lesson
+  post 'courses/:course_id/lessons/:id/verify', to: 'courses/lessons#verify', as: :verify_lesson
   get 'courses/:course_id/lessons/:id/scene_status', to: 'courses/lessons#scene_status', as: :lesson_scene_status
   post 'courses/:course_id/lessons/:lesson_id/scenes/:scene_id/regenerate',
        to: 'courses/scenes#regenerate',

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -69,6 +69,10 @@ module ContentStudio
         client.regenerate_scene(scene_id, narration: narration)
       end
 
+      def verify_lesson(lesson_id) # rubocop:disable Rails/Delegate
+        client.verify_lesson(lesson_id)
+      end
+
       private
 
       def client

--- a/engines/content_studio/lib/content_studio/neo_ai_client.rb
+++ b/engines/content_studio/lib/content_studio/neo_ai_client.rb
@@ -92,6 +92,13 @@ module ContentStudio
       post('/course/regenerate-scene', { scene_id: scene_id, narration: narration })
     end
 
+    def verify_lesson(lesson_id)
+      build_connection.post("#{API_PREFIX}/course/verify-lesson") do |req|
+        req.params[:lesson_id] = lesson_id
+        req.params[:partner_id] = partner_id
+      end
+    end
+
     # Stubs — no NeoAI equivalent for these BlackboardLMS-specific calls
     def current_user = User.new(id: nil, name: nil, email: nil, role: nil)
     def list_avatars = []
@@ -239,24 +246,27 @@ module ContentStudio
 
     def build_structure_lesson(data)
       scenes = (data['scenes'] || []).map { |s| build_scene(s) }
+      verified = data['verified'] == true
+      video_url = data['video_url']
       StructureLesson.new(
         id: data['id'],
         title: data['title'],
         description: data['description'],
         summary: data['summary'],
         estimated_duration: data['estimated_duration'],
-        status: derive_lesson_status(scenes),
-        video_url: data['video_url'],
+        status: derive_lesson_status(scenes, video_url: video_url, verified: verified),
+        video_url: video_url,
+        verified: verified,
         scenes: scenes
       )
     end
 
-    def derive_lesson_status(scenes)
+    def derive_lesson_status(scenes, video_url:, verified:)
       return 'WAITING' if scenes.empty?
-      return 'COMPLETED' if scenes.all? { |s| s.video_url.present? }
-      return 'PENDING' if scenes.any? { |s| s.video_url.blank? && s.status == 'PENDING' }
+      return 'VERIFIED' if verified && video_url.present?
+      return 'VIDEO_READY' if scenes.all? { |s| s.video_url.present? }
 
-      'WAITING'
+      'PENDING'
     end
   end
 end

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -77,8 +77,8 @@ module ContentStudio
 
   StructureModule = Struct.new(:id, :title, :lessons, keyword_init: true)
 
-  StructureLesson = Struct.new(:id, :title, :description, :summary, :estimated_duration, :status, :video_url, :scenes,
-                               keyword_init: true)
+  StructureLesson = Struct.new(:id, :title, :description, :summary, :estimated_duration, :status, :video_url, :verified,
+                               :scenes, keyword_init: true)
 
   GenerationStatus = Struct.new(:status, :stage, :redirect_url, keyword_init: true)
 

--- a/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
@@ -3,22 +3,15 @@
 require_relative '../../../rails_helper'
 
 RSpec.describe 'ContentStudio::Courses::Lessons', type: :request do
-  let(:local_content) do
-    ContentStudio::LocalContent.new(
-      id: 1, lang: 'en', status: 'published', video_url: nil, video_published_at: nil
-    )
-  end
-
   let(:lesson) do
-    ContentStudio::Lesson.new(
-      id: 1,
+    ContentStudio::StructureLesson.new(
+      id: '1',
       title: 'Introduction to Airport Services',
       description: 'This lesson introduces the core concepts of airport services management.',
-      duration: 1800,
-      lesson_type: 'video',
-      rating: 4.8,
-      video_streaming_source: 'youtube',
-      local_contents: [local_content],
+      estimated_duration: 1800,
+      status: 'PENDING',
+      video_url: nil,
+      verified: false,
       scenes: []
     )
   end
@@ -27,15 +20,15 @@ RSpec.describe 'ContentStudio::Courses::Lessons', type: :request do
     ContentStudio::CourseStructure.new(
       id: '1',
       title: 'Test Course',
-      duration: 3600,
       modules: [
         ContentStudio::StructureModule.new(
           id: 'm1',
           title: 'Module 1',
           lessons: [
             ContentStudio::StructureLesson.new(id: '1', title: 'Introduction to Airport Services',
-                                               status: 'in_process'),
-            ContentStudio::StructureLesson.new(id: '2', title: 'Rules and Regulations', status: 'in_process')
+                                               status: 'PENDING', scenes: []),
+            ContentStudio::StructureLesson.new(id: '2', title: 'Rules and Regulations',
+                                               status: 'PENDING', scenes: [])
           ]
         )
       ],

--- a/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
@@ -3,40 +3,25 @@
 require_relative '../../../../rails_helper'
 
 RSpec.describe 'content_studio/courses/lessons/show', type: :view do
-  let(:local_content_no_video) do
-    ContentStudio::LocalContent.new(
-      id: 1, lang: 'en', status: 'published', video_url: nil, video_published_at: nil
-    )
-  end
-
-  let(:local_content_with_video) do
-    ContentStudio::LocalContent.new(
-      id: 2, lang: 'en', status: 'published',
-      video_url: 'https://example-bucket.s3.amazonaws.com/lesson-1.mp4',
-      video_published_at: nil
-    )
-  end
-
   let(:scenes) do
     [
-      ContentStudio::Scene.new(id: 's1', timestamp: '0.00', narration: 'Scene one narration.', status: 'ready',
+      ContentStudio::Scene.new(id: 's1', timestamp: '0.00', narration: 'Scene one narration.', status: 'APPROVED',
                                video_url: nil),
-      ContentStudio::Scene.new(id: 's2', timestamp: '0.30', narration: 'Scene two narration.', status: 'ready',
+      ContentStudio::Scene.new(id: 's2', timestamp: '0.30', narration: 'Scene two narration.', status: 'APPROVED',
                                video_url: nil)
     ]
   end
 
   let(:lesson) do
-    ContentStudio::Lesson.new(
-      id: 1,
+    ContentStudio::StructureLesson.new(
+      id: '1',
       title: 'Introduction to Airport Services',
       description: 'This lesson introduces the core concepts of airport services management ' \
                    'including check-in procedures and passenger assistance.',
-      duration: 1800,
-      lesson_type: 'video',
-      rating: 4.8,
-      video_streaming_source: 'youtube',
-      local_contents: [local_content_no_video],
+      estimated_duration: 1800,
+      status: 'PENDING',
+      video_url: nil,
+      verified: false,
       scenes: scenes
     )
   end
@@ -79,9 +64,9 @@ RSpec.describe 'content_studio/courses/lessons/show', type: :view do
     expect(rendered).to include('Next')
   end
 
-  it 'renders the language from the first local content' do
+  it 'renders the language selector' do
     render
-    expect(rendered).to include('En')
+    expect(rendered).to include('English')
   end
 
   it 'renders the Script label' do
@@ -125,7 +110,7 @@ RSpec.describe 'content_studio/courses/lessons/show', type: :view do
   it 'renders scene items with scene id, status, and regenerate url data attributes' do
     render
     expect(rendered).to include('data-scene-id="s1"')
-    expect(rendered).to include('data-scene-status="ready"')
+    expect(rendered).to include('data-scene-status="APPROVED"')
     expect(rendered).to include('data-regenerate-url=')
   end
 
@@ -164,5 +149,46 @@ RSpec.describe 'content_studio/courses/lessons/show', type: :view do
   it 'renders the control bar with hover visibility class' do
     render
     expect(rendered).to include('group-hover:opacity-100')
+  end
+
+  context 'when lesson status is VIDEO_READY' do
+    let(:lesson) do
+      ContentStudio::StructureLesson.new(
+        id: '1', title: 'Introduction to Airport Services',
+        description: 'Desc', estimated_duration: 1800,
+        status: 'VIDEO_READY', video_url: nil, verified: false, scenes: scenes
+      )
+    end
+
+    it 'renders the Verify & Next button' do
+      render
+      expect(rendered).to include('Verify &amp; Next')
+    end
+
+    it 'renders the verify form targeting _top turbo frame' do
+      render
+      expect(rendered).to include('data-turbo-frame="_top"')
+    end
+  end
+
+  context 'when lesson status is VERIFIED' do
+    let(:lesson) do
+      ContentStudio::StructureLesson.new(
+        id: '1', title: 'Introduction to Airport Services',
+        description: 'Desc', estimated_duration: 1800,
+        status: 'VERIFIED', video_url: 'https://example.com/lesson.mp4', verified: true, scenes: scenes
+      )
+    end
+
+    it 'renders the verified icon and text' do
+      render
+      expect(rendered).to include('text-secondary')
+      expect(rendered).to include('Verified')
+    end
+
+    it 'does not render the Verify & Next form' do
+      render
+      expect(rendered).not_to include('Verify &amp; Next')
+    end
   end
 end

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     ContentStudio::StructureModule.new(
       id: 1, title: 'Airport Services',
       lessons: [
-        ContentStudio::StructureLesson.new(id: 1, title: 'Introduction', status: 'verified', scenes: []),
-        ContentStudio::StructureLesson.new(id: 2, title: 'Rules and regulations', status: 'video_ready', scenes: [])
+        ContentStudio::StructureLesson.new(id: 1, title: 'Introduction', status: 'VERIFIED', scenes: []),
+        ContentStudio::StructureLesson.new(id: 2, title: 'Rules and regulations', status: 'VIDEO_READY', scenes: [])
       ]
     )
   end
@@ -17,7 +17,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     ContentStudio::StructureModule.new(
       id: 2, title: 'Wine Serving',
       lessons: [
-        ContentStudio::StructureLesson.new(id: 3, title: 'Lesson name', status: 'in_process', scenes: [])
+        ContentStudio::StructureLesson.new(id: 3, title: 'Lesson name', status: 'PENDING', scenes: [])
       ]
     )
   end
@@ -56,11 +56,11 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     expect(rendered).to include('Rules and regulations')
   end
 
-  it 'renders lesson status chips' do
+  it 'renders lesson status icons' do
     render
-    expect(rendered).to include('Verified')
-    expect(rendered).to include('Video ready')
-    expect(rendered).to include('In Process')
+    expect(rendered).to include('w-6 h-6 text-secondary flex-shrink-0')
+    expect(rendered).to include('w-6 h-6 text-primary flex-shrink-0')
+    expect(rendered).to include('animate-spin')
   end
 
   it 'renders course name in sidebar' do
@@ -113,9 +113,9 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
   end
 
   context 'when thumbnail_url is absent' do
-    it 'renders the placeholder image in the thumbnail section' do
+    it 'renders the video_film gif as fallback in the thumbnail section' do
       render
-      expect(rendered).to include('placeholder')
+      expect(rendered).to match(/src="[^"]*video_film[^"]*\.gif"/)
     end
   end
 end


### PR DESCRIPTION
Fixes #

## Summary

- Adds `POST /courses/:course_id/lessons/:id/verify` route and `LessonsController#verify` action that calls `ApiClient.verify_lesson` then redirects to the next lesson or structure page
- Extends `StructureLesson` struct with a `verified` field; updates `derive_lesson_status` to return `VERIFIED` / `VIDEO_READY` / `PENDING` / `WAITING` based on backend data
- Replaces the hardcoded "Verify & Next" link on the lesson page with a status-driven UI: shows verified badge + text when `VERIFIED`, disabled form button otherwise (enabled only when `VIDEO_READY`)
- Updates structure page lesson-row icons to match the new statuses (`VIDEO_READY` → play-circle, `VERIFIED` → check-badge)
- Updates view specs and request specs to use the new `StructureLesson` struct and status constants