### PR TITLE
Implement user-initiated save of Neo AI course into BlackboardLMS

### DIFF
--- a/app/controllers/api/internal/courses_controller.rb
+++ b/app/controllers/api/internal/courses_controller.rb
@@ -54,6 +54,7 @@ module Api
       end
 
       def save
+        NeoAi::CourseSaveService.new(neo_ai).call(params[:id])
         render json: { status: 'ok' }
       end
 

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -47,6 +47,7 @@ class Lesson < ApplicationRecord
   end
 
   def local_contents_present?
+    return false if video_streaming_source.present?
     return false unless local_contents.reject(&:marked_for_destruction?).empty?
 
     errors.add(:base,

--- a/app/services/neo_ai/course_save_service.rb
+++ b/app/services/neo_ai/course_save_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module NeoAi
+  class CourseSaveService
+    def initialize(neo_ai_client)
+      @neo_ai = neo_ai_client
+    end
+
+    def call(neo_ai_course_id)
+      existing = Course.find_by(neo_ai_course_id: neo_ai_course_id)
+      return existing if existing.present?
+
+      data = @neo_ai.find_course(neo_ai_course_id)
+
+      ActiveRecord::Base.transaction do
+        course = Course.create!(
+          neo_ai_course_id: neo_ai_course_id,
+          title: data['title'],
+          description: data['description'],
+          visibility: :private
+        )
+
+        module_ids = (data['modules'] || []).map { |m| save_module(course, m).id }
+        course.update!(course_modules_in_order: module_ids)
+
+        course
+      end
+    end
+
+    private
+
+    def save_module(course, mod_data)
+      course_module = course.course_modules.create!(title: mod_data['title'])
+      lesson_ids = (mod_data['lessons'] || []).map { |l| save_lesson(course_module, l).id }
+      course_module.update!(lessons_in_order: lesson_ids)
+      course_module
+    end
+
+    def save_lesson(course_module, lesson_data)
+      course_module.lessons.create!(
+        title: lesson_data['title'],
+        description: lesson_data['description'],
+        duration: lesson_data['estimated_duration'].to_i,
+        video_streaming_source: lesson_data['video_url']
+      )
+    end
+  end
+end

--- a/db/migrate/20260520094656_add_neo_ai_course_id_to_courses.rb
+++ b/db/migrate/20260520094656_add_neo_ai_course_id_to_courses.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddNeoAiCourseIdToCourses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :courses, :neo_ai_course_id, :string
+    add_index :courses, :neo_ai_course_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_19_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -129,6 +129,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_19_000001) do
     t.integer "duration", default: 0
     t.decimal "rating"
     t.string "visibility", null: false
+    t.string "neo_ai_course_id"
+    t.index ["neo_ai_course_id"], name: "index_courses_on_neo_ai_course_id", unique: true
   end
 
   create_table "courses_tags", force: :cascade do |t|

--- a/spec/requests/api/internal/courses_spec.rb
+++ b/spec/requests/api/internal/courses_spec.rb
@@ -181,10 +181,59 @@ RSpec.describe 'Api::Internal::Courses', type: :request do
   end
 
   describe 'PATCH /api/internal/courses/:id/save' do
-    it 'returns ok' do
+    let(:neo_ai_data) do
+      {
+        'title' => 'AI Generated Course',
+        'description' => 'An AI generated course about a very interesting topic for learners',
+        'modules' => [
+          {
+            'id' => 'm1',
+            'title' => 'Module One',
+            'lessons' => [
+              {
+                'id' => 'l1',
+                'title' => 'Lesson One',
+                'description' => 'Intro lesson',
+                'estimated_duration' => 60,
+                'video_url' => 'https://example.com/video.mp4'
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    before do
       sign_in privileged_user
+      allow(neo_ai).to receive(:find_course).with('c1').and_return(neo_ai_data)
+    end
+
+    it 'returns ok' do
       patch '/api/internal/courses/c1/save'
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'creates a course in BlackboardLMS' do
+      expect { patch '/api/internal/courses/c1/save' }.to change(Course, :count).by(1)
+    end
+
+    it 'persists the course title and neo_ai_course_id' do
+      patch '/api/internal/courses/c1/save'
+      course = Course.last
+      expect(course.title).to eq('AI Generated Course')
+      expect(course.neo_ai_course_id).to eq('c1')
+    end
+
+    it 'creates modules and lessons' do
+      patch '/api/internal/courses/c1/save'
+      course = Course.last
+      expect(course.course_modules.count).to eq(1)
+      expect(course.course_modules.first.lessons.count).to eq(1)
+    end
+
+    it 'is idempotent on repeated calls' do
+      patch '/api/internal/courses/c1/save'
+      expect { patch '/api/internal/courses/c1/save' }.not_to change(Course, :count)
     end
   end
 

--- a/spec/services/neo_ai/course_save_service_spec.rb
+++ b/spec/services/neo_ai/course_save_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NeoAi::CourseSaveService do
+  let(:neo_ai) { instance_double(NeoAi::Client) }
+  let(:service) { described_class.new(neo_ai) }
+  let(:neo_ai_data) do
+    {
+      'title' => 'Test Course Title',
+      'description' => 'An AI generated course about a very interesting topic for learners',
+      'modules' => [
+        {
+          'id' => 'm1',
+          'title' => 'Module One',
+          'lessons' => [
+            {
+              'id' => 'l1',
+              'title' => 'Lesson One',
+              'description' => 'Introduction to the topic',
+              'estimated_duration' => 90,
+              'video_url' => 'https://neo.ai/video.mp4'
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  before do
+    allow(neo_ai).to receive(:find_course).with('neo-c1').and_return(neo_ai_data)
+  end
+
+  describe '#call' do
+    it 'creates a course with correct attributes' do
+      course = service.call('neo-c1')
+      expect(course.title).to eq('Test Course Title')
+      expect(course.neo_ai_course_id).to eq('neo-c1')
+      expect(course.visibility).to eq('private')
+    end
+
+    it 'creates modules with correct ordering' do
+      course = service.call('neo-c1')
+      expect(course.course_modules.count).to eq(1)
+      expect(course.course_modules_in_order).to eq([course.course_modules.first.id])
+    end
+
+    it 'creates lessons with duration and video source' do
+      course = service.call('neo-c1')
+      lesson = course.course_modules.first.lessons.first
+      expect(lesson.title).to eq('Lesson One')
+      expect(lesson.duration).to eq(90)
+      expect(lesson.video_streaming_source).to eq('https://neo.ai/video.mp4')
+    end
+
+    it 'sets lessons_in_order on the module' do
+      course = service.call('neo-c1')
+      mod = course.course_modules.first
+      expect(mod.lessons_in_order).to eq([mod.lessons.first.id])
+    end
+
+    it 'is idempotent - returns the existing course without duplicating' do
+      first = service.call('neo-c1')
+      expect { service.call('neo-c1') }.not_to change(Course, :count)
+      expect(service.call('neo-c1').id).to eq(first.id)
+    end
+
+    it 'does not call neo_ai again when the course is already saved' do
+      service.call('neo-c1')
+      service.call('neo-c1')
+      expect(neo_ai).to have_received(:find_course).once
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1275

## Summary

- Add `neo_ai_course_id` column to courses (unique index) so saves are idempotent — repeated calls for the same Neo AI course return the existing record without duplicating
- Add `NeoAi::CourseSaveService` which fetches course data from Neo AI and persists `Course`, `CourseModule`, and `Lesson` records in a single transaction
- Relax `Lesson#local_contents_present?` validation to skip when `video_streaming_source` is set — Neo AI lessons carry an external video URL, not an ActiveStorage blob
- Wire `Api::Internal::CoursesController#save` to the new service (replaces the stub)
- Add `spec/services/neo_ai/course_save_service_spec.rb` and expand the save section in the courses request spec