### PR TITLE
[ContentStudio] Add animated thin progress bar and move status card below stepper

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,4 +1,5 @@
 @import "directives.tailwind.css";
+@import "progressbar.tailwind.css";
 @import "buttons.tailwind.css";
 @import "typography.tailwind.css";
 @import "inputs.tailwind.css";

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -34,6 +34,8 @@ module.exports = {
         "primary-light":"#0057FA",
         "primary-light-50":"#EAF0FD",
         "primary-light-100":"#D9E3F5",
+        "cyan":"#06B6D4",
+        "teal":"#14B8A6",
         "secondary":"#A9D500",
         "secondary-dark":"#87AA00",
         "secondary-light":"#F2F9D9",

--- a/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
@@ -37,7 +37,9 @@
         <%= progressbar_component(
               numerator: scenes_with_video,
               denominator: [@lesson.scenes.size, 1].max,
-              full_width: true
+              full_width: true,
+              thin: true,
+              animated: has_pending
             ) %>
       </div>
       <% scenes = @lesson.scenes.presence || [] %>

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -13,10 +13,40 @@
   <% failed = @structure.stage.to_s.end_with?('_failed') %>
   <% has_pending = !failed && @structure.modules.flat_map(&:lessons).any? { |l| %w[PENDING WAITING].include?(l.status) } %>
   <turbo-frame id="course-structure">
-  <div class="flex gap-6 px-4"
+  <div class="flex flex-col gap-6 px-4"
        data-controller="collapsible-group structure-polling"
        data-structure-polling-pending-value="<%= has_pending %>">
-    <div class="flex-1 flex flex-col gap-6">
+
+    <%# Status card — below stepper, above modules %>
+    <% all_scenes = @structure.modules.flat_map(&:lessons).flat_map(&:scenes) %>
+    <% completed_scenes = all_scenes.count { |s| s.video_url.present? } %>
+    <% fill_pct = all_scenes.size > 0 ? (completed_scenes.to_f / all_scenes.size * 100).to_i : 0 %>
+    <% if has_pending || @structure.progress_text.present? %>
+      <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden">
+        <div class="flex items-center justify-between p-3">
+          <div class="flex items-center gap-2 min-w-0">
+            <%= image_tag 'image ai .gif', class: 'w-7 h-7 shrink-0', alt: '' %>
+            <span class="general-text-sm-normal text-letter-color truncate">
+              <%= @structure.progress_text.presence || 'Generating your course…' %>
+            </span>
+          </div>
+          <div class="flex items-center gap-1 flex-shrink-0 pl-3">
+            <span class="general-text-md-medium text-primary"><%= fill_pct %>%</span>
+            <%= icon 'check-circle', css: 'w-4 h-4 text-primary' %>
+          </div>
+        </div>
+        <%= progressbar_component(
+              numerator: completed_scenes,
+              denominator: [all_scenes.size, 1].max,
+              full_width: true,
+              animated: has_pending,
+              thin: true
+            ) %>
+      </div>
+    <% end %>
+
+    <div class="flex gap-6">
+      <div class="flex-1 flex flex-col gap-6">
       <% @structure.modules.each do |mod| %>
         <div class="bg-white border border-line-colour-light rounded-xl p-5 flex flex-col gap-4"
              data-controller="collapsible"
@@ -87,7 +117,7 @@
       </div>
     </div>
 
-    <div class="w-96 flex-shrink-0">
+      <div class="w-96 flex-shrink-0">
       <div class="bg-primary-light-50 border border-line-colour-light rounded-xl p-5 flex flex-col gap-5">
         <span class="main-text-md-semibold text-letter-color">Course Overview</span>
 
@@ -105,25 +135,6 @@
           </div>
         </div>
 
-        <% all_scenes = @structure.modules.flat_map(&:lessons).flat_map(&:scenes) %>
-        <% completed_scenes = all_scenes.count { |s| s.video_url.present? } %>
-        <div class="bg-white-light rounded-lg p-3 flex flex-col gap-2">
-          <div class="flex items-center justify-between">
-            <span class="general-text-md-medium text-letter-color">Progress</span>
-            <%= icon 'i-vector', css: 'w-4 h-4' %>
-          </div>
-          <%= progressbar_component(
-            numerator: completed_scenes,
-            denominator: [all_scenes.size, 1].max,
-            full_width: true
-          ) %>
-          <% if @structure.progress_text.present? %>
-            <p class="general-text-sm-medium text-letter-color">
-              <%= @structure.progress_text %><span class="typing-dots"><span>.</span><span>.</span><span>.</span></span>
-            </p>
-          <% end %>
-        </div>
-
         <div class="bg-white-light rounded-lg p-3 flex flex-col gap-3">
           <span class="main-text-sm-medium text-letter-color">Thumbnail</span>
           <div class="relative border border-line-colour-light rounded-lg overflow-hidden h-40">
@@ -135,9 +146,8 @@
             </button>
           </div>
         </div>
-
-
-</div>
+      </div>
+      </div>
     </div>
   </div>
   </turbo-frame>

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -118,4 +118,60 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
       expect(rendered).to match(/src="[^"]*video_film[^"]*\.gif"/)
     end
   end
+
+  context 'when there are pending lessons' do
+    it 'renders the status card below the stepper' do
+      render
+      expect(rendered).to include('border-secondary-dark')
+      expect(rendered).to include('Generating your course')
+    end
+
+    it 'renders the animated progress bar in the status card' do
+      render
+      expect(rendered).to include('progressbar-animated')
+    end
+  end
+
+  context 'when progress_text is present and no pending lessons' do
+    before do
+      all_verified = ContentStudio::StructureModule.new(
+        id: 1, title: 'Airport Services',
+        lessons: [
+          ContentStudio::StructureLesson.new(id: 1, title: 'Introduction', status: 'VERIFIED', scenes: [])
+        ]
+      )
+      assign(:structure, ContentStudio::CourseStructure.new(
+                           id: 1, title: 'Airport Services Management', duration: 9240,
+                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil,
+                           progress_text: 'Generating module 2 of 3'
+                         ))
+    end
+
+    it 'renders the status card with the progress text' do
+      render
+      expect(rendered).to include('border-secondary-dark')
+      expect(rendered).to include('Generating module 2 of 3')
+    end
+  end
+
+  context 'when no pending lessons and no progress_text' do
+    before do
+      all_verified = ContentStudio::StructureModule.new(
+        id: 1, title: 'Airport Services',
+        lessons: [
+          ContentStudio::StructureLesson.new(id: 1, title: 'Introduction', status: 'VERIFIED', scenes: [])
+        ]
+      )
+      assign(:structure, ContentStudio::CourseStructure.new(
+                           id: 1, title: 'Airport Services Management', duration: 9240,
+                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil
+                         ))
+    end
+
+    it 'does not render the status card' do
+      render
+      expect(rendered).not_to include('border-secondary-dark')
+      expect(rendered).not_to include('progressbar-animated')
+    end
+  end
 end

--- a/engines/neo_component/app/assets/stylesheets/progressbar.tailwind.css
+++ b/engines/neo_component/app/assets/stylesheets/progressbar.tailwind.css
@@ -1,0 +1,19 @@
+@keyframes progressbar-gradient-flow {
+  0%   { background-position: 0% 0%; }
+  100% { background-position: 100% 0%; }
+}
+
+@layer utilities {
+  .progressbar-animated {
+    background-image: linear-gradient(
+      90deg,
+      theme('colors.primary'),
+      theme('colors.cyan'),
+      theme('colors.teal'),
+      theme('colors.secondary'),
+      theme('colors.primary')
+    );
+    background-size: 300% 100%;
+    animation: progressbar-gradient-flow 2.2s linear infinite;
+  }
+}

--- a/engines/neo_component/app/helpers/view_component/progress_component.rb
+++ b/engines/neo_component/app/helpers/view_component/progress_component.rb
@@ -2,12 +2,12 @@
 
 module ViewComponent
   module ProgressComponent
-    def progressbar_component(numerator:, denominator:, full_width: false)
+    def progressbar_component(numerator:, denominator:, full_width: false, animated: false, thin: false)
       numerator = 0 if numerator.blank?
       denominator = 0 if denominator.blank?
       fill = denominator.zero? ? 0 : (numerator / denominator.to_f * 100).to_i
       render partial: 'view_components/progress_component/progressbar',
-             locals: { numerator:, denominator:, fill:, full_width: }
+             locals: { numerator:, denominator:, fill:, full_width:, animated:, thin: }
     end
   end
 end

--- a/engines/neo_component/app/views/neo_components/ui/progress/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/progress/index.html.erb
@@ -5,3 +5,11 @@
 <%= doc_section_component(title: "Progressbar - full width") do %>
   <%= progressbar_component(numerator: 30, denominator: 100, full_width: true) %>
 <% end %>
+
+<%= doc_section_component(title: "Progressbar - thin") do %>
+  <%= progressbar_component(numerator: 30, denominator: 100, full_width: true, thin: true) %>
+<% end %>
+
+<%= doc_section_component(title: "Progressbar - thin animated") do %>
+  <%= progressbar_component(numerator: 30, denominator: 100, full_width: true, thin: true, animated: true) %>
+<% end %>

--- a/engines/neo_component/app/views/view_components/progress_component/_progressbar.html.erb
+++ b/engines/neo_component/app/views/view_components/progress_component/_progressbar.html.erb
@@ -1,5 +1,12 @@
-<div class="flex h-[6px] md:h-2 border-none <%= full_width ? 'w-full' : 'w-[52px] md:w-[120px]' %>">
-  <div class="h-1 grow bg-primary-light-100 w-full h-full border border-primary-light-100 rounded md:rounded-lg">
-    <div class="h-1 bg-primary h-full border rounded-sm md:rounded" style="width: <%= fill %>%"></div>
+<% if thin %>
+  <div class="h-[3px] bg-primary-light-100 <%= full_width ? 'w-full' : 'w-[52px] md:w-[120px]' %>">
+    <div class="h-full rounded <%= animated ? 'progressbar-animated' : 'bg-primary' %>"
+         style="width: <%= fill %>%"></div>
   </div>
-</div>
+<% else %>
+  <div class="flex h-[6px] md:h-2 border-none <%= full_width ? 'w-full' : 'w-[52px] md:w-[120px]' %>">
+    <div class="h-1 grow bg-primary-light-100 w-full h-full border border-primary-light-100 rounded md:rounded-lg">
+      <div class="h-1 h-full border rounded-sm md:rounded <%= animated ? 'progressbar-animated' : 'bg-primary' %>" style="width: <%= fill %>%"></div>
+    </div>
+  </div>
+<% end %>

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -373,8 +373,25 @@ notification_bar(
 progressbar_component(
   numerator:,
   denominator:,
-  full_width: false   # true stretches to w-full; default is w-[52px] md:w-[120px]
+  full_width: false,  # true stretches to w-full; default is w-[52px] md:w-[120px]
+  thin: false,        # true renders a 3px bar (no border); default is 6-8px with border
+  animated: false     # true applies a flowing blue→cyan→teal→green gradient; width still reflects fill %
 )
+```
+
+**Variants**
+```ruby
+# Standard
+progressbar_component(numerator: 30, denominator: 100)
+
+# Full width
+progressbar_component(numerator: 30, denominator: 100, full_width: true)
+
+# Thin (3 px, no border) — use inside cards or compact layouts
+progressbar_component(numerator: 30, denominator: 100, full_width: true, thin: true)
+
+# Thin + animated gradient — use while generation is in progress
+progressbar_component(numerator: 30, denominator: 100, full_width: true, thin: true, animated: true)
 ```
 
 ---


### PR DESCRIPTION
Fixes #

## Summary

- Extends `progressbar_component` with `thin:` (3px bar, no border) and `animated:` (flowing blue→cyan→teal→green gradient) params; existing callers unaffected
- Adds `progressbar.tailwind.css` with `@keyframes progressbar-gradient-flow` and `.progressbar-animated` utility; imported into `application.tailwind.css`
- Adds `cyan` and `teal` colour tokens to `tailwind.config.js` (referenced via `theme()` in the CSS)
- Fixes animated thin bar bug where fill width was always 100% — now correctly reflects the actual percentage
- Moves the generation status card on the structure page from the sidebar to below the stepper (inside the turbo-frame so it refreshes on each poll); removes the old sidebar progress section
- Status card: progress text truncates with `min-w-0` so the percentage+icon are always visible; icon updated from `i-vector` to `check-circle` to match Figma
- Applies `thin: true, animated: has_pending` to the lesson page progress bar
- Adds thin and thin+animated examples to the UI demo page and updates `ui_manifest.md`