### PR TITLE
Dashboard: export to Excel, manager progress, member profile export, and pagination fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,7 @@ gem 'rails-html-sanitizer', '1.6.1'
 
 gem 'scorm-package', '~> 0.1.2', require: 'scorm_package'
 
+gem 'caxlsx', '~> 3.4'
 gem 'combine_pdf'
 gem 'grover'
 gem 'net-imap', '0.5.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    caxlsx (3.4.1)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     chartkick (5.1.0)
     coderay (1.1.3)
     combine_pdf (1.0.31)
@@ -212,6 +217,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.1.1)
+    htmlentities (4.4.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -560,6 +566,7 @@ DEPENDENCIES
   bullet
   bundler-audit
   capybara
+  caxlsx (~> 3.4)
   chartkick
   combine_pdf
   connection_pool (~> 2.5)

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DashboardsController < ApplicationController
-  before_action :set_dashboard_params, only: %i[index nudge_all appreciate_member team_progress team_member_profile started_vs_completed recent_activity nudge_user]
+  before_action :set_dashboard_params, only: %i[index nudge_all appreciate_member team_progress team_member_profile started_vs_completed recent_activity nudge_user export export_member]
 
   def index
     authorize :dashboard
@@ -34,10 +34,29 @@ class DashboardsController < ApplicationController
   def team_progress
     authorize :dashboard
     @dashboard = DashboardService.instance.build_dashboard_for(@team, @duration)
-    @sub_teams = @dashboard.sub_teams_progress
-    @tab = @sub_teams.any? && params[:tab] == 'teams' ? 'teams' : 'members'
+    all_sub_teams = @dashboard.sub_teams_progress
+    @tab = all_sub_teams.any? && params[:tab] == 'teams' ? 'teams' : 'members'
+    @sub_teams = Kaminari.paginate_array(all_sub_teams, total_count: all_sub_teams.size).page(params[:page]).per(10)
     @team_members = @dashboard.all_team_members_progress(params[:page], query: params[:query])
     @member_counts = @dashboard.team_member_status_counts
+  end
+
+  def export
+    authorize :dashboard
+    @dashboard = DashboardService.instance.build_dashboard_for(@team, @duration)
+    xlsx = DashboardExportService.new(@dashboard, @team, @duration).generate
+    filename = "dashboard-#{@team.name.parameterize}-#{Date.today}.xlsx"
+    send_data xlsx, filename:, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  end
+
+  def export_member
+    authorize :dashboard
+    @member = User.where(team_id: @team.team_hierarchy_ids).find(params[:user_id])
+    @dashboard = DashboardService.instance.build_dashboard_for(@team, @duration)
+    member_data = @dashboard.team_member_data(@member)
+    xlsx = MemberExportService.new(@member, member_data, @dashboard, @team).generate
+    filename = "member-#{@member.display_name.parameterize}-#{Date.today}.xlsx"
+    send_data xlsx, filename:, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
   end
 
   def nudge_all
@@ -50,6 +69,7 @@ class DashboardsController < ApplicationController
                      Enrollment
                        .joins(:user)
                        .where(users: { team_id: @team.team_hierarchy_ids })
+                       .where.not(users: { role: [User::ADMIN, User::SUPPORT] })
                        .where(course_id: params[:course_id], course_completed: false)
                        .includes(:user, :course)
                    else

--- a/app/javascript/controllers/download_controller.js
+++ b/app/javascript/controllers/download_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Prevents double-clicks on file download links by disabling the link
+// for a short window after the first click, then re-enabling it.
+export default class extends Controller {
+  static values = { cooldown: { type: Number, default: 6000 } }
+
+  start(event) {
+    if (this.#busy) {
+      event.preventDefault()
+      return
+    }
+
+    this.#busy = true
+    this.element.classList.add("pointer-events-none", "opacity-50")
+
+    this.#timer = setTimeout(() => this.#reset(), this.cooldownValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.#timer)
+  }
+
+  #busy = false
+  #timer = null
+
+  #reset() {
+    this.#busy = false
+    this.element.classList.remove("pointer-events-none", "opacity-50")
+  }
+}

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -39,4 +39,12 @@ class DashboardPolicy
   def appreciate_member?
     index?
   end
+
+  def export?
+    index?
+  end
+
+  def export_member?
+    index?
+  end
 end

--- a/app/services/dashboard_export_service.rb
+++ b/app/services/dashboard_export_service.rb
@@ -3,9 +3,8 @@
 require 'caxlsx'
 
 class DashboardExportService
-  HEADER_COLOR     = '1F3A5F'
-  HEADER_FG        = 'FFFFFF'
-  WIDEST_GAP_COLOR = 'FFF3CD'
+  include Exports::SpreadsheetHelpers
+
   MAX_ROWS = 1000
 
   def initialize(dashboard, team, duration)
@@ -34,34 +33,13 @@ class DashboardExportService
 
   private
 
-  def duration_label
-    range = @dashboard.duration
-    from  = range.begin.strftime('%d %b %Y')
-    to    = range.end.strftime('%d %b %Y')
-    "#{from} – #{to}"
-  end
-
-  def delta_label(value)
-    return 'No change' if value.zero?
-
-    value.positive? ? "+#{value}" : value.to_s
-  end
-
-  def format_seconds(seconds)
-    return '0m' if seconds.zero?
-
-    hours   = seconds / 3600
-    minutes = (seconds % 3600) / 60
-    hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
-  end
-
   # ─── Sheet 1: Summary ────────────────────────────────────────────────────
 
   def add_summary_sheet(wbk, header_style)
     wbk.add_worksheet(name: 'Summary') do |sheet|
       sheet.add_row ['Dashboard Export Report'], b: true, sz: 14
       sheet.add_row ['Team', @team.name]
-      sheet.add_row ['Period', duration_label]
+      sheet.add_row ['Period', duration_label(@dashboard.duration)]
       sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
       sheet.add_row []
       sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style

--- a/app/services/dashboard_export_service.rb
+++ b/app/services/dashboard_export_service.rb
@@ -64,28 +64,8 @@ class DashboardExportService
       sheet.add_row ['Period', duration_label]
       sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
       sheet.add_row []
-
       sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style
-
-      sheet.add_row ['Active Learners',
-                     @dashboard.active_learners_count,
-                     delta_label(@dashboard.active_learners_delta)]
-
-      sheet.add_row ['Completion %',
-                     "#{@dashboard.completion_percent_metric}%",
-                     delta_label(@dashboard.completion_percent_delta)]
-
-      sheet.add_row ['Avg Time Spent',
-                     format_seconds(@dashboard.average_time_spent_metric),
-                     delta_label(@dashboard.average_time_spent_delta)]
-
-      sheet.add_row ['Certificates Earned',
-                     @dashboard.certificates_count,
-                     delta_label(@dashboard.certificates_delta)]
-
-      sheet.add_row ['Active Courses', @dashboard.active_course_count_metric, '—']
-      sheet.add_row ['Learners Falling Behind', @dashboard.falling_behind_count, '—']
-
+      summary_metric_rows.each { |row| sheet.add_row row }
       sheet.column_widths 35, 25, 30
     end
   end
@@ -224,6 +204,17 @@ class DashboardExportService
         sheet.column_widths 30, 25, 45, 14, 14, 18
       end
     end
+  end
+
+  def summary_metric_rows
+    [
+      ['Active Learners', @dashboard.active_learners_count, delta_label(@dashboard.active_learners_delta)],
+      ['Completion %', "#{@dashboard.completion_percent_metric}%", delta_label(@dashboard.completion_percent_delta)],
+      ['Avg Time Spent', format_seconds(@dashboard.average_time_spent_metric), delta_label(@dashboard.average_time_spent_delta)],
+      ['Certificates Earned', @dashboard.certificates_count, delta_label(@dashboard.certificates_delta)],
+      ['Active Courses', @dashboard.active_course_count_metric, '—'],
+      ['Learners Falling Behind', @dashboard.falling_behind_count, '—']
+    ]
   end
 
   def activity_row(item)

--- a/app/services/dashboard_export_service.rb
+++ b/app/services/dashboard_export_service.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'caxlsx'
+
+class DashboardExportService
+  HEADER_COLOR     = '1F3A5F'
+  HEADER_FG        = 'FFFFFF'
+  WIDEST_GAP_COLOR = 'FFF3CD'
+  MAX_ROWS = 1000
+
+  def initialize(dashboard, team, duration)
+    @dashboard = dashboard
+    @team      = team
+    @duration  = duration
+  end
+
+  def generate
+    package = Axlsx::Package.new
+    wbk = package.workbook
+
+    header_style    = wbk.styles.add_style(bg_color: HEADER_COLOR, fg_color: HEADER_FG, b: true, sz: 11)
+    highlight_style = wbk.styles.add_style(bg_color: WIDEST_GAP_COLOR)
+
+    add_summary_sheet(wbk, header_style)
+    add_engagement_sheet(wbk, header_style)
+    add_started_vs_completed_sheet(wbk, header_style, highlight_style)
+    add_recent_activity_sheet(wbk, header_style)
+    add_team_members_sheet(wbk, header_style)
+    add_sub_teams_sheet(wbk, header_style)
+    add_self_assigned_sheet(wbk, header_style)
+
+    package.to_stream.read
+  end
+
+  private
+
+  def duration_label
+    range = @dashboard.duration
+    from  = range.begin.strftime('%d %b %Y')
+    to    = range.end.strftime('%d %b %Y')
+    "#{from} – #{to}"
+  end
+
+  def delta_label(value)
+    return 'No change' if value.zero?
+
+    value.positive? ? "+#{value}" : value.to_s
+  end
+
+  def format_seconds(seconds)
+    return '0m' if seconds.zero?
+
+    hours   = seconds / 3600
+    minutes = (seconds % 3600) / 60
+    hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
+  end
+
+  # ─── Sheet 1: Summary ────────────────────────────────────────────────────
+
+  def add_summary_sheet(wbk, header_style)
+    wbk.add_worksheet(name: 'Summary') do |sheet|
+      sheet.add_row ['Dashboard Export Report'], b: true, sz: 14
+      sheet.add_row ['Team', @team.name]
+      sheet.add_row ['Period', duration_label]
+      sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
+      sheet.add_row []
+
+      sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style
+
+      sheet.add_row ['Active Learners',
+                     @dashboard.active_learners_count,
+                     delta_label(@dashboard.active_learners_delta)]
+
+      sheet.add_row ['Completion %',
+                     "#{@dashboard.completion_percent_metric}%",
+                     delta_label(@dashboard.completion_percent_delta)]
+
+      sheet.add_row ['Avg Time Spent',
+                     format_seconds(@dashboard.average_time_spent_metric),
+                     delta_label(@dashboard.average_time_spent_delta)]
+
+      sheet.add_row ['Certificates Earned',
+                     @dashboard.certificates_count,
+                     delta_label(@dashboard.certificates_delta)]
+
+      sheet.add_row ['Active Courses', @dashboard.active_course_count_metric, '—']
+      sheet.add_row ['Learners Falling Behind', @dashboard.falling_behind_count, '—']
+
+      sheet.column_widths 35, 25, 30
+    end
+  end
+
+  # ─── Sheet 2: Daily Engagement ───────────────────────────────────────────
+
+  def add_engagement_sheet(wbk, header_style)
+    series = @dashboard.time_spent_series
+
+    wbk.add_worksheet(name: 'Daily Engagement') do |sheet|
+      sheet.add_row ['Date', 'Minutes Spent'], style: header_style
+
+      series.each do |date_key, minutes|
+        sheet.add_row [date_key, minutes]
+      end
+
+      peak_date = series.max_by { |_, v| v }
+      if peak_date
+        sheet.add_row []
+        sheet.add_row ['Peak Day', peak_date[0], "#{peak_date[1]} minutes"]
+      end
+
+      sheet.column_widths 20, 20
+    end
+  end
+
+  # ─── Sheet 3: Started vs Completed ───────────────────────────────────────
+
+  def add_started_vs_completed_sheet(wbk, header_style, highlight_style)
+    widest_gap  = @dashboard.widest_gap_courses
+    widest_ids  = widest_gap.to_set { |item| item[:course].id }
+    all_courses = @dashboard.all_started_vs_completed(1, exclude_ids: []).per(MAX_ROWS)
+
+    wbk.add_worksheet(name: 'Started vs Completed') do |sheet|
+      sheet.add_row ['* Highlighted rows have the widest gap between started and completed'], i: true
+      sheet.add_row ['Course', 'Total Enrollments', 'Started (period)',
+                     'Completed (period)', 'Started %', 'Completed %',
+                     'Last Activity', 'Widest Gap?'], style: header_style
+
+      all_courses.each do |item|
+        is_gap = widest_ids.include?(item[:course].id)
+        row_options = is_gap ? { style: highlight_style } : {}
+        sheet.add_row [
+          item[:course].title,
+          item[:total],
+          item[:started],
+          item[:completed],
+          "#{item[:started_percent]}%",
+          "#{item[:completed_percent]}%",
+          item[:last_activity_at]&.strftime('%d %b %Y') || '—',
+          is_gap ? 'Yes' : 'No'
+        ], **row_options
+      end
+
+      sheet.column_widths 40, 20, 20, 20, 14, 14, 20, 14
+    end
+  end
+
+  # ─── Sheet 4: Recent Activity ─────────────────────────────────────────────
+
+  def add_recent_activity_sheet(wbk, header_style)
+    activities = @dashboard.all_recent_activity(1).per(MAX_ROWS)
+
+    wbk.add_worksheet(name: 'Recent Activity') do |sheet|
+      sheet.add_row %w[Date User Team Activity Course], style: header_style
+      activities.each { |item| sheet.add_row activity_row(item) }
+      sheet.column_widths 22, 28, 28, 20, 40
+    end
+  end
+
+  # ─── Sheet 5: Team Members ────────────────────────────────────────────────
+
+  def add_team_members_sheet(wbk, header_style)
+    members = @dashboard.all_team_members_progress(1).per(MAX_ROWS)
+
+    wbk.add_worksheet(name: 'Team Members') do |sheet|
+      sheet.add_row ['Name', 'Team', 'Courses Assigned', 'Completed', 'Progress %'], style: header_style
+
+      members.each do |item|
+        sheet.add_row [
+          item[:user].display_name,
+          item[:team_name] || '—',
+          item[:courses],
+          item[:completed],
+          "#{item[:progress]}%"
+        ]
+      end
+
+      sheet.column_widths 30, 28, 20, 15, 15
+    end
+  end
+
+  # ─── Sheet 6: Sub-teams ───────────────────────────────────────────────────
+
+  def add_sub_teams_sheet(wbk, header_style)
+    sub_teams = @dashboard.sub_teams_progress
+
+    wbk.add_worksheet(name: 'Sub-teams') do |sheet|
+      if sub_teams.empty?
+        sheet.add_row ['No sub-teams found for this team.']
+      else
+        sheet.add_row ['Sub-team', 'Members', 'Progress %'], style: header_style
+
+        sub_teams.each do |item|
+          sheet.add_row [item[:name], item[:members_count], "#{item[:progress]}%"]
+        end
+
+        sheet.column_widths 30, 15, 15
+      end
+    end
+  end
+
+  # ─── Sheet 7: Self-Assigned Courses ──────────────────────────────────────
+
+  def add_self_assigned_sheet(wbk, header_style)
+    team_ids    = @team.team_hierarchy_ids
+    enrollments = Enrollment
+                  .joins(:user, :course)
+                  .where(users: { team_id: team_ids })
+                  .where(assigned_by_id: nil)
+                  .includes(course: :course_modules)
+                  .order(created_at: :desc)
+                  .first(MAX_ROWS)
+
+    users_by_id = User.includes(:team)
+                      .where(id: enrollments.map(&:user_id).uniq)
+                      .index_by(&:id)
+
+    wbk.add_worksheet(name: 'Self-Assigned') do |sheet|
+      if enrollments.empty?
+        sheet.add_row ['No self-assigned courses found for this team.']
+      else
+        sheet.add_row ['Learner', 'Team', 'Course', 'Progress %', 'Completed', 'Enrolled On'],
+                      style: header_style
+        enrollments.each { |e| sheet.add_row self_assigned_row(e, users_by_id) }
+        sheet.column_widths 30, 25, 45, 14, 14, 18
+      end
+    end
+  end
+
+  def activity_row(item)
+    [
+      item[:created_at].strftime('%d %b %Y %H:%M'),
+      item[:user]&.display_name || '—',
+      item[:user]&.team&.name || '—',
+      item[:action_text].capitalize,
+      item[:resource_name] || '—'
+    ]
+  end
+
+  def self_assigned_row(enrollment, users_by_id)
+    user = users_by_id[enrollment.user_id]
+    [
+      user&.display_name || '—',
+      user&.team&.name || '—',
+      enrollment.course.title,
+      "#{enrollment.progress}%",
+      enrollment.course_completed ? 'Yes' : 'No',
+      enrollment.created_at.strftime('%d %b %Y')
+    ]
+  end
+end

--- a/app/services/dashboard_export_service.rb
+++ b/app/services/dashboard_export_service.rb
@@ -210,7 +210,8 @@ class DashboardExportService
     [
       ['Active Learners', @dashboard.active_learners_count, delta_label(@dashboard.active_learners_delta)],
       ['Completion %', "#{@dashboard.completion_percent_metric}%", delta_label(@dashboard.completion_percent_delta)],
-      ['Avg Time Spent', format_seconds(@dashboard.average_time_spent_metric), delta_label(@dashboard.average_time_spent_delta)],
+      ['Avg Time Spent', format_seconds(@dashboard.average_time_spent_metric),
+       delta_label(@dashboard.average_time_spent_delta)],
       ['Certificates Earned', @dashboard.certificates_count, delta_label(@dashboard.certificates_delta)],
       ['Active Courses', @dashboard.active_course_count_metric, '—'],
       ['Learners Falling Behind', @dashboard.falling_behind_count, '—']

--- a/app/services/exports/spreadsheet_helpers.rb
+++ b/app/services/exports/spreadsheet_helpers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Exports
+  module SpreadsheetHelpers
+    tokens = JSON.parse(Rails.root.join('config/export_colors.json').read)
+
+    # caxlsx expects hex strings without the leading '#'
+    HEADER_COLOR     = tokens['export-header'].delete('#').freeze
+    HEADER_FG        = tokens['export-header-fg'].delete('#').freeze
+    WIDEST_GAP_COLOR = tokens['export-highlight'].delete('#').freeze
+
+    def duration_label(range)
+      "#{range.begin.strftime('%d %b %Y')} – #{range.end.strftime('%d %b %Y')}"
+    end
+
+    def delta_label(value)
+      return 'No change' if value.to_i.zero?
+
+      value.to_i.positive? ? "+#{value}" : value.to_s
+    end
+
+    def format_seconds(seconds)
+      return '0m' if seconds.to_i.zero?
+
+      hours   = seconds / 3600
+      minutes = (seconds % 3600) / 60
+      hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
+    end
+  end
+end

--- a/app/services/member_export_service.rb
+++ b/app/services/member_export_service.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'caxlsx'
+
+class MemberExportService
+  HEADER_COLOR = '1F3A5F'
+  HEADER_FG    = 'FFFFFF'
+
+  def initialize(member, member_data, dashboard, team)
+    @member      = member
+    @data        = member_data
+    @dashboard   = dashboard
+    @team        = team
+  end
+
+  def generate
+    package = Axlsx::Package.new
+    wbk = package.workbook
+    header_style = wbk.styles.add_style(bg_color: HEADER_COLOR, fg_color: HEADER_FG, b: true, sz: 11)
+
+    add_summary_sheet(wbk, header_style)
+    add_engagement_sheet(wbk, header_style)
+    add_course_progress_sheet(wbk, header_style)
+    add_quiz_sheet(wbk, header_style)
+    add_self_assigned_sheet(wbk, header_style)
+
+    package.to_stream.read
+  end
+
+  private
+
+  def duration_label
+    range = @dashboard.duration
+    "#{range.begin.strftime('%d %b %Y')} – #{range.end.strftime('%d %b %Y')}"
+  end
+
+  def delta_label(value)
+    return 'No change' if value.to_i.zero?
+
+    value.to_i.positive? ? "+#{value}" : value.to_s
+  end
+
+  def format_seconds(seconds)
+    return '0m' if seconds.to_i.zero?
+
+    hours   = seconds / 3600
+    minutes = (seconds % 3600) / 60
+    hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
+  end
+
+  # ─── Sheet 1: Summary ────────────────────────────────────────────────────
+
+  def add_summary_sheet(wbk, header_style)
+    wbk.add_worksheet(name: 'Summary') do |sheet|
+      sheet.add_row ['Member Export Report'], b: true, sz: 14
+      sheet.add_row ['Name',        @member.display_name]
+      sheet.add_row ['Team',        @member.team&.name || '—']
+      sheet.add_row ['Last Active', @member.last_sign_in_at&.strftime('%d %b %Y %H:%M') || '—']
+      sheet.add_row ['Period',      duration_label]
+      sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
+      sheet.add_row []
+
+      sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style
+
+      sheet.add_row ['Courses Enrolled',
+                     @data[:courses_count],
+                     delta_label(@data[:courses_delta])]
+
+      sheet.add_row ['Avg Completion %',
+                     "#{@data[:avg_completion_percent]}%",
+                     delta_label(@data[:avg_completion_delta])]
+
+      sheet.add_row ['Total Watch Time',
+                     format_seconds(@data[:total_watch_seconds].to_i),
+                     delta_label(@data[:watch_time_delta])]
+
+      sheet.add_row ['Certificates Earned',
+                     @data[:certificates_count].to_i,
+                     delta_label(@data[:certificates_delta])]
+
+      sheet.add_row ['Quiz Pass Rate',    "#{@data[:quiz_pass_rate]}%", '—']
+      sheet.add_row ['Quizzes Passed',    "#{@data[:quizzes_passed]}/#{@data[:total_quizzes]}", '—']
+      sheet.add_row ['Self-Assigned Courses', @data[:self_assigned_count].to_i, '—']
+
+      sheet.column_widths 35, 25, 30
+    end
+  end
+
+  # ─── Sheet 2: Daily Engagement ───────────────────────────────────────────
+
+  def add_engagement_sheet(wbk, header_style)
+    series = @data[:engagement_series] || {}
+
+    wbk.add_worksheet(name: 'Daily Engagement') do |sheet|
+      sheet.add_row ['Date', 'Hours Watched'], style: header_style
+
+      series.each do |date_key, hours|
+        sheet.add_row [date_key, hours]
+      end
+
+      peak = series.max_by { |_, v| v }
+      if peak
+        sheet.add_row []
+        sheet.add_row ['Peak Day', peak[0], "#{peak[1]} hrs"]
+      end
+
+      sheet.column_widths 22, 20
+    end
+  end
+
+  # ─── Sheet 3: Course Progress ─────────────────────────────────────────────
+
+  def add_course_progress_sheet(wbk, header_style)
+    enrollments = Enrollment.includes(:course)
+                            .where(user: @member)
+                            .order(created_at: :desc)
+
+    wbk.add_worksheet(name: 'Course Progress') do |sheet|
+      sheet.add_row ['Course', 'Progress %', 'Completed', 'Enrolled On'], style: header_style
+      enrollments.each { |e| sheet.add_row course_progress_row(e) }
+      sheet.column_widths 45, 14, 14, 18
+    end
+  end
+
+  # ─── Sheet 4: Quiz Performance ────────────────────────────────────────────
+
+  def add_quiz_sheet(wbk, header_style)
+    wbk.add_worksheet(name: 'Quiz Performance') do |sheet|
+      sheet.add_row %w[Metric Value], style: header_style
+      sheet.add_row ['Quizzes Passed', @data[:quizzes_passed]]
+      sheet.add_row ['Total Quizzes',  @data[:total_quizzes]]
+      sheet.add_row ['Pass Rate',      "#{@data[:quiz_pass_rate]}%"]
+
+      sheet.column_widths 30, 20
+    end
+  end
+
+  # ─── Sheet 5: Self-Assigned Courses ──────────────────────────────────────
+
+  def add_self_assigned_sheet(wbk, header_style)
+    enrollments = Enrollment.includes(:course)
+                            .where(user: @member, assigned_by_id: nil)
+                            .order(created_at: :desc)
+
+    wbk.add_worksheet(name: 'Self-Assigned') do |sheet|
+      sheet.add_row ['Course', 'Progress %', 'Completed', 'Enrolled On'], style: header_style
+
+      if enrollments.any?
+        enrollments.each { |e| sheet.add_row course_progress_row(e) }
+      else
+        sheet.add_row ['No self-assigned courses found.']
+      end
+
+      sheet.column_widths 45, 14, 14, 18
+    end
+  end
+
+  def course_progress_row(enrollment)
+    [
+      enrollment.course.title,
+      "#{enrollment.progress}%",
+      enrollment.course_completed ? 'Yes' : 'No',
+      enrollment.created_at.strftime('%d %b %Y')
+    ]
+  end
+end

--- a/app/services/member_export_service.rb
+++ b/app/services/member_export_service.rb
@@ -3,8 +3,7 @@
 require 'caxlsx'
 
 class MemberExportService
-  HEADER_COLOR = '1F3A5F'
-  HEADER_FG    = 'FFFFFF'
+  include Exports::SpreadsheetHelpers
 
   def initialize(member, member_data, dashboard, team)
     @member      = member
@@ -29,25 +28,6 @@ class MemberExportService
 
   private
 
-  def duration_label
-    range = @dashboard.duration
-    "#{range.begin.strftime('%d %b %Y')} – #{range.end.strftime('%d %b %Y')}"
-  end
-
-  def delta_label(value)
-    return 'No change' if value.to_i.zero?
-
-    value.to_i.positive? ? "+#{value}" : value.to_s
-  end
-
-  def format_seconds(seconds)
-    return '0m' if seconds.to_i.zero?
-
-    hours   = seconds / 3600
-    minutes = (seconds % 3600) / 60
-    hours.positive? ? "#{hours}h #{minutes}m" : "#{minutes}m"
-  end
-
   # ─── Sheet 1: Summary ────────────────────────────────────────────────────
 
   def add_summary_sheet(wbk, header_style)
@@ -56,7 +36,7 @@ class MemberExportService
       sheet.add_row ['Name',        @member.display_name]
       sheet.add_row ['Team',        @member.team&.name || '—']
       sheet.add_row ['Last Active', @member.last_sign_in_at&.strftime('%d %b %Y %H:%M') || '—']
-      sheet.add_row ['Period',      duration_label]
+      sheet.add_row ['Period',      duration_label(@dashboard.duration)]
       sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
       sheet.add_row []
       sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style

--- a/app/services/member_export_service.rb
+++ b/app/services/member_export_service.rb
@@ -59,29 +59,8 @@ class MemberExportService
       sheet.add_row ['Period',      duration_label]
       sheet.add_row ['Generated at', Time.zone.now.strftime('%d %b %Y %H:%M')]
       sheet.add_row []
-
       sheet.add_row ['Metric', 'Value', 'Change vs Previous Period'], style: header_style
-
-      sheet.add_row ['Courses Enrolled',
-                     @data[:courses_count],
-                     delta_label(@data[:courses_delta])]
-
-      sheet.add_row ['Avg Completion %',
-                     "#{@data[:avg_completion_percent]}%",
-                     delta_label(@data[:avg_completion_delta])]
-
-      sheet.add_row ['Total Watch Time',
-                     format_seconds(@data[:total_watch_seconds].to_i),
-                     delta_label(@data[:watch_time_delta])]
-
-      sheet.add_row ['Certificates Earned',
-                     @data[:certificates_count].to_i,
-                     delta_label(@data[:certificates_delta])]
-
-      sheet.add_row ['Quiz Pass Rate',    "#{@data[:quiz_pass_rate]}%", '—']
-      sheet.add_row ['Quizzes Passed',    "#{@data[:quizzes_passed]}/#{@data[:total_quizzes]}", '—']
-      sheet.add_row ['Self-Assigned Courses', @data[:self_assigned_count].to_i, '—']
-
+      summary_metric_rows.each { |row| sheet.add_row row }
       sheet.column_widths 35, 25, 30
     end
   end
@@ -153,6 +132,19 @@ class MemberExportService
 
       sheet.column_widths 45, 14, 14, 18
     end
+  end
+
+  def summary_metric_rows
+    [
+      ['Courses Enrolled',      @data[:courses_count], delta_label(@data[:courses_delta])],
+      ['Avg Completion %',      "#{@data[:avg_completion_percent]}%", delta_label(@data[:avg_completion_delta])],
+      ['Total Watch Time',      format_seconds(@data[:total_watch_seconds].to_i),
+       delta_label(@data[:watch_time_delta])],
+      ['Certificates Earned',   @data[:certificates_count].to_i, delta_label(@data[:certificates_delta])],
+      ['Quiz Pass Rate',        "#{@data[:quiz_pass_rate]}%", '—'],
+      ['Quizzes Passed',        "#{@data[:quizzes_passed]}/#{@data[:total_quizzes]}", '—'],
+      ['Self-Assigned Courses', @data[:self_assigned_count].to_i, '—']
+    ]
   end
 
   def course_progress_row(enrollment)

--- a/app/value_objects/concerns/dashboard_activity.rb
+++ b/app/value_objects/concerns/dashboard_activity.rb
@@ -62,41 +62,45 @@ module DashboardActivity
   end
 
   def upcoming_deadlines
-    Enrollment
-      .joins(:user, :course)
-      .where(users: { team_id: team_and_subteam_ids(@team) })
-      .where(course_completed: false)
-      .where(deadline_at: Time.current.beginning_of_day..5.days.from_now.end_of_day)
-      .includes(:user, :course)
-      .order(:deadline_at)
-      .group_by(&:course)
-      .map do |course, enrollments|
-        {
-          course:,
-          deadline_at: enrollments.first.deadline_at,
-          incomplete_count: enrollments.count,
-          days_left: (enrollments.first.deadline_at.to_date - Date.current).to_i
-        }
-      end
+    enrollments = Enrollment
+                  .joins(:user, :course)
+                  .where(users: { team_id: team_and_subteam_ids(@team) })
+                  .where(course_completed: false)
+                  .where(deadline_at: Time.current.beginning_of_day..5.days.from_now.end_of_day)
+                  .order(:deadline_at)
+                  .to_a
+
+    courses_by_id = Course.where(id: enrollments.map(&:course_id).uniq).index_by(&:id)
+
+    enrollments.group_by(&:course_id).map do |course_id, ces|
+      {
+        course: courses_by_id[course_id],
+        deadline_at: ces.first.deadline_at,
+        incomplete_count: ces.count,
+        days_left: (ces.first.deadline_at.to_date - Date.current).to_i
+      }
+    end
   end
 
   def overdue_deadlines
-    Enrollment
-      .joins(:user, :course)
-      .where(users: { team_id: team_and_subteam_ids(@team) })
-      .where(course_completed: false)
-      .where('deadline_at IS NOT NULL AND deadline_at < ?', Time.current.beginning_of_day)
-      .includes(:user, :course)
-      .order(:deadline_at)
-      .group_by(&:course)
-      .map do |course, enrollments|
-        {
-          course:,
-          deadline_at: enrollments.first.deadline_at,
-          incomplete_count: enrollments.count,
-          days_overdue: (Date.current - enrollments.first.deadline_at.to_date).to_i
-        }
-      end
+    enrollments = Enrollment
+                  .joins(:user, :course)
+                  .where(users: { team_id: team_and_subteam_ids(@team) })
+                  .where(course_completed: false)
+                  .where('deadline_at IS NOT NULL AND deadline_at < ?', Time.current.beginning_of_day)
+                  .order(:deadline_at)
+                  .to_a
+
+    courses_by_id = Course.where(id: enrollments.map(&:course_id).uniq).index_by(&:id)
+
+    enrollments.group_by(&:course_id).map do |course_id, ces|
+      {
+        course: courses_by_id[course_id],
+        deadline_at: ces.first.deadline_at,
+        incomplete_count: ces.count,
+        days_overdue: (Date.current - ces.first.deadline_at.to_date).to_i
+      }
+    end
   end
 
   def self_assigned_enrollments
@@ -113,12 +117,16 @@ module DashboardActivity
 
   def course_enrollment_data
     @course_enrollment_data ||= Rails.cache.fetch("#{base_cache_key}/course_enrollment_data", expires_in: 5.minutes) do
-      Enrollment
-        .joins(:user, :course)
-        .where(users: { team_id: team_and_subteam_ids(@team) })
-        .includes(:course)
-        .group_by(&:course)
-        .map { |course, ces| enrollment_row(course, ces) }
+      enrollments = Enrollment
+                    .joins(:user, :course)
+                    .where(users: { team_id: team_and_subteam_ids(@team) })
+                    .to_a
+
+      courses_by_id = Course.where(id: enrollments.map(&:course_id).uniq).index_by(&:id)
+
+      enrollments.group_by(&:course_id).map do |course_id, ces|
+        enrollment_row(courses_by_id[course_id], ces)
+      end
     end
   end
 

--- a/app/value_objects/concerns/dashboard_team.rb
+++ b/app/value_objects/concerns/dashboard_team.rb
@@ -7,8 +7,8 @@ module DashboardTeam
                             expires_in: 5.minutes) do
       users = User
               .where(team_id: team_and_subteam_ids(@team))
-              .where(role: User::LEARNER)
-              .active
+              .where.not(role: User::SUPPORT)
+              .skip_deactivated
               .includes(:enrollments, :team)
       users = users.where('name ILIKE ?', "%#{query}%") if query.present?
 
@@ -17,11 +17,11 @@ module DashboardTeam
         total = enrollments.length
         completed = enrollments.count(&:course_completed)
         progress = calculate_progress(total, completed)
-        { user:, courses: total, completed:, progress: }
+        { user:, team_name: user.team&.name, courses: total, completed:, progress: }
       end
     end
 
-    Kaminari.paginate_array(all, total_count: all.size).page(page).per(20)
+    Kaminari.paginate_array(all, total_count: all.size).page(page).per(10)
   end
 
   def team_member_data(user)
@@ -39,8 +39,8 @@ module DashboardTeam
   def team_member_status_counts
     all = Rails.cache.fetch("#{base_cache_key}/team_members_progress/", expires_in: 5.minutes) do
       User.where(team_id: team_and_subteam_ids(@team))
-          .where(role: User::LEARNER)
-          .active
+          .where.not(role: User::SUPPORT)
+          .skip_deactivated
           .includes(:enrollments)
           .map do |user|
             enrollments = user.enrollments.to_a
@@ -59,8 +59,8 @@ module DashboardTeam
   def team_members_progress
     User
       .where(team_id: team_and_subteam_ids(@team))
-      .where(role: User::LEARNER)
-      .active
+      .where.not(role: User::SUPPORT)
+      .skip_deactivated
       .includes(:enrollments, :team)
       .limit(4)
       .map do |user|
@@ -80,16 +80,17 @@ module DashboardTeam
 
     total_by_team = Enrollment
                     .joins(:user)
-                    .where(users: { team_id: sub_team_ids, role: User::LEARNER })
-                    .merge(User.active)
+                    .where(users: { team_id: sub_team_ids })
+                    .where.not(users: { role: User::SUPPORT })
+                    .merge(User.skip_deactivated)
                     .group('users.team_id')
                     .count
 
     completed_by_team = Enrollment
                         .joins(:user)
-                        .where(users: { team_id: sub_team_ids, role: User::LEARNER },
-                               course_completed: true)
-                        .merge(User.active)
+                        .where(users: { team_id: sub_team_ids }, course_completed: true)
+                        .where.not(users: { role: User::SUPPORT })
+                        .merge(User.skip_deactivated)
                         .group('users.team_id')
                         .count
 

--- a/app/value_objects/dashboard.rb
+++ b/app/value_objects/dashboard.rb
@@ -99,7 +99,7 @@ class Dashboard
     Enrollment
       .joins(:user)
       .where(users: { team_id: @team.team_hierarchy_ids })
-      .where.not(users: { role: [User::ADMIN, User::SUPPORT] })
+      .where.not(users: { role: User::SUPPORT })
       .where(course_completed: false)
       .where('deadline_at IS NOT NULL AND deadline_at < ?', 7.days.from_now)
       .includes(:user, :course)

--- a/app/value_objects/dashboard.rb
+++ b/app/value_objects/dashboard.rb
@@ -99,6 +99,7 @@ class Dashboard
     Enrollment
       .joins(:user)
       .where(users: { team_id: @team.team_hierarchy_ids })
+      .where.not(users: { role: [User::ADMIN, User::SUPPORT] })
       .where(course_completed: false)
       .where('deadline_at IS NOT NULL AND deadline_at < ?', 7.days.from_now)
       .includes(:user, :course)

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,6 +19,9 @@
       value: duration_select_value(@team),
       html_options: duration_select_html_options
     ) %>
+    <%= link_to export_dashboards_path(team_id: @team.id, duration: params[:duration], from_date: params[:from_date], to_date: params[:to_date]) do %>
+      <%= button_component(text: "Export", icon_name: "arrow-down-tray", type: "outline", icon_position: "left") %>
+    <% end %>
   </div>
 </div>
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,7 +19,8 @@
       value: duration_select_value(@team),
       html_options: duration_select_html_options
     ) %>
-    <%= link_to export_dashboards_path(team_id: @team.id, duration: params[:duration], from_date: params[:from_date], to_date: params[:to_date]) do %>
+    <%= link_to export_dashboards_path(team_id: @team.id, duration: params[:duration], from_date: params[:from_date], to_date: params[:to_date]),
+             data: { controller: "download", action: "click->download#start" } do %>
       <%= button_component(text: "Export", icon_name: "arrow-down-tray", type: "outline", icon_position: "left") %>
     <% end %>
   </div>

--- a/app/views/dashboards/recent_activity.html.erb
+++ b/app/views/dashboards/recent_activity.html.erb
@@ -19,38 +19,39 @@
     <p class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.recent_activity.new_starts") %></p>
   </div>
 </div>
-
-<div class="bg-white border border-line-colour-light rounded-xl px-5 md:max-w-[760px]">
-  <% @activities.each do |activity| %>
-    <div class="flex items-start justify-between py-4 border-b border-line-colour-light last:border-b-0">
-      <div class="flex items-start gap-3">
-        <div class="w-3 h-3 rounded-full mt-1 flex-none flex items-center justify-center
-          <%= activity[:type] == 'completed' ? 'bg-secondary-light' :
-              activity[:type] == 'certificate' ? 'bg-gold-light' : 'bg-primary-light-50' %>">
-          <div class="w-1.5 h-1.5 rounded-full
-            <%= activity[:type] == 'completed' ? 'bg-secondary' :
-                activity[:type] == 'certificate' ? 'bg-gold' : 'bg-primary' %>">
+<div class="flex justify-center">
+  <div class="bg-white border border-line-colour-light rounded-xl px-5 md:w-[760px]">
+    <% @activities.each do |activity| %>
+      <div class="flex items-start justify-between py-4 border-b border-line-colour-light last:border-b-0">
+        <div class="flex items-start gap-3">
+          <div class="w-3 h-3 rounded-full mt-1 flex-none flex items-center justify-center
+            <%= activity[:type] == 'completed' ? 'bg-secondary-light' :
+                activity[:type] == 'certificate' ? 'bg-gold-light' : 'bg-primary-light-50' %>">
+            <div class="w-1.5 h-1.5 rounded-full
+              <%= activity[:type] == 'completed' ? 'bg-secondary' :
+                  activity[:type] == 'certificate' ? 'bg-gold' : 'bg-primary' %>">
+            </div>
+          </div>
+          <div>
+            <p class="general-text-sm-normal">
+              <span class="main-text-sm-medium"><%= activity[:user]&.display_name %></span>
+              <%= activity[:action_text] %>
+            </p>
+            <p class="general-text-sm-normal text-letter-color-light"><%= activity[:resource_name] %></p>
+            <p class="general-text-xs-normal text-letter-color-light mt-0.5"><%= time_ago_in_words(activity[:created_at]) %> ago</p>
           </div>
         </div>
-        <div>
-          <p class="general-text-sm-normal">
-            <span class="main-text-sm-medium"><%= activity[:user]&.display_name %></span>
-            <%= activity[:action_text] %>
-          </p>
-          <p class="general-text-sm-normal text-letter-color-light"><%= activity[:resource_name] %></p>
-          <p class="general-text-xs-normal text-letter-color-light mt-0.5"><%= time_ago_in_words(activity[:created_at]) %> ago</p>
-        </div>
-      </div>
-      <% if activity[:type] == 'certificate' && activity[:user].present? %>
-        <%= link_to appreciate_member_dashboards_path(user_id: activity[:user].id, banner_type: 'crushing_it'),
-            data: { turbo_frame: 'modal' },
-            class: "flex items-center gap-1 text-primary general-text-sm-normal flex-none" do %>
-          <%= icon("chat-bubble-bottom-center-text", css: "h-4 w-4") %>
-          <span class="main-text-sm-normal"><%= t("dashboard.actions.congrats") %></span>
+        <% if activity[:type] == 'certificate' && activity[:user].present? %>
+          <%= link_to appreciate_member_dashboards_path(user_id: activity[:user].id, banner_type: 'crushing_it'),
+              data: { turbo_frame: 'modal' },
+              class: "flex items-center gap-1 text-primary general-text-sm-normal flex-none" do %>
+            <%= icon("chat-bubble-bottom-center-text", css: "h-4 w-4") %>
+            <span class="main-text-sm-normal"><%= t("dashboard.actions.congrats") %></span>
+          <% end %>
         <% end %>
-      <% end %>
-    </div>
-  <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>
 
 <div class="flex justify-end gap-3 mt-4">

--- a/app/views/dashboards/started_vs_completed.html.erb
+++ b/app/views/dashboards/started_vs_completed.html.erb
@@ -12,6 +12,7 @@
     </div>
   <% end %>
 </div>
+
 <div class="flex items-center justify-between my-6 px-1">
   <div class="flex justify-between gap-4 w-full">
     <div class="flex flex-row gap-3">
@@ -31,57 +32,60 @@
   </div>
 
 </div>
-
-<%= turbo_frame_tag "courses_results", data: { turbo_action: "advance" } do %>
-<% if @widest_gap_courses.any? %>
-  <div class="bg-gold-light rounded-xl p-5 mb-4">
-    <div class="flex items-center justify-center mb-3">
-      <h3 class="main-text-sm-medium text-letter-color-medium"><%= t("dashboard.started_vs_completed.widest_gap_title") %></h3>
-    </div>
-    <% @widest_gap_courses.each do |item| %>
-    <div class="flex justify-between gap-5 border-b border-line-colour-light last:border-b-0">
-      <div class="px-5 py-3 flex-1">
-        <div class="flex justify-between gap-2">
-          <p class="main-text-sm-medium line-clamp-1 mb-1"><%= item[:course].title %></p>
-          <span class="general-text-sm-normal w-8 text-right"><%= item[:completed] + item[:started] %>/<%= item[:total] %></span>
+<div class="flex justify-center">
+  <div class="md:w-[760px]">
+    <%= turbo_frame_tag "courses_results", data: { turbo_action: "advance" } do %>
+    <% if @widest_gap_courses.any? %>
+      <div class="bg-gold-light rounded-xl p-5 mb-4">
+        <div class="flex items-center justify-center mb-3">
+          <h3 class="main-text-sm-medium text-letter-color-medium"><%= t("dashboard.started_vs_completed.widest_gap_title") %></h3>
         </div>
-        <%= progressbar_component(segments: [
-            { value: item[:completed_percent], color: :secondary },
-            { value: item[:started_percent], color: :primary }
-          ]) %>
+        <% @widest_gap_courses.each do |item| %>
+        <div class="flex justify-between gap-5 border-b border-line-colour-light last:border-b-0">
+          <div class="px-5 py-3 flex-1">
+            <div class="flex justify-between gap-2">
+              <p class="main-text-sm-medium line-clamp-1 mb-1"><%= item[:course].title %></p>
+              <span class="general-text-sm-normal w-8 text-right"><%= item[:completed] + item[:started] %>/<%= item[:total] %></span>
+            </div>
+            <%= progressbar_component(segments: [
+                { value: item[:completed_percent], color: :secondary },
+                { value: item[:started_percent], color: :primary }
+              ]) %>
+          </div>
+          <%= link_to nudge_all_dashboards_path(course_id: item[:course].id, team_id: params[:team_id]), data: { turbo_frame: 'modal' }, class: "flex items-center gap-1 text-primary flex-none" do %>
+            <%= icon("chat-bubble-bottom-center-text", css: "h-4 w-4") %>
+            <span class="main-text-sm-normal"><%= t("dashboard.actions.nudge") %></span>
+          <% end %>
+        </div>
+        <% end %>
       </div>
-      <%= link_to nudge_all_dashboards_path(course_id: item[:course].id, team_id: params[:team_id]), data: { turbo_frame: 'modal' }, class: "flex items-center gap-1 text-primary flex-none" do %>
-        <%= icon("chat-bubble-bottom-center-text", css: "h-4 w-4") %>
-        <span class="main-text-sm-normal"><%= t("dashboard.actions.nudge") %></span>
+    <% end %>
+
+    <div class="bg-white rounded-xl border border-line-colour-light">
+      <% if @courses.any? %>
+        <div class="flex flex-col">
+          <% @courses.each do |item| %>
+            <div class="px-5 py-3 border-b border-line-colour-light last:border-b-0">
+              <div class="flex justify-between gap-2">
+                <p class="main-text-sm-medium line-clamp-1 mb-1"><%= item[:course].title %></p>
+                <span class="general-text-sm-normal w-8 text-right"><%= item[:completed] + item[:started] %>/<%= item[:total] %></span>
+              </div>
+              <%= progressbar_component(segments: [
+                { value: item[:completed_percent], color: :secondary },
+                { value: item[:started_percent], color: :primary }
+              ]) %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.started_vs_completed.empty") %></p>
       <% end %>
-     </div>
+    </div>
+
+    <div class="flex justify-end gap-3 mt-4">
+      <%= render 'shared/pagination/prev', items: @courses %>
+      <%= render 'shared/pagination/next', items: @courses %>
+    </div>
     <% end %>
   </div>
-<% end %>
-
-<div class="bg-white rounded-xl border border-line-colour-light">
-  <% if @courses.any? %>
-    <div class="flex flex-col">
-      <% @courses.each do |item| %>
-        <div class="px-5 py-3 border-b border-line-colour-light last:border-b-0">
-          <div class="flex justify-between gap-2">
-            <p class="main-text-sm-medium line-clamp-1 mb-1"><%= item[:course].title %></p>
-            <span class="general-text-sm-normal w-8 text-right"><%= item[:completed] + item[:started] %>/<%= item[:total] %></span>
-          </div>
-          <%= progressbar_component(segments: [
-            { value: item[:completed_percent], color: :secondary },
-            { value: item[:started_percent], color: :primary }
-          ]) %>
-        </div>
-      <% end %>
-    </div>
-  <% else %>
-    <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.started_vs_completed.empty") %></p>
-  <% end %>
 </div>
-
-<div class="flex justify-end gap-3 mt-4">
-  <%= render 'shared/pagination/prev', items: @courses %>
-  <%= render 'shared/pagination/next', items: @courses %>
-</div>
-<% end %>

--- a/app/views/dashboards/team_member_profile.html.erb
+++ b/app/views/dashboards/team_member_profile.html.erb
@@ -26,7 +26,8 @@
             duration: params[:duration],
             from_date: params[:from_date],
             to_date: params[:to_date]
-          ) do %>
+          ),
+          data: { controller: "download", action: "click->download#start" } do %>
         <%= button_component(text: 'Export', icon_name: 'arrow-down-tray', type: "outline", icon_position: 'left') %>
       <% end %>
     </div>

--- a/app/views/dashboards/team_member_profile.html.erb
+++ b/app/views/dashboards/team_member_profile.html.erb
@@ -13,13 +13,22 @@
         </p>
       </div>
     </div>
-    <div class="z-20">
+    <div class="z-20 flex items-center gap-2">
       <%= dropdown_component(
         name: "duration",
         options: duration_select_options(@team, member: @member, origin: safe_origin),
         value: duration_select_value(@team, member: @member, origin: safe_origin),
         html_options: duration_select_html_options
       ) %>
+      <%= link_to export_member_dashboards_path(
+            user_id: @member.id,
+            team_id: @team.id,
+            duration: params[:duration],
+            from_date: params[:from_date],
+            to_date: params[:to_date]
+          ) do %>
+        <%= button_component(text: 'Export', icon_name: 'arrow-down-tray', type: "outline", icon_position: 'left') %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/dashboards/team_progress.html.erb
+++ b/app/views/dashboards/team_progress.html.erb
@@ -34,92 +34,100 @@
     </div>
   <% end %>
 </div>
-
-<%= turbo_frame_tag "team_progress_results", data: { turbo_action: "advance" } do %>
-  <% if @tab == 'teams' %>
-    <div class="bg-white rounded-xl border border-line-colour-light">
-      <div class="grid grid-cols-3 px-5 py-3 border-b border-line-colour-light">
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.team") %></span>
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.members") %></span>
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.progress") %></span>
-      </div>
-      <div class="flex flex-col divide-y divide-line-colour-light">
-        <% if @sub_teams.any? %>
-          <% @sub_teams.each do |sub_team| %>
-            <%= link_to dashboard_path(team_id: sub_team[:id], duration: params[:duration]),
-                class: "block px-5",
-                data: { turbo_frame: "_top" } do %>
-              <div class="grid grid-cols-3 py-4 items-center">
-                <p class="main-text-sm-medium line-clamp-1"><%= sub_team[:name] %></p>
-                <span class="general-text-sm-normal"><%= t("dashboard.team_progress.members_count", count: sub_team[:members_count]) %></span>
-                <div class="flex items-center gap-3">
-                  <div class="flex-1 h-1.5 bg-primary-light-100 rounded-full">
-                    <div class="h-1.5 bg-primary rounded-full" style="width: <%= sub_team[:progress] %>%"></div>
-                  </div>
-                  <span class="general-text-xs-normal text-letter-color-light w-8"><%= sub_team[:progress] %>%</span>
-                </div>
-              </div>
-            <% end %>
-          <% end %>
-        <% else %>
-          <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.team_progress.no_teams_found") %></p>
-        <% end %>
-      </div>
-    </div>
-
-  <% else %>
-    <div class="bg-white rounded-xl border border-line-colour-light">
-      <div class="grid grid-cols-3 px-5 py-3 border-b border-line-colour-light">
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.member") %></span>
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.courses") %></span>
-        <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.progress") %></span>
-      </div>
-      <div class="flex flex-col divide-y divide-line-colour-light">
-        <% if @team_members.empty? %>
-          <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.team_progress.no_members_found", query: params[:query]) %></p>
-        <% end %>
-        <% @team_members.each do |member| %>
-          <%= link_to team_member_profile_dashboards_path(user_id: member[:user].id, origin: request.fullpath), class: "block", data: { turbo_frame: "_top" } do %>
-            <div class="grid grid-cols-3 px-5 py-4 items-center">
-              <div class="flex items-center gap-3">
-                <div class="w-8 h-8 rounded-full bg-primary-light-100 flex items-center justify-center flex-none">
-                  <span class="general-text-xs-normal text-primary font-medium">
-                    <%= member[:user].name.split.first(2).map { |n| n[0] }.join.upcase %>
-                  </span>
-                </div>
-                <div>
-                  <p class="main-text-sm-medium"><%= member[:user].display_name %></p>
-                  <p class="general-text-xs-normal text-letter-color-light"><%= member[:user].team&.name %></p>
-                </div>
-              </div>
-              <span class="general-text-sm-normal"><%= member[:completed] %>/<%= member[:courses] %></span>
-              <div class="flex items-center gap-3">
-                <div class="flex-1 h-1.5 bg-primary-light-100 rounded-full">
-                  <div class="h-1.5 rounded-full <%= member[:progress] == 100 ? 'bg-secondary' : member[:progress] < 20 ? 'bg-danger' : 'bg-primary' %>"
-                       style="width: <%= member[:progress] %>%"></div>
-                </div>
-                <span class="general-text-xs-normal text-letter-color-light w-8"><%= member[:progress] %>%</span>
-                <div class="w-14 flex items-center justify-center">
-                  <% if member[:progress] == 100 %>
-                    <%= icon("check-circle-solid", css: "h-5 w-5 text-secondary") %>
-                  <% elsif member[:progress] < 20 %>
-                    <div class="h-6 w-6 bg-primary-light-100 flex justify-center items-center rounded-full">
-                      <%= icon("chat-bubble-bottom-center-text", css: "h-3 w-3 text-primary") %>
+<div class="flex justify-center">
+  <div class="md:w-[760px]">
+    <%= turbo_frame_tag "team_progress_results", data: { turbo_action: "advance" } do %>
+      <% if @tab == 'teams' %>
+        <div class="bg-white rounded-xl border border-line-colour-light">
+          <div class="grid grid-cols-3 px-5 py-3 border-b border-line-colour-light">
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.team") %></span>
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.members") %></span>
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.progress") %></span>
+          </div>
+          <div class="flex flex-col divide-y divide-line-colour-light">
+            <% if @sub_teams.any? %>
+              <% @sub_teams.each do |sub_team| %>
+                <%= link_to dashboard_path(team_id: sub_team[:id], duration: params[:duration]),
+                    class: "block px-5",
+                    data: { turbo_frame: "_top" } do %>
+                  <div class="grid grid-cols-3 py-4 items-center">
+                    <p class="main-text-sm-medium line-clamp-1"><%= sub_team[:name] %></p>
+                    <span class="general-text-sm-normal"><%= t("dashboard.team_progress.members_count", count: sub_team[:members_count]) %></span>
+                    <div class="flex items-center gap-3">
+                      <div class="flex-1 h-1.5 bg-primary-light-100 rounded-full">
+                        <div class="h-1.5 bg-primary rounded-full" style="width: <%= sub_team[:progress] %>%"></div>
+                      </div>
+                      <span class="general-text-xs-normal text-letter-color-light w-8"><%= sub_team[:progress] %>%</span>
                     </div>
-                  <% else %>
-                    <%= icon("clock", css: "h-4 w-4 text-primary") %>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+                  </div>
+                <% end %>
+              <% end %>
+            <% else %>
+              <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.team_progress.no_teams_found") %></p>
+            <% end %>
+          </div>
+        </div>
 
-    <div class="flex justify-end gap-3 mt-4">
-      <%= render 'shared/pagination/prev', items: @team_members %>
-      <%= render 'shared/pagination/next', items: @team_members %>
-    </div>
-  <% end %>
-<% end %>
+        <div class="flex justify-end gap-3 mt-4">
+          <%= render 'shared/pagination/prev', items: @sub_teams %>
+          <%= render 'shared/pagination/next', items: @sub_teams %>
+        </div>
+
+      <% else %>
+        <div class="bg-white rounded-xl border border-line-colour-light">
+          <div class="grid grid-cols-3 px-5 py-3 border-b border-line-colour-light">
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.member") %></span>
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.courses") %></span>
+            <span class="general-text-sm-normal text-letter-color-light"><%= t("dashboard.team_progress.columns.progress") %></span>
+          </div>
+          <div class="flex flex-col divide-y divide-line-colour-light">
+            <% if @team_members.empty? %>
+              <p class="general-text-sm-normal text-letter-color-light text-center py-8"><%= t("dashboard.team_progress.no_members_found", query: params[:query]) %></p>
+            <% end %>
+            <% @team_members.each do |member| %>
+              <%= link_to team_member_profile_dashboards_path(user_id: member[:user].id, origin: request.fullpath), class: "block", data: { turbo_frame: "_top" } do %>
+                <div class="grid grid-cols-3 px-5 py-4 items-center">
+                  <div class="flex items-center gap-3">
+                    <div class="w-8 h-8 rounded-full bg-primary-light-100 flex items-center justify-center flex-none">
+                      <span class="general-text-xs-normal text-primary font-medium">
+                        <%= member[:user].name.split.first(2).map { |n| n[0] }.join.upcase %>
+                      </span>
+                    </div>
+                    <div>
+                      <p class="main-text-sm-medium"><%= member[:user].display_name %></p>
+                      <p class="general-text-xs-normal text-letter-color-light"><%= member[:team_name] %></p>
+                    </div>
+                  </div>
+                  <span class="general-text-sm-normal"><%= member[:completed] %>/<%= member[:courses] %></span>
+                  <div class="flex items-center gap-3">
+                    <div class="flex-1 h-1.5 bg-primary-light-100 rounded-full">
+                      <div class="h-1.5 rounded-full <%= member[:progress] == 100 ? 'bg-secondary' : member[:progress] < 20 ? 'bg-danger' : 'bg-primary' %>"
+                          style="width: <%= member[:progress] %>%"></div>
+                    </div>
+                    <span class="general-text-xs-normal text-letter-color-light w-8"><%= member[:progress] %>%</span>
+                    <div class="w-14 flex items-center justify-center">
+                      <% if member[:progress] == 100 %>
+                        <%= icon("check-circle-solid", css: "h-5 w-5 text-secondary") %>
+                      <% elsif member[:progress] < 20 %>
+                        <div class="h-6 w-6 bg-primary-light-100 flex justify-center items-center rounded-full">
+                          <%= icon("chat-bubble-bottom-center-text", css: "h-3 w-3 text-primary") %>
+                        </div>
+                      <% else %>
+                        <%= icon("clock", css: "h-4 w-4 text-primary") %>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-3 mt-4">
+          <%= render 'shared/pagination/prev', items: @team_members %>
+          <%= render 'shared/pagination/next', items: @team_members %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>      

--- a/app/views/shared/pagination/_next.html.erb
+++ b/app/views/shared/pagination/_next.html.erb
@@ -9,7 +9,7 @@
           ) %>
     <% end %>
   </div>
-<% else %>
+<% elsif items.total_pages > 1 %>
   <div class="w-fit hidden md:block">
     <%= button_component(
           text: 'Next',

--- a/app/views/shared/pagination/_prev.html.erb
+++ b/app/views/shared/pagination/_prev.html.erb
@@ -8,7 +8,7 @@
           ) %>
     <% end %>
   </div>
-<% else %>
+<% elsif items.total_pages > 1 %>
   <div class="w-fit hidden md:block">
     <%= button_component(
           text: 'Previous',

--- a/config/export_colors.json
+++ b/config/export_colors.json
@@ -1,0 +1,5 @@
+{
+  "export-header": "#1F3A5F",
+  "export-header-fg": "#FFFFFF",
+  "export-highlight": "#FFF3CD"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,8 @@ Rails.application.routes.draw do
       get  :team_member_profile
       get  :started_vs_completed
       get  :recent_activity
+      get  :export
+      get  :export_member
     end
   end
   resources :settings, only: :index

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,3 +1,5 @@
+const exportColors = require('./export_colors.json')
+
 module.exports = {
   content: [
     "./public/*.html",
@@ -43,7 +45,8 @@ module.exports = {
         "slate-grey-50":"#808285",
         "slate-grey-light":"#D1D3D4",
         "white":"#FFFFFF",
-        "white-light":"#FAFAFA"
+        "white-light":"#FAFAFA",
+        ...exportColors
       },
       borderRadius: {
         '4xl': '2rem',

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -82,4 +82,105 @@ RSpec.describe 'Dashboards', type: :request do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # GET #export
+  # ---------------------------------------------------------------------------
+  describe 'GET #export' do
+    let(:fake_xlsx) { 'fake-xlsx-binary' }
+    let(:mock_dashboard) { instance_double(Dashboard) }
+    let(:export_service) { instance_double(DashboardExportService, generate: fake_xlsx) }
+
+    before do
+      allow(DashboardService.instance).to receive(:build_dashboard_for).and_return(mock_dashboard)
+      allow(DashboardExportService).to receive(:new).and_return(export_service)
+    end
+
+    context 'when a manager requests the export' do
+      it 'responds with a successful xlsx download' do
+        get export_dashboards_path(team_id: team.id)
+        expect(response).to be_successful
+        expect(response.content_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      end
+
+      it 'sets a filename containing the team name and today\'s date' do
+        get export_dashboards_path(team_id: team.id)
+        disposition = response.headers['Content-Disposition']
+        expect(disposition).to include("dashboard-#{team.name.parameterize}")
+        expect(disposition).to include("#{Time.zone.today}.xlsx")
+      end
+
+      it 'delegates to DashboardExportService with the built dashboard' do
+        get export_dashboards_path(team_id: team.id)
+        expect(DashboardExportService).to have_received(:new).with(mock_dashboard, team, anything)
+        expect(export_service).to have_received(:generate)
+      end
+    end
+
+    context 'when a learner requests the export' do
+      before { sign_in learner }
+
+      it 'is unauthorized' do
+        get export_dashboards_path(team_id: team.id)
+        expect(flash[:notice]).to eq(I18n.t('pundit.unauthorized'))
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET #export_member
+  # ---------------------------------------------------------------------------
+  describe 'GET #export_member' do
+    let(:fake_xlsx) { 'fake-xlsx-binary' }
+    let(:mock_dashboard) { instance_double(Dashboard) }
+    let(:member_service) { instance_double(MemberExportService, generate: fake_xlsx) }
+    let(:member_data) { { courses_count: 2 } }
+
+    before do
+      allow(DashboardService.instance).to receive(:build_dashboard_for).and_return(mock_dashboard)
+      allow(mock_dashboard).to receive(:team_member_data).and_return(member_data)
+      allow(MemberExportService).to receive(:new).and_return(member_service)
+    end
+
+    context 'when a manager requests a member export' do
+      it 'responds with a successful xlsx download' do
+        get export_member_dashboards_path(team_id: team.id, user_id: learner.id)
+        expect(response).to be_successful
+        expect(response.content_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      end
+
+      it 'sets a filename containing the member name and today\'s date' do
+        get export_member_dashboards_path(team_id: team.id, user_id: learner.id)
+        disposition = response.headers['Content-Disposition']
+        expect(disposition).to include("member-#{learner.display_name.parameterize}")
+        expect(disposition).to include("#{Time.zone.today}.xlsx")
+      end
+
+      it 'delegates to MemberExportService with the member and their data' do
+        get export_member_dashboards_path(team_id: team.id, user_id: learner.id)
+        expect(MemberExportService).to have_received(:new).with(learner, member_data, mock_dashboard, team)
+        expect(member_service).to have_received(:generate)
+      end
+    end
+
+    context 'when the user_id does not belong to the manager\'s team hierarchy' do
+      let(:other_team)    { create(:team) }
+      let(:other_learner) { create(:user, :learner, t_team: other_team) }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect do
+          get export_member_dashboards_path(team_id: team.id, user_id: other_learner.id)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when a learner requests the export' do
+      before { sign_in learner }
+
+      it 'is unauthorized' do
+        get export_member_dashboards_path(team_id: team.id, user_id: learner.id)
+        expect(flash[:notice]).to eq(I18n.t('pundit.unauthorized'))
+      end
+    end
+  end
 end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -167,10 +167,9 @@ RSpec.describe 'Dashboards', type: :request do
       let(:other_team)    { create(:team) }
       let(:other_learner) { create(:user, :learner, t_team: other_team) }
 
-      it 'raises ActiveRecord::RecordNotFound' do
-        expect do
-          get export_member_dashboards_path(team_id: team.id, user_id: other_learner.id)
-        end.to raise_error(ActiveRecord::RecordNotFound)
+      it 'returns not found' do
+        get export_member_dashboards_path(team_id: team.id, user_id: other_learner.id)
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/services/dashboard_export_service_spec.rb
+++ b/spec/services/dashboard_export_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'zip'
+
+RSpec.describe DashboardExportService do
+  subject(:service) { described_class.new(dashboard, team, duration) }
+
+  let(:team)     { create(:team) }
+  let(:duration) { 30.days.ago.beginning_of_day..Time.zone.now.end_of_day }
+  let(:dashboard) { instance_double(Dashboard) }
+  let(:empty_page) { Enrollment.none.page(1) }
+
+  before do
+    allow(dashboard).to receive_messages(
+      duration: duration,
+      time_spent_series: {},
+      widest_gap_courses: [],
+      all_started_vs_completed: empty_page,
+      all_recent_activity: empty_page,
+      all_team_members_progress: empty_page,
+      sub_teams_progress: [],
+      active_learners_count: 10,
+      active_learners_delta: 2,
+      completion_percent_metric: 75,
+      completion_percent_delta: -5,
+      average_time_spent_metric: 3600,
+      average_time_spent_delta: 0,
+      certificates_count: 3,
+      certificates_delta: 1,
+      active_course_count_metric: 5,
+      falling_behind_count: 2
+    )
+  end
+
+  describe '#generate' do
+    it 'returns a non-empty binary string' do
+      result = service.generate
+      expect(result).to be_a(String).and be_present
+    end
+
+    it 'produces a valid xlsx (zip) file' do
+      expect(service.generate.bytes.first(2)).to eq([0x50, 0x4B])
+    end
+
+    it 'generates seven worksheets with the correct names' do
+      expect(worksheet_names(service.generate)).to eq(
+        ['Summary', 'Daily Engagement', 'Started vs Completed',
+         'Recent Activity', 'Team Members', 'Sub-teams', 'Self-Assigned']
+      )
+    end
+
+    it 'includes the team name in the summary sheet' do
+      binary = service.generate
+      Zip::File.open_buffer(binary) do |zip|
+        xml = zip.find_entry('xl/worksheets/sheet1.xml').get_input_stream.read
+        expect(xml).to include(team.name)
+      end
+    end
+
+    it 'includes the formatted period in the summary sheet' do
+      binary   = service.generate
+      expected = duration.begin.strftime('%d %b %Y')
+      Zip::File.open_buffer(binary) do |zip|
+        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
+        expect(shared_strings).to include(expected)
+      end
+    end
+  end
+
+  def worksheet_names(xlsx_binary)
+    Zip::File.open_buffer(xlsx_binary) do |zip|
+      content = zip.find_entry('xl/workbook.xml').get_input_stream.read
+      content.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+    end
+  end
+end

--- a/spec/services/dashboard_export_service_spec.rb
+++ b/spec/services/dashboard_export_service_spec.rb
@@ -51,27 +51,32 @@ RSpec.describe DashboardExportService do
     end
 
     it 'includes the team name in the summary sheet' do
-      binary = service.generate
-      Zip::File.open_buffer(binary) do |zip|
-        xml = zip.find_entry('xl/worksheets/sheet1.xml').get_input_stream.read
-        expect(xml).to include(team.name)
-      end
+      expect(sheet_xml(service.generate, 'xl/worksheets/sheet1.xml')).to include(team.name)
     end
 
     it 'includes the formatted period in the summary sheet' do
-      binary   = service.generate
       expected = duration.begin.strftime('%d %b %Y')
-      Zip::File.open_buffer(binary) do |zip|
-        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
-        expect(shared_strings).to include(expected)
-      end
+      expect(sheet_xml(service.generate, 'xl/worksheets/sheet1.xml')).to include(expected)
     end
   end
 
   def worksheet_names(xlsx_binary)
-    Zip::File.open_buffer(xlsx_binary) do |zip|
-      content = zip.find_entry('xl/workbook.xml').get_input_stream.read
-      content.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+    Zip::InputStream.open(StringIO.new(xlsx_binary)) do |zip|
+      while (entry = zip.get_next_entry)
+        next unless entry.name == 'xl/workbook.xml'
+
+        return zip.read.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+      end
     end
+    []
+  end
+
+  def sheet_xml(xlsx_binary, entry_name)
+    Zip::InputStream.open(StringIO.new(xlsx_binary)) do |zip|
+      while (entry = zip.get_next_entry)
+        return zip.read if entry.name == entry_name
+      end
+    end
+    ''
   end
 end

--- a/spec/services/exports/spreadsheet_helpers_spec.rb
+++ b/spec/services/exports/spreadsheet_helpers_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Exports::SpreadsheetHelpers do
+  subject(:helper) { Class.new { include Exports::SpreadsheetHelpers }.new }
+
+  describe '#duration_label' do
+    it 'formats a date range as "DD Mon YYYY – DD Mon YYYY"' do
+      range = Date.new(2024, 1, 1).beginning_of_day..Date.new(2024, 1, 31).end_of_day
+      expect(helper.duration_label(range)).to eq('01 Jan 2024 – 31 Jan 2024')
+    end
+  end
+
+  describe '#delta_label' do
+    it 'returns "No change" for zero' do
+      expect(helper.delta_label(0)).to eq('No change')
+    end
+
+    it 'returns "No change" for nil' do
+      expect(helper.delta_label(nil)).to eq('No change')
+    end
+
+    it 'prefixes positive values with +' do
+      expect(helper.delta_label(5)).to eq('+5')
+    end
+
+    it 'returns a plain string for negative values' do
+      expect(helper.delta_label(-3)).to eq('-3')
+    end
+  end
+
+  describe '#format_seconds' do
+    it 'returns "0m" for zero' do
+      expect(helper.format_seconds(0)).to eq('0m')
+    end
+
+    it 'returns "0m" for nil' do
+      expect(helper.format_seconds(nil)).to eq('0m')
+    end
+
+    it 'formats seconds under one hour as minutes only' do
+      expect(helper.format_seconds(1800)).to eq('30m')
+    end
+
+    it 'formats seconds over one hour as hours and minutes' do
+      expect(helper.format_seconds(5400)).to eq('1h 30m')
+    end
+
+    it 'omits minutes when there are none' do
+      expect(helper.format_seconds(7200)).to eq('2h 0m')
+    end
+  end
+end

--- a/spec/services/member_export_service_spec.rb
+++ b/spec/services/member_export_service_spec.rb
@@ -49,26 +49,31 @@ RSpec.describe MemberExportService do
     end
 
     it 'includes the member name in the summary sheet' do
-      binary = service.generate
-      Zip::File.open_buffer(binary) do |zip|
-        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
-        expect(shared_strings).to include(member.display_name)
-      end
+      expect(sheet_xml(service.generate, 'xl/worksheets/sheet1.xml')).to include(member.display_name)
     end
 
     it 'includes quiz pass rate from member_data' do
-      binary = service.generate
-      Zip::File.open_buffer(binary) do |zip|
-        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
-        expect(shared_strings).to include('80%')
-      end
+      expect(sheet_xml(service.generate, 'xl/worksheets/sheet4.xml')).to include('80%')
     end
   end
 
   def worksheet_names(xlsx_binary)
-    Zip::File.open_buffer(xlsx_binary) do |zip|
-      content = zip.find_entry('xl/workbook.xml').get_input_stream.read
-      content.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+    Zip::InputStream.open(StringIO.new(xlsx_binary)) do |zip|
+      while (entry = zip.get_next_entry)
+        next unless entry.name == 'xl/workbook.xml'
+
+        return zip.read.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+      end
     end
+    []
+  end
+
+  def sheet_xml(xlsx_binary, entry_name)
+    Zip::InputStream.open(StringIO.new(xlsx_binary)) do |zip|
+      while (entry = zip.get_next_entry)
+        return zip.read if entry.name == entry_name
+      end
+    end
+    ''
   end
 end

--- a/spec/services/member_export_service_spec.rb
+++ b/spec/services/member_export_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'zip'
+
+RSpec.describe MemberExportService do
+  subject(:service) { described_class.new(member, member_data, dashboard, team) }
+
+  let(:team)    { create(:team) }
+  let(:member)  { create(:user, :learner, t_team: team) }
+  let(:duration) { 30.days.ago.beginning_of_day..Time.zone.now.end_of_day }
+  let(:dashboard) { instance_double(Dashboard) }
+  let(:member_data) do
+    {
+      engagement_series: {},
+      courses_count: 3,
+      courses_delta: 1,
+      avg_completion_percent: 60,
+      avg_completion_delta: 5,
+      total_watch_seconds: 7200,
+      watch_time_delta: 0,
+      certificates_count: 1,
+      certificates_delta: 0,
+      quiz_pass_rate: 80,
+      quizzes_passed: 4,
+      total_quizzes: 5,
+      self_assigned_count: 2
+    }
+  end
+
+  before do
+    allow(dashboard).to receive(:duration).and_return(duration)
+  end
+
+  describe '#generate' do
+    it 'returns a non-empty binary string' do
+      result = service.generate
+      expect(result).to be_a(String).and be_present
+    end
+
+    it 'produces a valid xlsx (zip) file' do
+      expect(service.generate.bytes.first(2)).to eq([0x50, 0x4B])
+    end
+
+    it 'generates five worksheets with the correct names' do
+      expect(worksheet_names(service.generate)).to eq(
+        ['Summary', 'Daily Engagement', 'Course Progress', 'Quiz Performance', 'Self-Assigned']
+      )
+    end
+
+    it 'includes the member name in the summary sheet' do
+      binary = service.generate
+      Zip::File.open_buffer(binary) do |zip|
+        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
+        expect(shared_strings).to include(member.display_name)
+      end
+    end
+
+    it 'includes quiz pass rate from member_data' do
+      binary = service.generate
+      Zip::File.open_buffer(binary) do |zip|
+        shared_strings = zip.find_entry('xl/sharedStrings.xml').get_input_stream.read
+        expect(shared_strings).to include('80%')
+      end
+    end
+  end
+
+  def worksheet_names(xlsx_binary)
+    Zip::File.open_buffer(xlsx_binary) do |zip|
+      content = zip.find_entry('xl/workbook.xml').get_input_stream.read
+      content.scan(/<sheet\b[^>]+name="([^"]+)"/).flatten
+    end
+  end
+end

--- a/spec/value_objects/dashboard_spec.rb
+++ b/spec/value_objects/dashboard_spec.rb
@@ -335,10 +335,16 @@ RSpec.describe Dashboard do
       expect(result.map { |m| m[:user] }).not_to include(inactive)
     end
 
-    it 'does not include managers' do
+    it 'includes managers' do
       manager = create(:user, :manager, t_team: team)
       result = dashboard.team_members_progress
-      expect(result.map { |m| m[:user] }).not_to include(manager)
+      expect(result.map { |m| m[:user] }).to include(manager)
+    end
+
+    it 'does not include support users' do
+      support = create(:user, t_team: team, role: 'support')
+      result = dashboard.team_members_progress
+      expect(result.map { |m| m[:user] }).not_to include(support)
     end
   end
 
@@ -346,14 +352,14 @@ RSpec.describe Dashboard do
   # DashboardTeam — all_team_members_progress
   # ---------------------------------------------------------------------------
   describe '#all_team_members_progress' do
-    it 'returns paginated results (20 per page)' do
-      21.times { create(:user, :learner, t_team: team) }
+    it 'returns paginated results (10 per page)' do
+      11.times { create(:user, :learner, t_team: team) }
       result = dashboard.all_team_members_progress(1)
-      expect(result.size).to eq(20)
+      expect(result.size).to eq(10)
     end
 
     it 'returns the second page' do
-      21.times { create(:user, :learner, t_team: team) }
+      11.times { create(:user, :learner, t_team: team) }
       result = dashboard.all_team_members_progress(2)
       expect(result.size).to eq(1)
     end


### PR DESCRIPTION
## Summary

- **Dashboard export (Excel)** — Added an Export button beside the duration dropdown on the main dashboard. Downloads a 7-sheet XLSX report (Summary, Daily Engagement, Started vs Completed, Recent Activity, Team Members, Sub-teams, Self-Assigned) powered by a new `DashboardExportService`.

- **Member profile export** — Added an Export button on the team member profile page. Downloads a 5-sheet XLSX per member (Summary, Daily Engagement, Course Progress, Quiz Performance, Self-Assigned) via a new `MemberExportService`.

- **Manager/owner progress in team list** — Team progress (full page and index widget) and sub-team enrollment counts now include all non-support roles, matching the role filter already used by `Team#members` / the member list component. Previously only learners were shown.

- **Nudge list excludes admin and support** — `falling_behind_learners` and the course-specific nudge query now filter out admin and support users since they cannot attend courses.

- **Pagination hides buttons on single page** — Prev/Next buttons no longer render when all items fit on one page. Also added pagination to the sub-teams tab in team progress (was previously unpaginated).
