### PR TITLE
Fix N+1 query (local): eager load lessons on course modules

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -4,8 +4,9 @@ module Api
   module V1
     class CoursesController < ApiController
       def show
-        course = Course.includes(:tags, course_modules: { lessons: :local_contents })
-          .find(params[:id])
+        course = Course.includes(:tags).find(params[:id])
+        lessons = course.modules_in_order.flat_map(&:module_lessons)
+        ActiveRecord::Associations::Preloader.new(records: lessons, associations: :local_contents).call
         render json: course.to_json_data, status: :ok
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'Course not found' }, status: :not_found

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -221,7 +221,7 @@ class CoursesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_course
-    @course = Course.find(params[:id])
+    @course = Course.includes(course_modules: :lessons).find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -64,7 +64,10 @@ class CoursesController < ApplicationController
   # GET /courses/1 or /courses/1.json
   def show
     authorize @course
-    @course_modules = @course.modules_in_order
+    @course_modules = RecordOrdering.records_in_order(
+      @course.course_modules.includes(:lessons),
+      @course.course_modules_in_order
+    )
     @enrollment = current_user.get_enrollment_for(@course)
     if params[:program_id].present?
       @program = current_user.learning_partner.programs
@@ -221,7 +224,7 @@ class CoursesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_course
-    @course = Course.includes(course_modules: :lessons).find(params[:id])
+    @course = Course.find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -64,10 +64,7 @@ class CoursesController < ApplicationController
   # GET /courses/1 or /courses/1.json
   def show
     authorize @course
-    @course_modules = RecordOrdering.records_in_order(
-      @course.course_modules.includes(:lessons),
-      @course.course_modules_in_order
-    )
+    @course_modules = @course.modules_in_order
     @enrollment = current_user.get_enrollment_for(@course)
     if params[:program_id].present?
       @program = current_user.learning_partner.programs

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -105,7 +105,7 @@ class Course < ApplicationRecord
   end
 
   def modules_in_order
-    @modules_in_order ||= RecordOrdering.records_in_order(course_modules.includes(:lessons), course_modules_in_order)
+    @modules_in_order ||= RecordOrdering.records_in_order(course_modules, course_modules_in_order)
   end
 
   private

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -105,7 +105,7 @@ class Course < ApplicationRecord
   end
 
   def modules_in_order
-    @modules_in_order ||= RecordOrdering.records_in_order(course_modules, course_modules_in_order)
+    @modules_in_order ||= RecordOrdering.records_in_order(course_modules.includes(:lessons), course_modules_in_order)
   end
 
   private

--- a/app/views/dashboards/recent_activity.html.erb
+++ b/app/views/dashboards/recent_activity.html.erb
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-<div class="bg-white border border-line-colour-light rounded-xl px-5">
+<div class="bg-white border border-line-colour-light rounded-xl px-5 md:max-w-[760px]">
   <% @activities.each do |activity| %>
     <div class="flex items-start justify-between py-4 border-b border-line-colour-light last:border-b-0">
       <div class="flex items-start gap-3">


### PR DESCRIPTION
## Problem
Bullet detected an N+1 query when opening a course — course_modules were 
loaded without eager loading lessons, causing a separate DB query per 
module when the view called module_lessons.

## Fix
- Course#modules_in_order — added .includes(:lessons) once in the model. 
  Every caller (web show, helper, view, course_json.rb) gets the fix automatically
- CoursesController#show — reverted to @course.modules_in_order, 
  removing the duplicated inline fix
- Api::V1::CoursesController#show — dropped the now-redundant 
  course_modules: { lessons: ... } includes and preloads local_contents 
  separately after modules_in_order runs, since that's the only extra 
  association the API needs

## Why this approach
Fixing it in the model ensures all callers benefit from the fix rather 
than patching one action in isolation. The API controller is updated to 
avoid unnecessary duplicate includes.