### PR TITLE
Privileged user course management

### DIFF
--- a/app/controllers/api/internal/courses_controller.rb
+++ b/app/controllers/api/internal/courses_controller.rb
@@ -54,7 +54,7 @@ module Api
       end
 
       def save
-        NeoAi::CourseSaveService.new(neo_ai).call(params[:id])
+        NeoAi::CourseSaveService.new(neo_ai).call(params[:id], learning_partner_id: current_user.learning_partner_id)
         render json: { status: 'ok' }
       end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,7 +4,7 @@ class CoursesController < ApplicationController
   include CourseAssociationsPreloader
 
   before_action :set_course, only: %i[show edit update destroy enroll unenroll proceed publish unpublish]
-  before_action :set_course_active_nav, only: %i[show]
+  before_action :set_course_active_nav, only: %i[show index explore continue complete manage]
   before_action :set_tags, only: %i[new create edit update]
 
   include SearchContextHelper
@@ -12,6 +12,13 @@ class CoursesController < ApplicationController
   # GET /courses or /courses.json
   def index
     authorize :course
+    @data = HomePageService.instance.build_data_for(current_user)
+    @tags = Tag.load_tags
+  end
+
+  def manage
+    authorize :course, :manage?
+    @type = params[:type]
     if current_user.is_admin?
       search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term],
                                          type: params[:type])
@@ -19,7 +26,11 @@ class CoursesController < ApplicationController
                                        .includes(:tags, banner_attachment: :blob)
       @courses = @courses.page(filter_params[:page])
     else
-      @data = HomePageService.instance.build_data_for(current_user)
+      @courses = Course.where(learning_partner_id: current_user.learning_partner_id)
+                       .where.not(neo_ai_course_id: nil)
+                       .includes(:tags, banner_attachment: :blob)
+                       .order(created_at: :desc)
+                       .page(filter_params[:page])
     end
     @tags = Tag.load_tags
   end
@@ -135,6 +146,10 @@ class CoursesController < ApplicationController
   # DELETE /courses/1 or /courses/1.json
   def destroy
     authorize @course
+    ActiveRecord::Associations::Preloader.new(
+      records: [@course],
+      associations: { course_modules: { lessons: :local_contents } }
+    ).call
     @course.destroy!
     redirect_to courses_url, notice: I18n.t('course.deleted')
   end
@@ -216,7 +231,13 @@ class CoursesController < ApplicationController
   private
 
   def set_course_active_nav
-    @active_nav = params[:mode] == Program::MANAGER_MODE ? 'programs' : 'courses'
+    @active_nav = if params[:mode] == Program::MANAGER_MODE
+                    'programs'
+                  elsif %w[index explore continue complete].include?(action_name)
+                    'explore'
+                  else
+                    'courses'
+                  end
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,8 @@ module ApplicationHelper
   end
 
   def selected_language(local_content)
+    return if local_content.nil?
+
     LocalContent::SUPPORTED_LANGUAGES[local_content.lang.to_sym]
   end
 

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -28,6 +28,8 @@ module LessonsHelper
   end
 
   def get_video_iframe(local_content)
+    return if local_content.nil?
+
     video_url = local_content.video.blob.metadata['url']
 
     return if video_url.blank?

--- a/app/jobs/neo_ai/download_lesson_video_job.rb
+++ b/app/jobs/neo_ai/download_lesson_video_job.rb
@@ -9,8 +9,6 @@ module NeoAi
       return if lesson.nil? || lesson.video_streaming_source.blank?
 
       with_tracing "lesson_id=#{lesson_id}" do
-        lesson.local_contents.destroy_all
-
         URI.open(lesson.video_streaming_source, 'rb') do |file| # rubocop:disable Security/Open
           blob = ActiveStorage::Blob.create_and_upload!(
             io: file,
@@ -18,6 +16,7 @@ module NeoAi
             content_type: 'video/mp4'
           )
 
+          lesson.local_contents.destroy_all
           Lessons::UpdateService.instance.update_lesson!(
             lesson,
             local_contents_attributes: [{ blob_id: blob.id, lang: LocalContent::DEFAULT_LANGUAGE.downcase }]

--- a/app/jobs/neo_ai/download_lesson_video_job.rb
+++ b/app/jobs/neo_ai/download_lesson_video_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+module NeoAi
+  class DownloadLessonVideoJob < BaseJob
+    def perform(lesson_id)
+      lesson = Lesson.find_by(id: lesson_id)
+      return if lesson.nil? || lesson.video_streaming_source.blank?
+
+      with_tracing "lesson_id=#{lesson_id}" do
+        lesson.local_contents.destroy_all
+
+        URI.open(lesson.video_streaming_source, 'rb') do |file| # rubocop:disable Security/Open
+          blob = ActiveStorage::Blob.create_and_upload!(
+            io: file,
+            filename: 'video.mp4',
+            content_type: 'video/mp4'
+          )
+
+          Lessons::UpdateService.instance.update_lesson!(
+            lesson,
+            local_contents_attributes: [{ blob_id: blob.id, lang: LocalContent::DEFAULT_LANGUAGE.downcase }]
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -9,6 +9,8 @@ class Course < ApplicationRecord
 
   enum :visibility, { public: 'public', private: 'private' }, prefix: :visibility
 
+  belongs_to :learning_partner, optional: true
+
   has_many :course_modules, dependent: :destroy
   has_many :questions, dependent: :destroy
   has_many :assessments, dependent: :destroy

--- a/app/policies/course_module_policy.rb
+++ b/app/policies/course_module_policy.rb
@@ -9,7 +9,7 @@ class CourseModulePolicy
   end
 
   def new?
-    user.is_admin? || user.privileged_user?
+    user.is_admin? || own_content_studio_module?
   end
 
   def show?
@@ -17,7 +17,7 @@ class CourseModulePolicy
   end
 
   def create?
-    user.is_admin? || user.privileged_user?
+    user.is_admin? || own_content_studio_module?
   end
 
   def update?

--- a/app/policies/course_module_policy.rb
+++ b/app/policies/course_module_policy.rb
@@ -9,23 +9,23 @@ class CourseModulePolicy
   end
 
   def new?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def show?
-    user.is_admin?
+    user.is_admin? || own_content_studio_module?
   end
 
   def create?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def update?
-    user.is_admin?
+    user.is_admin? || own_content_studio_module?
   end
 
   def edit?
-    user.is_admin?
+    user.is_admin? || own_content_studio_module?
   end
 
   def destroy?
@@ -33,11 +33,11 @@ class CourseModulePolicy
   end
 
   def moveup?
-    user.is_admin?
+    user.is_admin? || own_content_studio_module?
   end
 
   def movedown?
-    user.is_admin?
+    user.is_admin? || own_content_studio_module?
   end
 
   def summary?
@@ -46,5 +46,11 @@ class CourseModulePolicy
 
   def redo_quiz?
     true
+  end
+
+  private
+
+  def own_content_studio_module?
+    user.privileged_user? && CoursePolicy.new(user, course_module.course).edit?
   end
 end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -14,6 +14,10 @@ class CoursePolicy
     user.present?
   end
 
+  def manage?
+    user.is_admin? || user.privileged_user?
+  end
+
   def continue?
     !user.is_admin?
   end
@@ -32,6 +36,7 @@ class CoursePolicy
 
   def show?
     return true if user.is_admin?
+    return true if user.privileged_user? && own_content_studio_course?
 
     return false unless visible_course?(course)
 
@@ -39,16 +44,16 @@ class CoursePolicy
   end
 
   def update?
-    user.is_admin?
+    user.is_admin? || (user.privileged_user? && own_content_studio_course?)
   end
 
   def edit?
-    user.is_admin?
+    user.is_admin? || (user.privileged_user? && own_content_studio_course?)
   end
 
   def destroy?
-    # course should not be published and should not have any enrollments
-    user.is_admin? && !course.published? && !course.enrollments_present?
+    (user.is_admin? || (user.privileged_user? && own_content_studio_course?)) &&
+      !course.published? && !course.enrollments_present?
   end
 
   def enroll?
@@ -73,13 +78,14 @@ class CoursePolicy
   end
 
   def publish?
-    return false if !user.is_admin? || course.published?
+    return false if course.published?
+    return false unless user.is_admin? || (user.privileged_user? && own_content_studio_course?)
 
     course.ready_to_publish?
   end
 
   def unpublish?
-    user.is_admin? && course.published?
+    (user.is_admin? || (user.privileged_user? && own_content_studio_course?)) && course.published?
   end
 
   def search?
@@ -88,5 +94,11 @@ class CoursePolicy
 
   def explore?
     user.present?
+  end
+
+  private
+
+  def own_content_studio_course?
+    course.neo_ai_course_id.present? && course.learning_partner_id == user.learning_partner_id
   end
 end

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -13,7 +13,7 @@ class LessonPolicy
   end
 
   def show?
-    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record.course_module.course)
+    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record)
   end
 
   def create?

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -9,15 +9,15 @@ class LessonPolicy
   end
 
   def new?
-    user.is_admin? || user.privileged_user?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def show?
-    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record)
+    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record.course_module.course)
   end
 
   def create?
-    user.is_admin? || user.privileged_user?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def update?

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -9,28 +9,26 @@ class LessonPolicy
   end
 
   def new?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def show?
-    user.is_admin? || user.enrolled_for_course?(record)
+    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record)
   end
 
   def create?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def update?
-    user.is_admin?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def edit?
-    user.is_admin?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def destroy?
-    return false unless user.is_admin?
-
     course = record.course_module.course
     CoursePolicy.new(user, course).destroy?
   end
@@ -40,14 +38,20 @@ class LessonPolicy
   end
 
   def moveup?
-    user.is_admin?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def movedown?
-    user.is_admin?
+    user.is_admin? || own_content_studio_lesson?
   end
 
   def transcribe?
     user.is_admin?
+  end
+
+  private
+
+  def own_content_studio_lesson?
+    user.privileged_user? && CoursePolicy.new(user, record.course_module.course).edit?
   end
 end

--- a/app/policies/question_policy.rb
+++ b/app/policies/question_policy.rb
@@ -9,38 +9,44 @@ class QuestionPolicy
   end
 
   def index?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def new?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def create?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def generate?
-    user.is_admin?
+    user.is_admin? || user.privileged_user?
   end
 
   def update?
-    user.is_admin?
+    user.is_admin? || own_content_studio_question?
   end
 
   def edit?
-    user.is_admin?
+    user.is_admin? || own_content_studio_question?
   end
 
   def destroy?
-    user.is_admin?
+    user.is_admin? || own_content_studio_question?
   end
 
   def verify?
-    user.is_admin?
+    user.is_admin? || own_content_studio_question?
   end
 
   def unverify?
-    user.is_admin?
+    user.is_admin? || own_content_studio_question?
+  end
+
+  private
+
+  def own_content_studio_question?
+    user.privileged_user? && CoursePolicy.new(user, question.course).edit?
   end
 end

--- a/app/services/neo_ai/course_save_service.rb
+++ b/app/services/neo_ai/course_save_service.rb
@@ -78,8 +78,7 @@ module NeoAi
       )
       lesson.save!
       lesson.update!(rich_description: lesson_data['description']) if lesson_data['description'].present?
-      enqueue_video_download(lesson) if lesson_data['video_url'].present? &&
-                                        (lesson.saved_change_to_video_streaming_source? || lesson.local_contents.none?)
+      enqueue_video_download(lesson) if lesson_data['video_url'].present?
       lesson
     end
 

--- a/app/services/neo_ai/course_save_service.rb
+++ b/app/services/neo_ai/course_save_service.rb
@@ -6,43 +6,111 @@ module NeoAi
       @neo_ai = neo_ai_client
     end
 
-    def call(neo_ai_course_id)
-      existing = Course.find_by(neo_ai_course_id: neo_ai_course_id)
-      return existing if existing.present?
-
+    def call(neo_ai_course_id, learning_partner_id:)
       data = @neo_ai.find_course(neo_ai_course_id)
 
       ActiveRecord::Base.transaction do
-        course = Course.create!(
-          neo_ai_course_id: neo_ai_course_id,
-          title: data['title'],
-          description: data['description'],
-          visibility: :private
-        )
+        existing = Course.find_by(neo_ai_course_id: neo_ai_course_id)
 
-        module_ids = (data['modules'] || []).map { |m| save_module(course, m).id }
-        course.update!(course_modules_in_order: module_ids)
-
-        course
+        if existing
+          sync_course(existing, data)
+        else
+          course = Course.create!(
+            neo_ai_course_id: neo_ai_course_id,
+            title: data['title'],
+            description: data['description'],
+            visibility: :private,
+            learning_partner_id: learning_partner_id
+          )
+          attach_level_tag(course, data['level'])
+          module_ids = (data['modules'] || []).map { |m| save_module(course, m).id }
+          course.update!(course_modules_in_order: module_ids)
+          course
+        end
       end
     end
 
     private
 
+    def sync_course(course, data)
+      course.update!(title: data['title'], description: data['description'])
+
+      api_modules = data['modules'] || []
+      api_module_ids = api_modules.pluck('id').compact
+
+      course.course_modules
+            .where.not(neo_ai_module_id: nil)
+            .where.not(neo_ai_module_id: api_module_ids)
+            .destroy_all
+
+      cs_module_ids = api_modules.map { |m| sync_module(course, m).id }
+      bb_module_ids = course.course_modules.where(neo_ai_module_id: nil).order(:created_at).ids
+
+      course.update!(course_modules_in_order: cs_module_ids + bb_module_ids)
+      course
+    end
+
+    def sync_module(course, mod_data)
+      course_module = course.course_modules.find_or_initialize_by(neo_ai_module_id: mod_data['id'])
+      course_module.update!(title: mod_data['title'])
+
+      api_lessons = mod_data['lessons'] || []
+      api_lesson_ids = api_lessons.pluck('id').compact
+
+      course_module.lessons
+                   .where.not(neo_ai_lesson_id: nil)
+                   .where.not(neo_ai_lesson_id: api_lesson_ids)
+                   .destroy_all
+
+      cs_lesson_ids = api_lessons.map { |l| sync_lesson(course_module, l).id }
+      bb_lesson_ids = course_module.lessons.where(neo_ai_lesson_id: nil).order(:created_at).ids
+
+      course_module.update!(lessons_in_order: cs_lesson_ids + bb_lesson_ids)
+      course_module
+    end
+
+    def sync_lesson(course_module, lesson_data)
+      lesson = course_module.lessons.find_or_initialize_by(neo_ai_lesson_id: lesson_data['id'])
+      lesson.assign_attributes(
+        title: lesson_data['title'],
+        duration: lesson_data['estimated_duration'].to_i,
+        video_streaming_source: lesson_data['video_url']
+      )
+      lesson.save!
+      lesson.update!(rich_description: lesson_data['description']) if lesson_data['description'].present?
+      enqueue_video_download(lesson) if lesson_data['video_url'].present? &&
+                                        (lesson.saved_change_to_video_streaming_source? || lesson.local_contents.none?)
+      lesson
+    end
+
+    def attach_level_tag(course, level)
+      return if level.blank?
+
+      tag = Tag.find_or_create_by!(name: level, tag_type: :level)
+      course.tags << tag
+    end
+
     def save_module(course, mod_data)
-      course_module = course.course_modules.create!(title: mod_data['title'])
+      course_module = course.course_modules.create!(title: mod_data['title'], neo_ai_module_id: mod_data['id'])
       lesson_ids = (mod_data['lessons'] || []).map { |l| save_lesson(course_module, l).id }
       course_module.update!(lessons_in_order: lesson_ids)
       course_module
     end
 
     def save_lesson(course_module, lesson_data)
-      course_module.lessons.create!(
+      lesson = course_module.lessons.create!(
         title: lesson_data['title'],
-        description: lesson_data['description'],
         duration: lesson_data['estimated_duration'].to_i,
-        video_streaming_source: lesson_data['video_url']
+        video_streaming_source: lesson_data['video_url'],
+        neo_ai_lesson_id: lesson_data['id']
       )
+      lesson.update!(rich_description: lesson_data['description']) if lesson_data['description'].present?
+      enqueue_video_download(lesson) if lesson_data['video_url'].present?
+      lesson
+    end
+
+    def enqueue_video_download(lesson)
+      NeoAi::DownloadLessonVideoJob.perform_async(lesson.id)
     end
   end
 end

--- a/app/views/course_modules/show.html.erb
+++ b/app/views/course_modules/show.html.erb
@@ -70,8 +70,10 @@
       <li class="mb-4 rounded border p-6 text-sm border-line-colour-light">
         <div class="flex flex-col items-center justify-center">
           <h2 class="text-semibold pb-4"><%= t("lesson.empty") %></h2>
-          <%= link_to new_course_module_lesson_path(@course, @course_module), class: "nav-link" do %>
-            <%= button(label: 'New lesson',icon_name: "plus") %>
+          <% if policy(@course_module).edit? %>
+            <%= link_to new_course_module_lesson_path(@course, @course_module), class: "nav-link" do %>
+              <%= button(label: 'New lesson', icon_name: "plus") %>
+            <% end %>
           <% end %>
         </div>
       </li>
@@ -80,7 +82,7 @@
 </div>
 <div class="flex justify-between">
   <h1 class="heading page-sub-heading">Quizzes</h1>
-  <% if policy(:quiz).new? && @course_module.quizzes.present? %>
+  <% if policy(@course_module).edit? && @course_module.quizzes.present? %>
     <div class="flex gap-4">
       <%= render 'course_modules/generate_quiz_button',
                   service: @quiz_generation_service,
@@ -141,7 +143,7 @@
         <li class="mb-4 gap-2 justify-between rounded border p-6 text-sm border-line-colour-light">
           <div class="flex flex-col items-center justify-center">
             <h2 class="text-semibold pb-4"><%= t("quiz.empty") %></h2>
-            <% if policy(:quiz).new? %>
+            <% if policy(@course_module).edit? %>
             <div class="flex gap-4">
               <%= render 'course_modules/generate_quiz_button',
                           service: @quiz_generation_service,

--- a/app/views/course_modules/show.html.erb
+++ b/app/views/course_modules/show.html.erb
@@ -25,7 +25,7 @@
 <div class="heading page-heading my-4"><%= @course_module.title %></div>
 <div class="flex justify-between">
   <h1 class="heading page-sub-heading">Lessons</h1>
-  <% if policy(:lesson).new? && @course_module.lessons.present? %>
+  <% if policy(@course_module).edit? && @course_module.lessons.present? %>
     <%= link_to new_course_module_lesson_path(@course, @course_module), class: "nav-link" do %>
       <%= button(label: 'New lesson', icon_name: "plus") %>
     <% end %>
@@ -49,13 +49,13 @@
                 <% end %>
               <% end %>
               <div class="flex flex-col items-center">
-                <% if policy(:lesson).moveup? %>
+                <% if policy(@course_module).edit? %>
                   <%= link_to moveup_course_module_lesson_path(@course, @course_module, lesson), data: {
                     turbo_method: :put }, class: "link" do %>
                     <span class="block icon icon-arrow-up icon-small bg-primary"></span>
                   <% end %>
                 <% end %>
-                <% if policy(:lesson).movedown? %>
+                <% if policy(@course_module).edit? %>
                   <%= link_to movedown_course_module_lesson_path(@course, @course_module,
                                                                  lesson), data: { turbo_method: :put }, class: "link" do %>
                     <span class="block icon icon-arrow-down icon-small bg-primary"></span>
@@ -92,7 +92,7 @@
     </div>
   <% end %>
 </div>
-<% if current_user.is_admin? %>
+<% if policy(@course_module).edit? %>
   <div class="my-4">
     <ul>
       <% if @course_module.quizzes.present? %>
@@ -120,13 +120,13 @@
                              tooltip_text: quiz_delete_tooltip_message(@course), disabled: true) %>
                 <% end %>
                 <div class="flex flex-col items-center">
-                  <% if policy(:lesson).moveup? %>
+                  <% if policy(@course_module).edit? %>
                     <%= link_to moveup_course_module_quiz_path(@course, @course_module, quiz), data: {
                       turbo_method: :put }, class: "link" do %>
                       <span class="block icon icon-arrow-up icon-small bg-primary"></span>
                     <% end %>
                   <% end %>
-                  <% if policy(:lesson).movedown? %>
+                  <% if policy(@course_module).edit? %>
                     <%= link_to movedown_course_module_quiz_path(@course, @course_module, quiz), data: {
                       turbo_method: :put }, class: "link" do %>
                       <span class="block icon icon-arrow-down icon-small bg-primary"></span>

--- a/app/views/courses/_admin_actions.html.erb
+++ b/app/views/courses/_admin_actions.html.erb
@@ -1,4 +1,4 @@
-<% if policy(:course_module).new? %>
+<% if policy(course).edit? %>
   <%= link_to new_course_module_path(course), data: { turbo_frame: "modal" }, class:"flex-1 md:w-fit" do %>
     <%= button_component(text: "Add module", size:"sm", icon_name: "plus") %>
   <% end %>

--- a/app/views/courses/_course_header_card.html.erb
+++ b/app/views/courses/_course_header_card.html.erb
@@ -15,10 +15,10 @@
         <%= course_duration(course) %>
       </span>
     </div>  
-    <% if current_user.is_admin? %>
+    <% if policy(course).edit? %>
       <div class="absolute top-8 md:top-4 right-8 md:right-16 flex">
-      <%= menu_component(menu_items: course_menu_items(course)) %>      
-      </div> 
+      <%= menu_component(menu_items: course_menu_items(course)) %>
+      </div>
     <% end %>
     <div class="md:hidden">
       <% if local_assigns[:enrollment].present? %>

--- a/app/views/courses/_filters.html.erb
+++ b/app/views/courses/_filters.html.erb
@@ -5,7 +5,7 @@
      </button>
      <h2 class="main-text-lg-medium ">Filter by</h2>
   </div>
-  <%= form_with url: courses_path, method: :get, local: true,class:"h-full flex flex-col justify-between", data: {action: "submit->courses#formSubmit"} do |form| %>
+  <%= form_with url: local_assigns.fetch(:filter_url) { courses_path }, method: :get, local: true,class:"h-full flex flex-col justify-between", data: {action: "submit->courses#formSubmit"} do |form| %>
     <div class="overflow-y-auto max-h-[calc(100vh-220px)] py-2 ">
       <span class="main-text-sm-normal cursor-pointer flex justify-end px-8 text-primary" data-action="click->courses#clearFilters">Clear filter</span>
       <div class="flex flex-col border-b border-line-colour px-8">

--- a/app/views/courses/_module_accordion_header.html.erb
+++ b/app/views/courses/_module_accordion_header.html.erb
@@ -28,7 +28,7 @@
     <% end %>
 
     <div class="flex flex-col items-center gap-2">
-      <% if policy(:course_module).moveup? %>
+      <% if policy(course_module).moveup? %>
         <%= link_to moveup_course_module_path(course, course_module), data: { turbo_method: :put } do %>
           <div class="h-4 w-4 rounded border border-slate-grey-light">
           <%= icon("arrow-long-up", css: "h-4 w-4 text-primary") %>
@@ -36,7 +36,7 @@
         <% end %>
       <% end %>
 
-      <% if policy(:course_module).movedown? %>
+      <% if policy(course_module).movedown? %>
         <%= link_to movedown_course_module_path(course, course_module), data: { turbo_method: :put } do %>
           <div class="h-4 w-4 rounded border border-slate-grey-light">
           <%= icon("arrow-long-down", css: "h-4 w-4 text-primary") %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,5 +1,1 @@
-<% if current_user.is_admin? %>
-  <%= render 'courses/list/admin', tags: @tags, type: @type, courses: @courses %>
-<% else %>
-  <%= render 'courses/list/non_admin', tags: @tags, data: @data %>
-<% end %>
+<%= render 'courses/list/non_admin', tags: @tags, data: @data %>

--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="courses">
   <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40 bg-white">
-    <%= render 'filters', tags: tags %>
+    <%= render 'filters', tags: tags, filter_url: manage_courses_path %>
     <div class="flex flex-row justify-between">
       <h1 class="heading-xl">My Courses</h1>
       <% if policy(:course).new? %>
@@ -12,7 +12,7 @@
     <div class="flex flex-col gap-1">
       <div class="flex gap-2 md:gap-3 items-center">
         <div class="flex flex-col gap-1 w-full justify-start">
-          <%= form_tag courses_path, method: :get, data: { action: "submit->courses#formSubmit" } do %>
+          <%= form_tag manage_courses_path, method: :get, data: { action: "submit->courses#formSubmit" } do %>
             <div class="flex gap-2 md:gap-3 items-center">
               <div class="relative rounded-md border border-line-colour-light w-full">      
                 <%= input_text_component( 

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -1,0 +1,1 @@
+<%= render 'courses/list/admin', tags: @tags, type: @type, courses: @courses %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -14,8 +14,8 @@
         [@course.title, nil]
       ] %>
     <% else %>
-      <%# Generic breadcrumb for direct navigation (admin and non-program context) %>
-      <%= breadcrumbs_component links: [[I18n.t('course.label'), courses_path], [@course.title, nil]] %>
+      <% courses_index = policy(@course).manage? ? manage_courses_path : courses_path %>
+      <%= breadcrumbs_component links: [[I18n.t('course.label'), courses_index], [@course.title, nil]] %>
     <% end %>
 
     

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -19,10 +19,10 @@
     <% end %>
 
     
-    <div class="flex <%= current_user.is_admin? ? 'flex-col' : 'flex-row items-center'%> md:flex-row justify-between gap-4 w-full">
+    <div class="flex <%= policy(@course).edit? ? 'flex-col' : 'flex-row items-center'%> md:flex-row justify-between gap-4 w-full">
       <%= render 'shared/components/back_button', back_link: :back %>
       <div class="flex flex-nowrap w-full md:w-fit gap-4 justify-end">
-        <% if current_user.is_admin? %>
+        <% if policy(@course).edit? %>
           <%= render 'courses/admin_actions', course: @course %>
         <% else %>
           <%= render 'courses/non_admin_actions', course: @course, assessment: @assessment, enrollment: @enrollment %>
@@ -34,7 +34,7 @@
 <%= render 'courses/course_header_card', course: @course, enrollment: @enrollment %>
 
 <div class="-mt-4">
-  <% if current_user.is_admin? %>
+  <% if policy(@course).edit? %>
     <div class="flex gap-4 mb-5">
       <%= link_to course_materials_path(@course) do %>
         <%= button_component text: "Course Materials", type: "outline", size: "sm" %>
@@ -54,7 +54,7 @@
   <% else %>
     <div class="flex flex-col items-center justify-center flex-grow py-6">
       <h2 class="text-semibold"><%= t("course.course_module.empty") %></h2>
-      <% if policy(:course_module).new? %>
+      <% if policy(@course).edit? %>
         <%= link_to new_course_module_path(@course),  data: { turbo_frame: "modal" }, class: "mt-4" do %>
           <%= button_component(text: "Add module", size:"sm", icon_name: "plus") %>
         <% end %>

--- a/app/views/lessons/_video_frame.html.erb
+++ b/app/views/lessons/_video_frame.html.erb
@@ -1,5 +1,5 @@
 <div id="video-frame" class="embed-container bg-line-colour rounded-xl xl:h-[226px]">
-  <% if local_content.video.attached? %>
+  <% if local_content %>
     <% if APP_CONFIG.external_video_hosting? && vimeo_upload_timed_out?(local_content) && current_user.is_admin? %>
       <div class="absolute inset-0 flex justify-center items-center rounded-xl">
         <%= link_to retry_local_content_path(local_content),

--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -46,6 +46,13 @@
               icon_name: 'bolt',
               label: 'Content Studio' %>
         <% end %>
+        <% if policy(:course).manage? %>
+          <%= render 'shared/components/sidebar_item',
+              nav_key: 'courses',
+              url: manage_courses_path,
+              icon_name: 'book-open',
+              label: t('sidebar.courses') %>
+        <% end %>
         <% if policy(:learning_partner).show? %>
           <%= render 'shared/components/sidebar_item',
               nav_key: 'learning_partners',
@@ -65,7 +72,7 @@
           <div class="flex-1 h-px bg-letter-color-light"></div>
         </li>
         <%= render 'shared/components/sidebar_item',
-            nav_key: 'courses',
+            nav_key: 'explore',
             url: courses_path,
             icon_name: 'book-open',
             label: t('sidebar.explore') %>

--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -67,21 +67,23 @@
               icon_name: 'rectangle-group',
               label: t('sidebar.assets') %>
         <% end %>
-        <li class="flex items-center gap-1 pt-5 pb-1 px-5">
-          <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.learning') %></span>
-          <div class="flex-1 h-px bg-letter-color-light"></div>
-        </li>
-        <%= render 'shared/components/sidebar_item',
-            nav_key: 'explore',
-            url: courses_path,
-            icon_name: 'book-open',
-            label: t('sidebar.explore') %>
-        <% if policy(:my_profile).show? %>
+        <% unless current_user.is_admin? %>
+          <li class="flex items-center gap-1 pt-5 pb-1 px-5">
+            <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.learning') %></span>
+            <div class="flex-1 h-px bg-letter-color-light"></div>
+          </li>
           <%= render 'shared/components/sidebar_item',
-              nav_key: 'my_profiles',
-              url: profile_path,
-              icon_name: 'user-circle',
-              label: t('my_profile.label') %>
+              nav_key: 'explore',
+              url: courses_path,
+              icon_name: 'book-open',
+              label: t('sidebar.explore') %>
+          <% if policy(:my_profile).show? %>
+            <%= render 'shared/components/sidebar_item',
+                nav_key: 'my_profiles',
+                url: profile_path,
+                icon_name: 'user-circle',
+                label: t('my_profile.label') %>
+          <% end %>
         <% end %>
         <li class="flex items-center gap-1 pt-5 pb-1 px-5">
           <span class="general-text-lg-normal text-letter-color-light"><%= t('sidebar.support') %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
     partners: "Partners"
     assets: "Assets"
     explore: "Explore"
+    courses: "Courses"
   dashboard:
     index:
       team_label: "Team:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
       get :explore
       get :continue
       get :complete
+      get :manage
     end
     member do
       put :enroll

--- a/db/migrate/20260601151721_add_learning_partner_to_courses.rb
+++ b/db/migrate/20260601151721_add_learning_partner_to_courses.rb
@@ -1,0 +1,5 @@
+class AddLearningPartnerToCourses < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :courses, :learning_partner, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20260602033316_add_neo_ai_module_id_to_course_modules.rb
+++ b/db/migrate/20260602033316_add_neo_ai_module_id_to_course_modules.rb
@@ -1,0 +1,5 @@
+class AddNeoAiModuleIdToCourseModules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :course_modules, :neo_ai_module_id, :string
+  end
+end

--- a/db/migrate/20260602033317_add_neo_ai_lesson_id_to_lessons.rb
+++ b/db/migrate/20260602033317_add_neo_ai_lesson_id_to_lessons.rb
@@ -1,0 +1,5 @@
+class AddNeoAiLessonIdToLessons < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lessons, :neo_ai_lesson_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_02_033317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -112,6 +112,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
     t.integer "quizzes_count", default: 0
     t.bigint "lessons_in_order", default: [], array: true
     t.bigint "quizzes_in_order", default: [], array: true
+    t.string "neo_ai_module_id"
     t.index ["course_id"], name: "index_course_modules_on_course_id"
   end
 
@@ -130,6 +131,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
     t.decimal "rating"
     t.string "visibility", null: false
     t.string "neo_ai_course_id"
+    t.bigint "learning_partner_id"
+    t.index ["learning_partner_id"], name: "index_courses_on_learning_partner_id"
     t.index ["neo_ai_course_id"], name: "index_courses_on_neo_ai_course_id", unique: true
   end
 
@@ -210,6 +213,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
     t.integer "duration", default: 0
     t.decimal "rating"
     t.datetime "last_rated_at"
+    t.string "neo_ai_lesson_id"
     t.index ["course_module_id"], name: "index_lessons_on_course_module_id"
   end
 
@@ -424,6 +428,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_20_094656) do
   add_foreign_key "course_certificates", "courses"
   add_foreign_key "course_certificates", "users"
   add_foreign_key "course_modules", "courses"
+  add_foreign_key "courses", "learning_partners"
   add_foreign_key "enrollments", "courses"
   add_foreign_key "enrollments", "users"
   add_foreign_key "enrollments", "users", column: "assigned_by_id"

--- a/spec/requests/courses/index_spec.rb
+++ b/spec/requests/courses/index_spec.rb
@@ -85,12 +85,6 @@ RSpec.describe 'Request spec for GET /courses' do
         .to eq(Course.limit(12).order(created_at: :desc).pluck(:id).sort)
     end
 
-    it 'shows all available courses when type is all' do
-      get(manage_courses_path, params: { type: 'all' })
-      expect(assigns[:courses].pluck(:id).sort)
-        .to eq(Course.limit(12).order(created_at: :desc).pluck(:id).sort)
-    end
-
     it 'filters available courses when tags are provided' do
       get manage_courses_path, params: { type: 'all', tags: [level_tags.last.name] }
       expect(assigns[:courses].pluck(:id).sort).to eq([@courses[14].id, @courses[1].id].sort)
@@ -102,7 +96,7 @@ RSpec.describe 'Request spec for GET /courses' do
     end
 
     it 'filters available courses by search term and tags' do
-      get manage_courses_path, params: { type: 'all', term: @courses[2].title, tags: [level_tags.first.id] }
+      get manage_courses_path, params: { type: 'all', term: @courses[2].title, tags: [level_tags.first.name] }
       expect(assigns[:courses].pluck(:id)).to eq([@courses[2].id])
     end
   end

--- a/spec/requests/courses/index_spec.rb
+++ b/spec/requests/courses/index_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Request spec for GET /courses' do
     end
   end
 
-  describe 'accessing index page by admin' do
+  describe 'accessing manage page by admin' do
     before do
       admin = create :user, :admin
       sign_in admin
@@ -74,35 +74,35 @@ RSpec.describe 'Request spec for GET /courses' do
 
     let(:courses) { @courses }
 
-    it 'successfully renders the index page for an admin' do
-      get('/courses')
-      expect(response.status).to render_template(:index)
+    it 'successfully renders the manage page for an admin' do
+      get(manage_courses_path)
+      expect(response.status).to render_template(:manage)
     end
 
     it 'shows only the first 12 available courses on the admin dashboard' do
-      get('/courses')
+      get(manage_courses_path)
       expect(assigns[:courses].pluck(:id).sort)
         .to eq(Course.limit(12).order(created_at: :desc).pluck(:id).sort)
     end
 
     it 'shows all available courses when type is all' do
-      get('/courses', params: { type: 'all' })
+      get(manage_courses_path, params: { type: 'all' })
       expect(assigns[:courses].pluck(:id).sort)
         .to eq(Course.limit(12).order(created_at: :desc).pluck(:id).sort)
     end
 
     it 'filters available courses when tags are provided' do
-      get courses_path, params: { type: 'all', tags: [level_tags.last.name] }
+      get manage_courses_path, params: { type: 'all', tags: [level_tags.last.name] }
       expect(assigns[:courses].pluck(:id).sort).to eq([@courses[14].id, @courses[1].id].sort)
     end
 
     it 'filters available courses by a search term' do
-      get courses_path, params: { type: 'all', term: @courses.last.title }
+      get manage_courses_path, params: { type: 'all', term: @courses.last.title }
       expect(assigns[:courses].pluck(:id)).to eq([@courses.last.id])
     end
 
     it 'filters available courses by search term and tags' do
-      get courses_path, params: { type: 'all', term: @courses[2].title, tags: [level_tags.first.id] }
+      get manage_courses_path, params: { type: 'all', term: @courses[2].title, tags: [level_tags.first.id] }
       expect(assigns[:courses].pluck(:id)).to eq([@courses[2].id])
     end
   end

--- a/spec/requests/courses/manage_spec.rb
+++ b/spec/requests/courses/manage_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Request spec for GET /courses/manage' do
       sign_in learner
 
       get(manage_courses_path)
-      expect(response).not_to render_template(:manage)
+      expect(response).to redirect_to(error_401_path)
     end
   end
 end

--- a/spec/requests/courses/manage_spec.rb
+++ b/spec/requests/courses/manage_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Request spec for GET /courses/manage' do
+  describe 'accessing manage page by privileged user' do
+    %i[manager owner].each do |role|
+      context "as #{role}" do
+        before do
+          @team = create :team
+          @user = create :user, role, team: @team
+          sign_in @user
+        end
+
+        it 'successfully renders the manage page' do
+          get(manage_courses_path)
+          expect(response).to render_template(:manage)
+        end
+
+        it 'shows only Content Studio courses for the learning partner' do
+          lp = @user.learning_partner
+          own_course = create(:course, neo_ai_course_id: 'cs-own', learning_partner: lp)
+          other_course = create(:course, neo_ai_course_id: 'cs-other', learning_partner: create(:learning_partner))
+          regular_course = create(:course)
+
+          get(manage_courses_path)
+
+          ids = assigns(:courses).pluck(:id)
+          expect(ids).to include(own_course.id)
+          expect(ids).not_to include(other_course.id)
+          expect(ids).not_to include(regular_course.id)
+        end
+      end
+    end
+  end
+
+  describe 'access control' do
+    it 'redirects learners away from manage page' do
+      team = create :team
+      learner = create :user, :learner, team: team
+      sign_in learner
+
+      get(manage_courses_path)
+      expect(response).not_to render_template(:manage)
+    end
+  end
+end

--- a/spec/requests/courses/manage_spec.rb
+++ b/spec/requests/courses/manage_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Request spec for GET /courses/manage' do
   describe 'accessing manage page by privileged user' do
     %i[manager owner].each do |role|
-      context "as #{role}" do
+      context "when accessed as #{role}" do
         before do
           @team = create :team
           @user = create :user, role, team: @team

--- a/spec/services/neo_ai/course_save_service_spec.rb
+++ b/spec/services/neo_ai/course_save_service_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe NeoAi::CourseSaveService do
   let(:neo_ai) { instance_double(NeoAi::Client) }
   let(:service) { described_class.new(neo_ai) }
+  let(:learning_partner) { create(:learning_partner) }
   let(:neo_ai_data) do
     {
       'title' => 'Test Course Title',
       'description' => 'An AI generated course about a very interesting topic for learners',
+      'level' => 'Beginner',
       'modules' => [
         {
           'id' => 'm1',
@@ -29,46 +31,169 @@ RSpec.describe NeoAi::CourseSaveService do
 
   before do
     allow(neo_ai).to receive(:find_course).with('neo-c1').and_return(neo_ai_data)
+    allow(NeoAi::DownloadLessonVideoJob).to receive(:perform_async)
   end
 
-  describe '#call' do
+  describe '#call — initial save' do
     it 'creates a course with correct attributes' do
-      course = service.call('neo-c1')
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
       expect(course.title).to eq('Test Course Title')
       expect(course.neo_ai_course_id).to eq('neo-c1')
       expect(course.visibility).to eq('private')
     end
 
-    it 'creates modules with correct ordering' do
-      course = service.call('neo-c1')
-      expect(course.course_modules.count).to eq(1)
-      expect(course.course_modules_in_order).to eq([course.course_modules.first.id])
+    it 'creates modules with neo_ai_module_id and correct ordering' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      mod = course.course_modules.first
+      expect(mod.neo_ai_module_id).to eq('m1')
+      expect(course.course_modules_in_order).to eq([mod.id])
     end
 
-    it 'creates lessons with duration and video source' do
-      course = service.call('neo-c1')
+    it 'creates lessons with neo_ai_lesson_id, duration, and video source' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
       lesson = course.course_modules.first.lessons.first
+      expect(lesson.neo_ai_lesson_id).to eq('l1')
       expect(lesson.title).to eq('Lesson One')
       expect(lesson.duration).to eq(90)
       expect(lesson.video_streaming_source).to eq('https://neo.ai/video.mp4')
     end
 
     it 'sets lessons_in_order on the module' do
-      course = service.call('neo-c1')
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
       mod = course.course_modules.first
       expect(mod.lessons_in_order).to eq([mod.lessons.first.id])
     end
 
-    it 'is idempotent - returns the existing course without duplicating' do
-      first = service.call('neo-c1')
-      expect { service.call('neo-c1') }.not_to change(Course, :count)
-      expect(service.call('neo-c1').id).to eq(first.id)
+    it 'enqueues a video download job for each lesson with a video URL' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      lesson = course.course_modules.first.lessons.first
+      expect(NeoAi::DownloadLessonVideoJob).to have_received(:perform_async).with(lesson.id)
     end
 
-    it 'does not call neo_ai again when the course is already saved' do
-      service.call('neo-c1')
-      service.call('neo-c1')
-      expect(neo_ai).to have_received(:find_course).once
+    it 'attaches the level tag from the API response' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.tags.select(&:level?).map(&:name)).to contain_exactly('Beginner')
+    end
+
+    it 'skips level tag when level is absent' do
+      neo_ai_data.delete('level')
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.tags.select(&:level?)).to be_empty
+    end
+  end
+
+  describe '#call — re-save (course already exists)' do
+    let!(:existing_course) do
+      service.call('neo-c1', learning_partner_id: learning_partner.id)
+    end
+
+    before do
+      neo_ai_data.merge!(
+        'title' => 'Updated Title',
+        'description' => 'Updated description — long enough to satisfy the minimum length validation on Course',
+        'modules' => [
+          {
+            'id' => 'm1',
+            'title' => 'Module One Updated',
+            'lessons' => [
+              {
+                'id' => 'l1',
+                'title' => 'Lesson One Updated',
+                'description' => 'Updated lesson description',
+                'estimated_duration' => 120,
+                'video_url' => 'https://neo.ai/updated.mp4'
+              },
+              {
+                'id' => 'l2',
+                'title' => 'Lesson Two',
+                'description' => nil,
+                'estimated_duration' => 60,
+                'video_url' => 'https://neo.ai/lesson2.mp4'
+              }
+            ]
+          },
+          {
+            'id' => 'm2',
+            'title' => 'Module Two',
+            'lessons' => []
+          }
+        ]
+      )
+    end
+
+    it 'does not create a duplicate course' do
+      expect { service.call('neo-c1', learning_partner_id: learning_partner.id) }
+        .not_to change(Course, :count)
+    end
+
+    it 'updates title and description' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.title).to eq('Updated Title')
+      expect(course.description).to start_with('Updated description')
+    end
+
+    it 'updates existing CS modules in place' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      mod = course.course_modules.find_by(neo_ai_module_id: 'm1')
+      expect(mod.title).to eq('Module One Updated')
+    end
+
+    it 'adds new CS modules' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.course_modules.find_by(neo_ai_module_id: 'm2')).to be_present
+    end
+
+    it 'updates existing CS lessons in place' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      mod = course.course_modules.find_by(neo_ai_module_id: 'm1')
+      lesson = mod.lessons.find_by(neo_ai_lesson_id: 'l1')
+      expect(lesson.title).to eq('Lesson One Updated')
+      expect(lesson.duration).to eq(120)
+    end
+
+    it 'adds new CS lessons' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      mod = course.course_modules.find_by(neo_ai_module_id: 'm1')
+      expect(mod.lessons.find_by(neo_ai_lesson_id: 'l2')).to be_present
+    end
+
+    it 'destroys CS modules removed from the API' do
+      neo_ai_data['modules'].reject! { |m| m['id'] == 'm1' }
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.course_modules.find_by(neo_ai_module_id: 'm1')).to be_nil
+    end
+
+    it 'destroys CS lessons removed from the API' do
+      neo_ai_data['modules'].first['lessons'].reject! { |l| l['id'] == 'l1' }
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      mod = course.course_modules.find_by(neo_ai_module_id: 'm1')
+      expect(mod.lessons.find_by(neo_ai_lesson_id: 'l1')).to be_nil
+    end
+
+    it 'preserves Blackboard-added modules' do
+      bb_module = existing_course.course_modules.create!(title: 'Blackboard Module')
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(course.course_modules.find_by(id: bb_module.id)).to be_present
+    end
+
+    it 'preserves Blackboard-added lessons' do
+      mod = existing_course.course_modules.find_by(neo_ai_module_id: 'm1')
+      bb_lesson = create(:lesson, course_module: mod)
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      updated_mod = course.course_modules.find_by(neo_ai_module_id: 'm1')
+      expect(updated_mod.lessons.find_by(id: bb_lesson.id)).to be_present
+    end
+
+    it 'places CS modules before Blackboard-added modules in ordering' do
+      bb_module = existing_course.course_modules.create!(title: 'Blackboard Module')
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      cs_ids = course.course_modules.where.not(neo_ai_module_id: nil).ids
+      expect(course.course_modules_in_order).to eq(cs_ids + [bb_module.id])
+    end
+
+    it 'does not change the level tag on re-save' do
+      service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(existing_course.reload.tags.select(&:level?).map(&:name)).to contain_exactly('Beginner')
     end
   end
 end


### PR DESCRIPTION
Fixes #

## Summary

- Separate `courses#manage` action (admin/owner course list) from `courses#index` (learner home); scope manage view for privileged users to their own CS-saved courses
- Extend `CoursePolicy`, `CourseModulePolicy`, `LessonPolicy`, `QuestionPolicy` to grant privileged users full authoring access on their own CS courses
- Add `learning_partner_id` to courses; fix module/lesson reorder and authoring guards to use instance-level policy checks
- Re-saving a CS course upserts modules/lessons by `neo_ai_module_id`/`neo_ai_lesson_id`; CS-deleted records are removed, Blackboard-added records are preserved; level tag attached on first save
- Add `NeoAi::DownloadLessonVideoJob` — downloads CS lesson video into ActiveStorage and creates `LocalContent`, triggering the Vimeo upload flow in production
- Hide Learning sidebar section for admins; fix course page breadcrumb to link back to manage path for admin/privileged users