### PR TITLE
Rename Explore to Courses for admin and move it under Managing section

### DIFF
--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -60,21 +60,29 @@
               icon_name: 'rectangle-group',
               label: t('sidebar.assets') %>
         <% end %>
-        <li class="flex items-center gap-1 pt-5 pb-1 px-5">
-          <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.learning') %></span>
-          <div class="flex-1 h-px bg-letter-color-light"></div>
-        </li>
-        <%= render 'shared/components/sidebar_item',
-            nav_key: 'courses',
-            url: courses_path,
-            icon_name: 'book-open',
-            label: t('sidebar.explore') %>
-        <% if policy(:my_profile).show? %>
+        <% if current_user.is_admin? %>
           <%= render 'shared/components/sidebar_item',
-              nav_key: 'my_profiles',
-              url: profile_path,
-              icon_name: 'user-circle',
-              label: t('my_profile.label') %>
+              nav_key: 'courses',
+              url: courses_path,
+              icon_name: 'book-open',
+              label: t('sidebar.courses') %>
+        <% else %>
+          <li class="flex items-center gap-1 pt-5 pb-1 px-5">
+            <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.learning') %></span>
+            <div class="flex-1 h-px bg-letter-color-light"></div>
+          </li>
+          <%= render 'shared/components/sidebar_item',
+              nav_key: 'courses',
+              url: courses_path,
+              icon_name: 'book-open',
+              label: t('sidebar.explore') %>
+          <% if policy(:my_profile).show? %>
+            <%= render 'shared/components/sidebar_item',
+                nav_key: 'my_profiles',
+                url: profile_path,
+                icon_name: 'user-circle',
+                label: t('my_profile.label') %>
+          <% end %>
         <% end %>
         <li class="flex items-center gap-1 pt-5 pb-1 px-5">
           <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.support') %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,12 +250,13 @@ en:
   sidebar:
     managing: "Managing"
     learning: "Learning"
-    support: "Support"
+    support: "Help"
     dashboard: "Dashboard"
     programs: "Programs"
     partners: "Partners"
     assets: "Assets"
     explore: "Explore"
+    courses: "Courses"
   dashboard:
     index:
       team_label: "Team:"


### PR DESCRIPTION
## Summary
Rename the "Explore" sidebar link to "Courses" for admin users and relocate it under the Managing section; non-admin users (managers, learners) continue to see "Explore" under the Learning section unchanged.

## Related Issue
Closes #1368

## Changes

- _sidebar.html.erb — conditionally render "Courses" under the Managing section for admin; wrap the existing "Explore" + Learning section in an else branch for all other roles
- en.yml — add sidebar.courses: "Courses" translation key

Learner's side bar
<img width="265" height="994" alt="Screenshot 2026-06-01 at 1 58 16 PM" src="https://github.com/user-attachments/assets/254cd5e1-a845-4817-a4fc-b871408b9351" />
Admin's side bar
<img width="264" height="1003" alt="Screenshot 2026-06-01 at 1 58 37 PM" src="https://github.com/user-attachments/assets/6007f8d7-ed41-4716-8d6d-df3af5232d78" />
Manager's side bar
<img width="265" height="995" alt="Screenshot 2026-06-01 at 1 58 50 PM" src="https://github.com/user-attachments/assets/159832ce-3062-44b6-8ed1-96dd6b2bc003" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
