### PR TITLE
Fix video upload preview and filename not showing after file selection

### DIFF
--- a/app/javascript/controllers/lessons_form_controller.js
+++ b/app/javascript/controllers/lessons_form_controller.js
@@ -75,11 +75,11 @@ export default class extends Controller {
 
     const record = this.nestedRecordContainer.lastElementChild;
     this.setDefaultLanguageFor(record);
-    const outlet = this.videoUploadOutlets.find(outlet =>
-      record.contains(outlet.element)
-    );
 
-    outlet?.setFile(file);
+    // Stimulus connects outlets asynchronously. Store the file directly on the
+    // outlet element so video_upload_controller can pick it up in connect().
+    const videoUploadEl = record.querySelector('[data-controller~="video-upload"]');
+    if (videoUploadEl) videoUploadEl._pendingFile = file;
 
     this.videoInputTarget.value = "";
     this.videoFieldCount++;

--- a/app/javascript/controllers/video_upload_controller.js
+++ b/app/javascript/controllers/video_upload_controller.js
@@ -24,6 +24,10 @@ export default class extends Controller {
     if (this.hiddenBlobIdTarget.value) {
       this.restoreUploadedVideo();
     }
+    if (this.element._pendingFile) {
+      this.setFile(this.element._pendingFile);
+      delete this.element._pendingFile;
+    }
   }
   restoreUploadedVideo() {
     const blobId = this.hiddenBlobIdTarget.value;

--- a/app/views/lessons/_form.html.erb
+++ b/app/views/lessons/_form.html.erb
@@ -60,7 +60,9 @@
         </div>
         
         <div class="flex-1 hidden" data-lessons-form-target="uploadButtonEnabled">
-          <%= button_component(text: submit_label_for(lesson), disabled: false ) %>
+          <%= form.button type: :submit, class: 'w-full' do %>
+            <%= button_component(text: submit_label_for(lesson)) %>
+          <% end %>
         </div>
                  
       </div>


### PR DESCRIPTION
Fixes #1338

## Root cause

The bugs were introduced in #1229 (January 29, 2026 — "Lesson creation and editing forms modification as per new design"). Video upload had worked correctly before that redesign; all three issues below were broken from day one of the new design.

---

## Bug 1 — Create button did nothing

`uploadButtonEnabled` contained a `button_component` which renders a `<div>`, not a `<button type="submit">`. Clicking it never submitted the form.

**Fix:** wrap in `form.button type: :submit`, following the existing pattern used in `assessments/_assessment.html.erb`.

---

## Bug 2 — Filename and preview not shown after selecting a video

`videoSelected()` searched `videoUploadOutlets` immediately after appending the cloned template node, then called `outlet?.setFile(file)`. But Stimulus connects outlets via `MutationObserver` — a microtask that runs *after* the current synchronous call stack completes. So the outlet was never in `videoUploadOutlets` at that moment and `setFile()` was a silent no-op.

**Fix:** instead of relying on the outlet callback, store the file directly on the outlet DOM element (`videoUploadEl._pendingFile = file`) before Stimulus connects it. `video_upload_controller#connect()` reads and clears `_pendingFile`, guaranteeing `setFile()` is called exactly once, regardless of timing.

```js
// lessons_form_controller.js — videoSelected()
// Before: outlet not found yet, setFile() never called
const outlet = this.videoUploadOutlets.find(o => record.contains(o.element));
outlet?.setFile(file); // always undefined — silent no-op

// After: hand file off via DOM; video_upload_controller picks it up in connect()
const videoUploadEl = record.querySelector('[data-controller~="video-upload"]');
if (videoUploadEl) videoUploadEl._pendingFile = file;

// video_upload_controller.js — connect()
if (this.element._pendingFile) {
  this.setFile(this.element._pendingFile);
  delete this.element._pendingFile;
}
```