### PR TITLE
Gate Content Studio access per learning partner via payment plan flag

### DIFF
--- a/app/controllers/learning_partners_controller.rb
+++ b/app/controllers/learning_partners_controller.rb
@@ -123,11 +123,12 @@ class LearningPartnersController < ApplicationController
       :banner,
       supported_countries: [],
       payment_plan_attributes: [
-        :id,  
+        :id,
         :start_date,
         :end_date,
         :total_seats,
-        :per_seat_cost
+        :per_seat_cost,
+        :content_studio_enabled
       ]
     )
   end

--- a/app/controllers/payment_plans_controller.rb
+++ b/app/controllers/payment_plans_controller.rb
@@ -48,7 +48,7 @@ class PaymentPlansController < ApplicationController
   end
 
   def payment_plan_params
-    params.require(:payment_plan).permit(:start_date, :end_date, :total_seats, :per_seat_cost)
+    params.require(:payment_plan).permit(:start_date, :end_date, :total_seats, :per_seat_cost, :content_studio_enabled)
   end
 
   def set_payment_plan

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,6 +76,13 @@ class UsersController < ApplicationController
     @user.role = params[:selected]
   end
 
+  def toggle_content_studio_creator
+    authorize @user, :assign_content_studio_creator?
+    @user.update!(content_studio_creator: !@user.content_studio_creator?)
+    key = @user.content_studio_creator? ? 'user.content_studio_creator_enabled' : 'user.content_studio_creator_disabled'
+    redirect_to member_path(@user), notice: I18n.t(key)
+  end
+
   def change_team
     authorize @user
     sub_teams = current_user.team.sub_teams

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -76,7 +76,8 @@ module UsersHelper
       activate_item(user),
       delete_item(user),
       change_role_item(user),
-      change_team_item(user)
+      change_team_item(user),
+      content_studio_creator_item(user)
     ].compact
   end
 
@@ -135,6 +136,18 @@ module UsersHelper
       url: change_team_member_path,
       type: :link,
       options: { data: { turbo_frame: 'modal' } }
+    )
+  end
+
+  def content_studio_creator_item(user)
+    return unless policy(user).assign_content_studio_creator?
+
+    label_key = user.content_studio_creator? ? 'users.disable_content_studio' : 'users.enable_content_studio'
+    ViewComponent::MenuComponentHelper::MenuItem.new(
+      label: t(label_key),
+      url: toggle_content_studio_creator_member_path(user),
+      type: :link,
+      options: { data: { turbo_method: :patch } }
     )
   end
 end

--- a/app/models/learning_partner.rb
+++ b/app/models/learning_partner.rb
@@ -27,6 +27,10 @@ class LearningPartner < ApplicationRecord
 
   has_rich_text :content
 
+  def content_studio_enabled?
+    payment_plan&.content_studio_enabled? || false
+  end
+
   def parent_team
     @parent_team ||= Team.where(learning_partner_id: id, parent_team_id: nil).first
   end

--- a/app/policies/content_studio_policy.rb
+++ b/app/policies/content_studio_policy.rb
@@ -9,6 +9,6 @@ class ContentStudioPolicy
   end
 
   def index?
-    user.privileged_user?
+    user.content_studio_creator? && user.learning_partner.content_studio_enabled?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -51,6 +51,13 @@ class UserPolicy
     user.manager_of?(other_user) && user.id != other_user.id
   end
 
+  def assign_content_studio_creator?
+    other_user.learning_partner.content_studio_enabled? &&
+      user.is_support? &&
+      user.manager_of?(other_user) &&
+      (other_user.is_manager? || other_user.is_owner?)
+  end
+
   private
 
   def changing_own_team?

--- a/app/views/payment_plans/_form.html.erb
+++ b/app/views/payment_plans/_form.html.erb
@@ -19,7 +19,15 @@
   </div>
   <%= input_text_component(form:, name: :total_seats, label: "User Limit", placeholder: "Enter Limit") %> 
 
-  <%= input_text_component(form:, name: :per_seat_cost, label: "Per user amount ( ₹ )", placeholder: "Enter amount") %>      
+  <%= input_text_component(form:, name: :per_seat_cost, label: "Per user amount ( ₹ )", placeholder: "Enter amount") %>
+
+  <%= form.hidden_field :content_studio_enabled, value: '0' %>
+  <%= input_checkbox_component(
+    name: 'payment_plan[content_studio_enabled]',
+    label: 'Enable Content Studio',
+    value: '1',
+    html_options: { checked: payment_plan.content_studio_enabled }
+  ) %>
 
   <% if action_name == "new" %>
     <div class="flex items-center gap-3 text-sm">

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -9,6 +9,7 @@ production:
   external_video_hosting: true
   sidekiq_auth_enabled: true
   enable_chatwoot: true
+  content_studio: true
 
 staging:
   <<: *default

--- a/config/initializers/content_studio.rb
+++ b/config/initializers/content_studio.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-ContentStudio.authorization_callback = ->(user) { user.privileged_user? }
+ContentStudio.authorization_callback = lambda { |user|
+  user.content_studio_creator? && user.learning_partner.content_studio_enabled?
+}
 ContentStudio.public_host = Rails.application.credentials.dig(:app, :base_url) || ContentStudio.public_host

--- a/config/initializers/content_studio.rb
+++ b/config/initializers/content_studio.rb
@@ -3,4 +3,6 @@
 ContentStudio.authorization_callback = lambda { |user|
   user.content_studio_creator? && user.learning_partner.content_studio_enabled?
 }
-ContentStudio.public_host = Rails.application.credentials.dig(:app, :base_url) || ContentStudio.public_host
+app_base_url = Rails.application.credentials.dig(:app, :base_url)
+ContentStudio.base_url = app_base_url || ContentStudio.base_url
+ContentStudio.public_host = app_base_url || ContentStudio.public_host

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,6 +405,11 @@ en:
     deactivate_failed: "User deactivate failed"
     deactivated_account: "Your account is deactivated, please contact your team manager."
     deleted: "User deleted"
+    content_studio_creator_enabled: "Content Studio access enabled."
+    content_studio_creator_disabled: "Content Studio access disabled."
+  users:
+    enable_content_studio: "Enable Content Studio"
+    disable_content_studio: "Disable Content Studio"
   page_not_found: "The page you're looking for is missing."
   learning_partner:
     label: "Learning partner"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,7 @@ Rails.application.routes.draw do
       get :change_role
       patch :confirm_change_role
       get :select_roles
+      patch :toggle_content_studio_creator
     end
   end
 

--- a/db/migrate/20260518000001_add_content_studio_enabled_to_payment_plans.rb
+++ b/db/migrate/20260518000001_add_content_studio_enabled_to_payment_plans.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContentStudioEnabledToPaymentPlans < ActiveRecord::Migration[8.0]
+  def change
+    add_column :payment_plans, :content_studio_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260519000001_add_content_studio_creator_to_users.rb
+++ b/db/migrate/20260519000001_add_content_studio_creator_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContentStudioCreatorToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :content_studio_creator, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_19_040807) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_19_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -230,6 +230,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_040807) do
     t.integer "total_seats", null: false
     t.decimal "per_seat_cost", null: false
     t.bigint "learning_partner_id", null: false
+    t.boolean "content_studio_enabled", default: false, null: false
     t.index ["learning_partner_id"], name: "index_payment_plans_on_learning_partner_id"
   end
 
@@ -404,6 +405,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_040807) do
     t.datetime "phone_confirmation_sent_at"
     t.datetime "phone_confirmed_at"
     t.string "country_code"
+    t.boolean "content_studio_creator", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["learning_partner_id"], name: "index_users_on_learning_partner_id"

--- a/engines/content_studio/app/controllers/content_studio/application_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/application_controller.rb
@@ -24,7 +24,7 @@ module ContentStudio
     end
 
     def require_content_studio_access!
-      redirect_to root_path unless ContentStudio.authorization_callback.call(try(:current_user))
+      redirect_to '/' unless ContentStudio.authorization_callback.call(try(:current_user))
     end
   end
 end

--- a/engines/content_studio/spec/dummy/config/routes.rb
+++ b/engines/content_studio/spec/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root to: proc { [200, {}, ['']] }
+
   mount ContentStudio::Engine => '/content_studio'
 
   namespace :api do

--- a/engines/content_studio/spec/requests/content_studio/application_controller_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/application_controller_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../rails_helper'
+
+RSpec.describe 'ContentStudio::ApplicationController', type: :request do
+  describe 'unauthorized access' do
+    before do
+      allow(ContentStudio).to receive(:authorization_callback).and_return(->(_user) { false })
+      get '/content_studio'
+    end
+
+    it 'redirects to /' do
+      expect(response).to redirect_to('/')
+    end
+  end
+end

--- a/spec/models/learning_partner_spec.rb
+++ b/spec/models/learning_partner_spec.rb
@@ -152,6 +152,22 @@ RSpec.describe LearningPartner, type: :model do
     end
   end
 
+  describe '#content_studio_enabled?' do
+    it 'returns false when no payment plan exists' do
+      expect(learning_partner.content_studio_enabled?).to be false
+    end
+
+    it 'returns false when payment plan has content_studio_enabled: false' do
+      create(:payment_plan, learning_partner:, content_studio_enabled: false)
+      expect(learning_partner.content_studio_enabled?).to be false
+    end
+
+    it 'returns true when payment plan has content_studio_enabled: true' do
+      create(:payment_plan, learning_partner:, content_studio_enabled: true)
+      expect(learning_partner.content_studio_enabled?).to be true
+    end
+  end
+
   describe '#active_certificate_template' do
     before do
       @certificate_template = create(:certificate_template, learning_partner:, active: true)

--- a/spec/policies/content_studio_policy_spec.rb
+++ b/spec/policies/content_studio_policy_spec.rb
@@ -7,19 +7,41 @@ RSpec.describe ContentStudioPolicy do
   let(:team) { create :team, learning_partner: }
 
   describe '#index?' do
-    it 'returns true for owner' do
-      user = create(:user, :owner, team:, learning_partner:)
-      expect(described_class.new(user, nil)).to be_index
+    context 'when partner has content studio enabled and user is a creator' do
+      before { create(:payment_plan, learning_partner:, content_studio_enabled: true) }
+
+      it 'returns true for owner with creator flag' do
+        user = create(:user, :owner, team:, learning_partner:, content_studio_creator: true)
+        expect(described_class.new(user, nil)).to be_index
+      end
+
+      it 'returns true for manager with creator flag' do
+        user = create(:user, :manager, team:, learning_partner:, content_studio_creator: true)
+        expect(described_class.new(user, nil)).to be_index
+      end
+
+      it 'returns false for owner without creator flag' do
+        user = create(:user, :owner, team:, learning_partner:)
+        expect(described_class.new(user, nil)).not_to be_index
+      end
     end
 
-    it 'returns true for manager' do
-      user = create(:user, :manager, team:, learning_partner:)
-      expect(described_class.new(user, nil)).to be_index
+    context 'when partner has content studio disabled' do
+      before { create(:payment_plan, learning_partner:, content_studio_enabled: false) }
+
+      it 'returns false even when user has creator flag' do
+        user = create(:user, :owner, team:, learning_partner:, content_studio_creator: true)
+        expect(described_class.new(user, nil)).not_to be_index
+      end
     end
 
-    it 'returns false for learner' do
-      user = create(:user, :learner, team:, learning_partner:)
-      expect(described_class.new(user, nil)).not_to be_index
+    context 'when user has no creator flag' do
+      before { create(:payment_plan, learning_partner:, content_studio_enabled: true) }
+
+      it 'returns false for learner' do
+        user = create(:user, :learner, team:, learning_partner:)
+        expect(described_class.new(user, nil)).not_to be_index
+      end
     end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -99,4 +99,43 @@ RSpec.describe UserPolicy do
       expect(described_class.new(new_support_user, @manager)).not_to be_change_team
     end
   end
+
+  describe '#assign_content_studio_creator?' do
+    let(:support_user) { create(:user, role: 'support', team: parent_team, learning_partner:) }
+
+    before do
+      create(:payment_plan, learning_partner:, content_studio_enabled: true)
+      @manager = create(:user, :manager, team: parent_team, learning_partner:)
+      @owner = create(:user, :owner, team: parent_team, learning_partner:)
+      @learner = create(:user, :learner, team: parent_team, learning_partner:)
+    end
+
+    it 'returns true for support user assigning to manager' do
+      expect(described_class.new(support_user, @manager)).to be_assign_content_studio_creator
+    end
+
+    it 'returns true for support user assigning to owner' do
+      expect(described_class.new(support_user, @owner)).to be_assign_content_studio_creator
+    end
+
+    it 'returns false when partner has content studio disabled' do
+      learning_partner.payment_plan.update!(content_studio_enabled: false)
+      expect(described_class.new(support_user, @manager)).not_to be_assign_content_studio_creator
+    end
+
+    it 'returns false for support user assigning to learner' do
+      expect(described_class.new(support_user, @learner)).not_to be_assign_content_studio_creator
+    end
+
+    it 'returns false for manager attempting to assign' do
+      expect(described_class.new(@manager, @owner)).not_to be_assign_content_studio_creator
+    end
+
+    it 'returns false for support user from a different learning partner' do
+      other_partner = create(:learning_partner)
+      other_team = create(:team, learning_partner: other_partner)
+      other_support = create(:user, role: 'support', team: other_team, learning_partner: other_partner)
+      expect(described_class.new(other_support, @manager)).not_to be_assign_content_studio_creator
+    end
+  end
 end

--- a/spec/requests/payment_plans_spec.rb
+++ b/spec/requests/payment_plans_spec.rb
@@ -114,6 +114,22 @@ RSpec.describe 'Request spec for PaymentPlans' do
       expect(response).to redirect_to(error_401_path)
     end
 
+    it 'enables content studio' do
+      put learning_partner_payment_plan_path(learning_partner),
+          params: payment_plan_params.deep_merge(payment_plan: { content_studio_enabled: true })
+
+      expect(@payment_plan.reload.content_studio_enabled).to be true
+    end
+
+    it 'disables content studio' do
+      @payment_plan.update!(content_studio_enabled: true)
+
+      put learning_partner_payment_plan_path(learning_partner),
+          params: payment_plan_params.deep_merge(payment_plan: { content_studio_enabled: false })
+
+      expect(@payment_plan.reload.content_studio_enabled).to be false
+    end
+
     it 'Update payment plan failure' do
       put learning_partner_payment_plan_path(learning_partner), params: { payment_plan: { start_date: nil } }
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -60,4 +60,37 @@ RSpec.describe 'Request spec for Users' do
       expect(response.status).to eq(422)
     end
   end
+
+  describe 'PATCH /toggle_content_studio_creator' do
+    let(:support_user) { create(:user, role: 'support', team: parent_team, learning_partner:) }
+
+    before do
+      create(:payment_plan, learning_partner:, content_studio_enabled: true)
+      sign_in support_user
+    end
+
+    it 'enables content studio creator for a manager' do
+      expect do
+        patch toggle_content_studio_creator_member_path(@learner)
+      end.to change { @learner.reload.content_studio_creator }.from(false).to(true)
+
+      expect(response).to redirect_to(member_path(@learner))
+    end
+
+    it 'disables content studio creator when already enabled' do
+      @learner.update!(content_studio_creator: true)
+
+      expect do
+        patch toggle_content_studio_creator_member_path(@learner)
+      end.to change { @learner.reload.content_studio_creator }.from(true).to(false)
+    end
+
+    it 'returns 401 when a non-support user attempts to toggle' do
+      sign_in manager
+
+      patch toggle_content_studio_creator_member_path(@learner)
+
+      expect(response).to redirect_to(error_401_path)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #

Adds a per-partner feature flag (`content_studio_enabled`) on `PaymentPlan` to control which learning partners can access Content Studio, and a per-user `content_studio_creator` flag that support users can assign to managers and owners within an enabled partner.

## Changes

- Add `content_studio_enabled` boolean to `payment_plans` (default `false`)
- Add `LearningPartner#content_studio_enabled?` delegating to payment plan
- Add `content_studio_creator` boolean to `users` (default `false`)
- Gate Content Studio access on both flags: partner must have Content Studio enabled and user must have the creator flag set
- Allow support users to toggle `content_studio_creator` for managers/owners via `PATCH /member/:id/toggle_content_studio_creator` (policy-gated: partner flag must be enabled)
- Add Enable/Disable Content Studio menu item to the user action menu (visible to support users only)
- Expose `content_studio_enabled` toggle in the payment plan form (admin UI)
- Fix engine unauthorized redirect to use `'/'` instead of `main_app.root_path` (host app has no plain root route)
- Enable Content Studio globally in `app_config.yml`; per-partner and per-user flags govern actual access

<img width="1409" height="680" alt="Screenshot 2026-05-20 at 12 17 35 PM" src="https://github.com/user-attachments/assets/02b5dbcd-cdbd-4e30-9a06-7660329df219" />
<img width="1412" height="665" alt="Screenshot 2026-05-20 at 12 18 25 PM" src="https://github.com/user-attachments/assets/d9d62886-9d7c-4094-9de7-ca9277ff4ffd" />
