### PR TITLE
[ContentStudio] Add Save/Discard buttons to structure page and wire course card navigation

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/courses/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/structure_controller.rb
@@ -5,6 +5,8 @@ module ContentStudio
     class StructureController < ApplicationController
       def show
         @structure = ApiClient.course_structure(params[:id])
+      rescue Faraday::ResourceNotFound
+        redirect_to root_path
       end
 
       def save
@@ -15,6 +17,9 @@ module ContentStudio
       def discard
         ApiClient.discard_course(params[:id])
         redirect_to root_path
+      rescue Faraday::BadRequestError
+        flash[:alert] = t('content_studio.courses.discard.locked')
+        redirect_to course_structure_path(id: params[:id])
       end
     end
   end

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -16,7 +16,7 @@ module ContentStudio
     end
 
     def studio_course_card(course, status)
-      course_card_component(
+      card = course_card_component(
         title: course.title,
         banner_url: course.thumbnail_url.presence,
         duration: format_duration(course.duration),
@@ -27,6 +27,7 @@ module ContentStudio
         progress: course.progress,
         badge: studio_badge(status)
       )
+      link_to(card, course_structure_path(id: course.id), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -146,6 +146,21 @@
             </button>
           </div>
         </div>
+
+        <div class="flex gap-3">
+          <%= form_with url: discard_course_path(id: @structure.id), method: :delete, class: 'flex-1', data: { turbo_frame: '_top' } do |f| %>
+            <%= f.button class: 'w-full' do %>
+              <%= button_component(text: 'Discard Course', type: 'outline', colorscheme: 'danger',
+                                   html_options: { class: 'w-full' }) %>
+            <% end %>
+          <% end %>
+          <%= form_with url: save_course_path(id: @structure.id), method: :patch, class: 'flex-1' do |f| %>
+            <%= f.button class: 'w-full' do %>
+              <%= button_component(text: 'Save Course', type: 'solid', colorscheme: 'primary',
+                                   html_options: { class: 'w-full' }) %>
+            <% end %>
+          <% end %>
+        </div>
       </div>
       </div>
     </div>

--- a/engines/content_studio/config/locales/en.yml
+++ b/engines/content_studio/config/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  content_studio:
+    courses:
+      discard:
+        locked: "Course is currently being processed. Please wait before deleting."

--- a/engines/content_studio/lib/content_studio/neo_ai_client.rb
+++ b/engines/content_studio/lib/content_studio/neo_ai_client.rb
@@ -111,7 +111,10 @@ module ContentStudio
     end
 
     def save_course(_course_id) = nil
-    def discard_course(_course_id) = nil
+
+    def discard_course(course_id)
+      delete("/course/#{course_id}")
+    end
 
     private
 
@@ -124,6 +127,10 @@ module ContentStudio
         req.params[:partner_id] = partner_id
         req.headers['no_video'] = 'true' if no_video
       end
+    end
+
+    def delete(path)
+      build_connection.delete("#{API_PREFIX}#{path}", { partner_id: partner_id })
     end
 
     def build_connection

--- a/engines/content_studio/spec/requests/content_studio/courses/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/structure_spec.rb
@@ -11,11 +11,25 @@ RSpec.describe 'ContentStudio::Courses::Structure', type: :request do
   end
 
   describe 'GET /content_studio/courses/:id/structure' do
-    before { allow(ContentStudio::ApiClient).to receive(:course_structure).and_return(structure) }
+    context 'when the course exists' do
+      before { allow(ContentStudio::ApiClient).to receive(:course_structure).and_return(structure) }
 
-    it 'returns HTTP 200' do
-      get '/content_studio/courses/1/structure'
-      expect(response).to have_http_status(:ok)
+      it 'returns HTTP 200' do
+        get '/content_studio/courses/1/structure'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the course is not found' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:course_structure)
+          .and_raise(Faraday::ResourceNotFound.new(nil))
+      end
+
+      it 'redirects to the content studio root' do
+        get '/content_studio/courses/missing/structure'
+        expect(response).to redirect_to('/content_studio/')
+      end
     end
   end
 
@@ -29,11 +43,30 @@ RSpec.describe 'ContentStudio::Courses::Structure', type: :request do
   end
 
   describe 'DELETE /content_studio/courses/:id' do
-    before { allow(ContentStudio::ApiClient).to receive(:discard_course) }
+    context 'when the course is discarded successfully' do
+      before { allow(ContentStudio::ApiClient).to receive(:discard_course) }
 
-    it 'redirects after discard' do
-      delete '/content_studio/courses/1'
-      expect(response).to have_http_status(:redirect)
+      it 'redirects to the content studio root' do
+        delete '/content_studio/courses/1'
+        expect(response).to redirect_to('/content_studio/')
+      end
+    end
+
+    context 'when the course is locked' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:discard_course)
+          .and_raise(Faraday::BadRequestError.new(nil))
+      end
+
+      it 'redirects back to the structure page' do
+        delete '/content_studio/courses/1'
+        expect(response).to redirect_to('/content_studio/courses/1/structure')
+      end
+
+      it 'sets a flash alert' do
+        delete '/content_studio/courses/1'
+        expect(flash[:alert]).to eq(I18n.t('content_studio.courses.discard.locked'))
+      end
     end
   end
 end

--- a/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe 'content_studio/courses/index', type: :view do
     expect(rendered).to include('Pending')
   end
 
+  it 'wraps each course card in a link to its structure page' do
+    render
+    expect(rendered).to include('href="/content_studio/courses/1/structure"')
+  end
+
   context 'when a tab has no courses' do
     before do
       assign(:verified, [])

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -154,6 +154,27 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     end
   end
 
+  it 'renders the Save Course button' do
+    render
+    expect(rendered).to include('Save Course')
+  end
+
+  it 'renders the Discard Course button' do
+    render
+    expect(rendered).to include('Discard Course')
+  end
+
+  it 'renders the discard form targeting the discard route with turbo_frame _top' do
+    render
+    expect(rendered).to include('action="/content_studio/courses/1"')
+    expect(rendered).to include('data-turbo-frame="_top"')
+  end
+
+  it 'renders the save form targeting the save route' do
+    render
+    expect(rendered).to include('action="/content_studio/courses/1/save"')
+  end
+
   context 'when no pending lessons and no progress_text' do
     before do
       all_verified = ContentStudio::StructureModule.new(


### PR DESCRIPTION
## Summary

- Add **Save Course** and **Discard Course** buttons to the Course Overview sidebar on the structure page, matching the Figma design
- Implement `discard_course` in `NeoAiClient` — calls `DELETE /api/v1/course/:id` on the neo-ai service (was a no-op)
- Handle error cases in `StructureController`: locked course (400 → flash alert + redirect back), deleted course (404 on `show` → redirect to engine root)
- Use `data-turbo-frame="_top"` on the discard form so Turbo performs a full-page navigation instead of a frame update
- Wrap carousel course cards in links to their structure pages via `studio_course_card` helper
- Add engine-scoped locale file (`engines/content_studio/config/locales/en.yml`) for Content Studio strings
- Extend request and view specs to cover all new behaviours