### PR TITLE
Add content_type_card_component to NeoComponent

### DIFF
--- a/engines/neo_component/app/helpers/ui_helper.rb
+++ b/engines/neo_component/app/helpers/ui_helper.rb
@@ -19,6 +19,7 @@ module UiHelper
   include ViewComponent::Card::ProgramCardComponent
   include ViewComponent::Card::CertificateCardComponent
   include ViewComponent::Card::LongProgramCardComponent
+  include ViewComponent::Card::ContentTypeCardComponent
   include ViewComponent::CourseSelectComponent
   include ViewComponent::MemberListComponent
   include ViewComponent::NotificationBarComponent

--- a/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
+++ b/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
@@ -23,7 +23,12 @@ module ViewComponent
           highlights:,
           caption:,
           selected:,
-          disabled:
+          disabled:,
+          label_classes: disabled \
+            ? 'opacity-40 cursor-not-allowed pointer-events-none border-line-colour' \
+            : 'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary ' \
+              'has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary ' \
+              'has-[input:checked]:ring-2 has-[input:checked]:ring-primary'
         }
       end
     end

--- a/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
+++ b/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
@@ -24,11 +24,13 @@ module ViewComponent
           caption:,
           selected:,
           disabled:,
-          label_classes: disabled \
-            ? 'opacity-40 cursor-not-allowed pointer-events-none border-line-colour' \
-            : 'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary ' \
-              'has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary ' \
-              'has-[input:checked]:ring-2 has-[input:checked]:ring-primary'
+          label_classes: if disabled
+                           'opacity-40 cursor-not-allowed pointer-events-none border-line-colour'
+                         else
+                           'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary ' \
+                             'has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary ' \
+                             'has-[input:checked]:ring-2 has-[input:checked]:ring-primary'
+                         end
         }
       end
     end

--- a/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
+++ b/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Card
+    module ContentTypeCardComponent
+      def content_type_card_component(
+        title:,
+        description:,
+        icon_name:,
+        radio_value:,
+        radio_name:,
+        highlights: [],
+        caption: nil,
+        selected: false,
+        disabled: false
+      )
+        render partial: 'view_components/cards/content_type_card_component', locals: {
+          title:,
+          description:,
+          icon_name:,
+          radio_value:,
+          radio_name:,
+          highlights:,
+          caption:,
+          selected:,
+          disabled:
+        }
+      end
+    end
+  end
+end

--- a/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
+++ b/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
@@ -25,7 +25,7 @@ module ViewComponent
           selected:,
           disabled:,
           label_classes: if disabled
-                           'opacity-40 cursor-not-allowed pointer-events-none border-line-colour'
+                           'opacity-40 pointer-events-none border-line-colour'
                          else
                            'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary ' \
                              'has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary ' \

--- a/engines/neo_component/app/views/neo_components/ui/cards/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/cards/index.html.erb
@@ -1,3 +1,55 @@
+<%= doc_section_component(title: "Content Type Card — default (unselected)") do %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl">
+    <%= content_type_card_component(
+          title: 'Video',
+          description: 'Upload or link a video for learners to watch.',
+          icon_name: 'play-circle',
+          radio_name: 'content_type_example',
+          radio_value: 'video',
+          highlights: ['Supports MP4, MOV, AVI', 'Auto-captioning available']
+        ) %>
+    <%= content_type_card_component(
+          title: 'Document',
+          description: 'Share a PDF, Word doc, or presentation.',
+          icon_name: 'play-circle',
+          radio_name: 'content_type_example',
+          radio_value: 'document',
+          highlights: ['PDF, DOCX, PPTX supported', 'In-browser preview'],
+          caption: 'Best for · Frontline teams, instructor-led, in-person'
+
+          
+        ) %>
+  </div>
+<% end %>
+
+<%= doc_section_component(title: "Content Type Card — with caption") do %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl">
+    <%= content_type_card_component(
+          title: 'Quiz',
+          description: 'Test learner knowledge with multiple-choice or open questions.',
+          icon_name: 'question-mark-circle',
+          radio_name: 'content_type_caption_example',
+          radio_value: 'quiz',
+          highlights: ['Instant grading', 'Attempt limits'],
+          caption: 'Available on Professional plan and above'
+        ) %>
+  </div>
+<% end %>
+
+<%= doc_section_component(title: "Content Type Card — disabled") do %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl">
+    <%= content_type_card_component(
+          title: 'Live Session',
+          description: 'Schedule a real-time virtual classroom session.',
+          icon_name: 'play-circle',
+          radio_name: 'content_type_disabled_example',
+          radio_value: 'live_session',
+          highlights: ['Zoom & Teams integration', 'Attendance tracking'],
+          disabled: true
+        ) %>
+  </div>
+<% end %>
+
 <%= doc_section_component(title: "Certificate Card with thumbnail") do %>
   <div class="flex gap-4">
     <%= certificate_card_component(

--- a/engines/neo_component/app/views/neo_components/ui/cards/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/cards/index.html.erb
@@ -11,13 +11,11 @@
     <%= content_type_card_component(
           title: 'Document',
           description: 'Share a PDF, Word doc, or presentation.',
-          icon_name: 'play-circle',
+          icon_name: 'document-text-outline',
           radio_name: 'content_type_example',
           radio_value: 'document',
           highlights: ['PDF, DOCX, PPTX supported', 'In-browser preview'],
           caption: 'Best for · Frontline teams, instructor-led, in-person'
-
-          
         ) %>
   </div>
 <% end %>

--- a/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
+++ b/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
@@ -1,36 +1,32 @@
-<label class="group relative flex flex-col gap-4 rounded-xl border p-5 bg-white transition-all
-  <%= disabled ? 'opacity-50 cursor-not-allowed pointer-events-none border-line-colour' :
-    'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary has-[input:checked]:ring-2 has-[input:checked]:ring-primary' %>">
+<label class="group relative flex flex-col gap-4 rounded-xl border p-5 bg-white transition-all <%= label_classes %>">
 
   <%= radio_button_tag radio_name, radio_value, selected, class: 'hidden', disabled: disabled %>
 
   <div class="flex items-start justify-between gap-3">
     <div class="flex items-center gap-3">
-      <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary-light
-        <%= disabled ? 'text-disabled-color' : 'text-primary' %>">
+      <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary-light text-primary">
         <%= icon(icon_name, css: 'w-5 h-5') %>
       </span>
-      <p class="main-text-lg-semibold <%= disabled ? 'text-disabled-color' : 'text-letter-color' %>">
+      <p class="main-text-lg-semibold text-letter-color">
         <%= title %>
       </p>
     </div>
 
     <span class="flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center mt-0.5
-      <%= disabled ? 'border-disabled-color' :
-        'border-slate-grey-50 group-hover:border-primary group-has-[input:checked]:border-primary group-has-[input:checked]:bg-primary' %>">
+      border-slate-grey-50 group-hover:border-primary group-has-[input:checked]:border-primary group-has-[input:checked]:bg-primary">
       <span class="w-2 h-2 rounded-full bg-white hidden group-has-[input:checked]:block"></span>
     </span>
   </div>
 
-  <p class="general-text-md-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color-light' %>">
+  <p class="general-text-md-normal text-letter-color-light">
     <%= description %>
   </p>
 
   <% if highlights.present? %>
     <ul class="space-y-1.5">
       <% highlights.each do |highlight| %>
-        <li class="flex items-center gap-2 general-text-sm-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color' %>">
-          <div class="w-1.5 h-1.5 rounded-full flex-shrink-0 <%= disabled ? 'bg-disabled-color' : 'bg-secondary-dark' %>"></div>
+        <li class="flex items-center gap-2 general-text-sm-normal text-letter-color">
+          <div class="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-secondary-dark"></div>
           <%= highlight %>
         </li>
       <% end %>
@@ -38,7 +34,7 @@
   <% end %>
 
   <% if caption.present? %>
-    <p class="general-text-sm-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color-light' %> border-t border-primary-light-50 group-has-[input:checked]:border-white pt-3 mt-auto">
+    <p class="general-text-sm-normal text-letter-color-light border-t border-primary-light-50 group-has-[input:checked]:border-white pt-3 mt-auto">
       <%= caption %>
     </p>
   <% end %>

--- a/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
+++ b/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
@@ -7,8 +7,8 @@
   <div class="flex items-start justify-between gap-3">
     <div class="flex items-center gap-3">
       <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary-light
-        <%= disabled ? 'text-disabled-color' : 'text-primary ' %>">
-        <%= icon(icon_name, css: 'w-5 h-5 text-primary') %>
+        <%= disabled ? 'text-disabled-color' : 'text-primary' %>">
+        <%= icon(icon_name, css: 'w-5 h-5') %>
       </span>
       <p class="main-text-lg-semibold <%= disabled ? 'text-disabled-color' : 'text-letter-color' %>">
         <%= title %>

--- a/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
+++ b/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
@@ -1,0 +1,45 @@
+<label class="group relative flex flex-col gap-4 rounded-xl border p-5 bg-white transition-all
+  <%= disabled ? 'opacity-50 cursor-not-allowed pointer-events-none border-line-colour' :
+    'cursor-pointer border-line-colour hover:border-primary hover:ring-2 hover:ring-primary has-[input:checked]:bg-primary-light-50 has-[input:checked]:border-primary has-[input:checked]:ring-2 has-[input:checked]:ring-primary' %>">
+
+  <%= radio_button_tag radio_name, radio_value, selected, class: 'hidden', disabled: disabled %>
+
+  <div class="flex items-start justify-between gap-3">
+    <div class="flex items-center gap-3">
+      <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary-light
+        <%= disabled ? 'text-disabled-color' : 'text-primary ' %>">
+        <%= icon(icon_name, css: 'w-5 h-5 text-primary') %>
+      </span>
+      <p class="main-text-lg-semibold <%= disabled ? 'text-disabled-color' : 'text-letter-color' %>">
+        <%= title %>
+      </p>
+    </div>
+
+    <span class="flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center mt-0.5
+      <%= disabled ? 'border-disabled-color' :
+        'border-slate-grey-50 group-hover:border-primary group-has-[input:checked]:border-primary group-has-[input:checked]:bg-primary' %>">
+      <span class="w-2 h-2 rounded-full bg-white hidden group-has-[input:checked]:block"></span>
+    </span>
+  </div>
+
+  <p class="general-text-md-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color-light' %>">
+    <%= description %>
+  </p>
+
+  <% if highlights.present? %>
+    <ul class="space-y-1.5">
+      <% highlights.each do |highlight| %>
+        <li class="flex items-center gap-2 general-text-sm-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color' %>">
+          <div class="w-1.5 h-1.5 rounded-full flex-shrink-0 <%= disabled ? 'bg-disabled-color' : 'bg-secondary-dark' %>"></div>
+          <%= highlight %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if caption.present? %>
+    <p class="general-text-sm-normal <%= disabled ? 'text-disabled-color' : 'text-letter-color-light' %> border-t border-primary-light-50 group-has-[input:checked]:border-white pt-3 mt-auto">
+      <%= caption %>
+    </p>
+  <% end %>
+</label>

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -98,11 +98,9 @@ RSpec.describe UiHelper, type: :helper do
         expect(doc.at_css('input[type="radio"]')['disabled']).to be_present
       end
 
-      it 'applies disabled cursor classes to the label' do
+      it 'applies pointer-events-none to the label' do
         doc = render_card(disabled: true)
-        label_class = doc.at_css('label')['class']
-        expect(label_class).to include('cursor-not-allowed')
-        expect(label_class).to include('pointer-events-none')
+        expect(doc.at_css('label')['class']).to include('pointer-events-none')
       end
 
       it 'applies opacity-40 to the label (single source of dimming for all children)' do

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe UiHelper, type: :helper do
       expect(input['class']).to include('hidden')
     end
 
-    it 'renders an icon element for the given icon_name' do
+    it 'renders an icon span containing an svg for the given icon_name' do
       doc = render_card(icon_name: 'play-circle')
-      expect(doc.at_css('svg, img, [data-icon], .icon, span.icon')).to be_present
+      expect(doc.at_css('span svg')).to be_present
     end
 
     it 'renders an unchecked radio by default' do
@@ -56,6 +56,11 @@ RSpec.describe UiHelper, type: :helper do
     end
 
     describe 'highlights' do
+      it 'renders a ul when highlights are provided' do
+        doc = render_card(highlights: ['Supports MP4'])
+        expect(doc.at_css('ul')).to be_present
+      end
+
       it 'renders each highlight as a list item' do
         doc = render_card(highlights: ['Supports MP4', 'Auto-captioning'])
         items = doc.css('li').map(&:text).map(&:strip)
@@ -66,6 +71,11 @@ RSpec.describe UiHelper, type: :helper do
         doc = render_card(highlights: ['Supports MP4', 'Auto-captioning'])
         dots = doc.css('li div.rounded-full')
         expect(dots.length).to eq(2)
+      end
+
+      it 'applies bg-secondary-dark to bullet dots' do
+        doc = render_card(highlights: ['One'])
+        expect(doc.at_css('li div.rounded-full')['class']).to include('bg-secondary-dark')
       end
 
       it 'omits the highlights list when highlights is empty' do
@@ -85,10 +95,20 @@ RSpec.describe UiHelper, type: :helper do
         expect(doc.text).to include('Available on Pro plan')
       end
 
+      it 'renders the caption with a top border divider' do
+        doc = render_card(caption: 'Available on Pro plan')
+        caption_p = doc.css('p').find { |p| p.text.include?('Available on Pro plan') }
+        expect(caption_p['class']).to include('border-t')
+      end
+
       it 'omits the caption when nil' do
         doc = render_card(caption: nil)
-        paragraphs = doc.css('p').map(&:text)
-        expect(paragraphs).not_to include('Available on Pro plan')
+        expect(doc.css('p').count).to eq(2)
+      end
+
+      it 'omits the caption when an empty string' do
+        doc = render_card(caption: '')
+        expect(doc.css('p').count).to eq(2)
       end
     end
 
@@ -98,33 +118,38 @@ RSpec.describe UiHelper, type: :helper do
         expect(doc.at_css('input[type="radio"]')['disabled']).to be_present
       end
 
-      it 'applies pointer-events-none to the label' do
+      it 'applies opacity-40 and pointer-events-none to the label' do
         doc = render_card(disabled: true)
-        expect(doc.at_css('label')['class']).to include('pointer-events-none')
+        label_class = doc.at_css('label')['class']
+        expect(label_class).to include('opacity-40')
+        expect(label_class).to include('pointer-events-none')
       end
 
-      it 'applies opacity-40 to the label (single source of dimming for all children)' do
+      it 'does not apply cursor-pointer to the label' do
         doc = render_card(disabled: true)
-        expect(doc.at_css('label')['class']).to include('opacity-40')
-      end
-
-      it 'keeps secondary-dark colour on bullet dots (opacity-40 on the label handles disabled dimming)' do
-        doc = render_card(disabled: true, highlights: %w[One Two])
-        dots = doc.css('li div.rounded-full')
-        dots.each { |dot| expect(dot['class']).to include('bg-secondary-dark') }
+        expect(doc.at_css('label')['class']).not_to include('cursor-pointer')
       end
     end
 
     describe 'enabled state' do
-      it 'applies cursor-pointer to the label' do
+      it 'applies cursor-pointer and interactive classes to the label' do
         doc = render_card(disabled: false)
-        expect(doc.at_css('label')['class']).to include('cursor-pointer')
+        label_class = doc.at_css('label')['class']
+        expect(label_class).to include('cursor-pointer')
+        expect(label_class).to include('hover:border-primary')
+        expect(label_class).to include('has-[input:checked]:ring-primary')
       end
 
-      it 'applies secondary-dark colour to the bullet dots' do
-        doc = render_card(highlights: ['One'], disabled: false)
-        dot = doc.at_css('li div.rounded-full')
-        expect(dot['class']).to include('bg-secondary-dark')
+      it 'does not apply pointer-events-none or opacity-40 to the label' do
+        doc = render_card(disabled: false)
+        label_class = doc.at_css('label')['class']
+        expect(label_class).not_to include('pointer-events-none')
+        expect(label_class).not_to include('opacity-40')
+      end
+
+      it 'does not mark the radio input as disabled' do
+        doc = render_card(disabled: false)
+        expect(doc.at_css('input[type="radio"]')['disabled']).to be_nil
       end
     end
   end

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe UiHelper, type: :helper do
         expect(label_class).to include('pointer-events-none')
       end
 
-      it 'applies disabled colour to the bullet dots' do
+      it 'keeps secondary-dark colour on bullet dots (opacity-50 on the label handles disabled dimming)' do
         doc = render_card(disabled: true, highlights: %w[One Two])
         dots = doc.css('li div.rounded-full')
-        dots.each { |dot| expect(dot['class']).to include('bg-disabled-color') }
+        dots.each { |dot| expect(dot['class']).to include('bg-secondary-dark') }
       end
     end
 

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe UiHelper, type: :helper do
       expect(input['class']).to include('hidden')
     end
 
+    it 'renders an icon element for the given icon_name' do
+      doc = render_card(icon_name: 'play-circle')
+      expect(doc.at_css('svg, img, [data-icon], .icon, span.icon')).to be_present
+    end
+
     it 'renders an unchecked radio by default' do
       doc = render_card
       expect(doc.at_css('input[type="radio"]')['checked']).to be_nil
@@ -100,7 +105,12 @@ RSpec.describe UiHelper, type: :helper do
         expect(label_class).to include('pointer-events-none')
       end
 
-      it 'keeps secondary-dark colour on bullet dots (opacity-50 on the label handles disabled dimming)' do
+      it 'applies opacity-40 to the label (single source of dimming for all children)' do
+        doc = render_card(disabled: true)
+        expect(doc.at_css('label')['class']).to include('opacity-40')
+      end
+
+      it 'keeps secondary-dark colour on bullet dots (opacity-40 on the label handles disabled dimming)' do
         doc = render_card(disabled: true, highlights: %w[One Two])
         dots = doc.css('li div.rounded-full')
         dots.each { |dot| expect(dot['class']).to include('bg-secondary-dark') }

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe UiHelper, type: :helper do
       end
 
       it 'applies disabled colour to the bullet dots' do
-        doc = render_card(disabled: true, highlights: ['One', 'Two'])
+        doc = render_card(disabled: true, highlights: %w[One Two])
         dots = doc.css('li div.rounded-full')
         dots.each { |dot| expect(dot['class']).to include('bg-disabled-color') }
       end

--- a/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
+++ b/engines/neo_component/spec/helpers/ui_helper_content_type_card_component_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative '../rails_helper'
+
+RSpec.describe UiHelper, type: :helper do
+  def render_card(**kwargs)
+    defaults = {
+      title: 'Video',
+      description: 'Upload or link a video for learners to watch.',
+      icon_name: 'play-circle',
+      radio_name: 'content_type',
+      radio_value: 'video'
+    }
+    html = helper.content_type_card_component(**defaults, **kwargs)
+    Nokogiri::HTML::DocumentFragment.parse(html)
+  end
+
+  describe '#content_type_card_component' do
+    it 'renders a label as the outer wrapper' do
+      doc = render_card
+      expect(doc.at_css('label')).to be_present
+    end
+
+    it 'renders the title' do
+      doc = render_card(title: 'Quiz')
+      expect(doc.text).to include('Quiz')
+    end
+
+    it 'renders the description' do
+      doc = render_card(description: 'Test learner knowledge.')
+      expect(doc.text).to include('Test learner knowledge.')
+    end
+
+    it 'renders a hidden radio button with the correct name and value' do
+      doc = render_card(radio_name: 'content_type', radio_value: 'quiz')
+      input = doc.at_css('input[type="radio"]')
+      expect(input).to be_present
+      expect(input['name']).to eq('content_type')
+      expect(input['value']).to eq('quiz')
+      expect(input['class']).to include('hidden')
+    end
+
+    it 'renders an unchecked radio by default' do
+      doc = render_card
+      expect(doc.at_css('input[type="radio"]')['checked']).to be_nil
+    end
+
+    it 'renders a pre-checked radio when selected: true' do
+      doc = render_card(selected: true)
+      expect(doc.at_css('input[type="radio"]')['checked']).to eq('checked')
+    end
+
+    describe 'highlights' do
+      it 'renders each highlight as a list item' do
+        doc = render_card(highlights: ['Supports MP4', 'Auto-captioning'])
+        items = doc.css('li').map(&:text).map(&:strip)
+        expect(items).to include('Supports MP4', 'Auto-captioning')
+      end
+
+      it 'renders a bullet dot div for each highlight' do
+        doc = render_card(highlights: ['Supports MP4', 'Auto-captioning'])
+        dots = doc.css('li div.rounded-full')
+        expect(dots.length).to eq(2)
+      end
+
+      it 'omits the highlights list when highlights is empty' do
+        doc = render_card(highlights: [])
+        expect(doc.at_css('ul')).to be_nil
+      end
+
+      it 'omits the highlights list when highlights is not provided' do
+        doc = render_card
+        expect(doc.at_css('ul')).to be_nil
+      end
+    end
+
+    describe 'caption' do
+      it 'renders the caption when present' do
+        doc = render_card(caption: 'Available on Pro plan')
+        expect(doc.text).to include('Available on Pro plan')
+      end
+
+      it 'omits the caption when nil' do
+        doc = render_card(caption: nil)
+        paragraphs = doc.css('p').map(&:text)
+        expect(paragraphs).not_to include('Available on Pro plan')
+      end
+    end
+
+    describe 'disabled state' do
+      it 'renders a disabled radio input' do
+        doc = render_card(disabled: true)
+        expect(doc.at_css('input[type="radio"]')['disabled']).to be_present
+      end
+
+      it 'applies disabled cursor classes to the label' do
+        doc = render_card(disabled: true)
+        label_class = doc.at_css('label')['class']
+        expect(label_class).to include('cursor-not-allowed')
+        expect(label_class).to include('pointer-events-none')
+      end
+
+      it 'applies disabled colour to the bullet dots' do
+        doc = render_card(disabled: true, highlights: ['One', 'Two'])
+        dots = doc.css('li div.rounded-full')
+        dots.each { |dot| expect(dot['class']).to include('bg-disabled-color') }
+      end
+    end
+
+    describe 'enabled state' do
+      it 'applies cursor-pointer to the label' do
+        doc = render_card(disabled: false)
+        expect(doc.at_css('label')['class']).to include('cursor-pointer')
+      end
+
+      it 'applies secondary-dark colour to the bullet dots' do
+        doc = render_card(highlights: ['One'], disabled: false)
+        dot = doc.at_css('li div.rounded-full')
+        expect(dot['class']).to include('bg-secondary-dark')
+      end
+    end
+  end
+end

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -333,7 +333,7 @@ The entire card is a `<label>` wrapping a hidden `<input type="radio">` — clic
 - **Default** — white background, `border-line-colour`
 - **Hover** — `border-primary`
 - **Selected** — `border-primary` + `ring-2 ring-primary`; icon background unchanged (`bg-secondary-light`), radio dot appears
-- **Disabled** — `opacity-50`, `cursor-not-allowed`, non-interactive
+- **Disabled** — `opacity-40`, `pointer-events-none`, non-interactive
 
 **Example — three content-type options, first pre-selected:**
 ```ruby

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -320,7 +320,7 @@ content_type_card_component(
   icon_name:,             # Icon name (see icon helper)
   radio_value:,           # Value submitted when this card is selected
   radio_name:,            # Radio group name (shared across cards in the same group)
-  highlights: [],         # Array of strings — rendered as a bulleted list with check icons
+  highlights: [],         # Array of strings — rendered as a bulleted list with plain dot markers
   caption: nil,           # Optional footer note (shown below a divider line)
   selected: false,        # Pre-select this card
   disabled: false         # Muted, non-interactive state
@@ -332,7 +332,7 @@ The entire card is a `<label>` wrapping a hidden `<input type="radio">` — clic
 **Visual states:**
 - **Default** — white background, `border-line-colour`
 - **Hover** — `border-primary`
-- **Selected** — `border-primary` + `ring-2 ring-primary-light-50`; icon background fills with primary, radio dot appears
+- **Selected** — `border-primary` + `ring-2 ring-primary`; icon background unchanged (`bg-secondary-light`), radio dot appears
 - **Disabled** — `opacity-50`, `cursor-not-allowed`, non-interactive
 
 **Example — three content-type options, first pre-selected:**

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -312,6 +312,62 @@ long_program_card_component(program:, enrolled_program_ids:)
 certificate_card_component(certificate:, thumbnail_url: nil)
 ```
 
+### `content_type_card_component`
+```ruby
+content_type_card_component(
+  title:,                 # Card heading
+  description:,           # Short body text
+  icon_name:,             # Icon name (see icon helper)
+  radio_value:,           # Value submitted when this card is selected
+  radio_name:,            # Radio group name (shared across cards in the same group)
+  highlights: [],         # Array of strings — rendered as a bulleted list with check icons
+  caption: nil,           # Optional footer note (shown below a divider line)
+  selected: false,        # Pre-select this card
+  disabled: false         # Muted, non-interactive state
+)
+```
+
+The entire card is a `<label>` wrapping a hidden `<input type="radio">` — clicking anywhere selects it.
+
+**Visual states:**
+- **Default** — white background, `border-line-colour`
+- **Hover** — `border-primary`
+- **Selected** — `border-primary` + `ring-2 ring-primary-light-50`; icon background fills with primary, radio dot appears
+- **Disabled** — `opacity-50`, `cursor-not-allowed`, non-interactive
+
+**Example — three content-type options, first pre-selected:**
+```ruby
+content_type_card_component(
+  title: 'Video Course',
+  description: 'AI-generated video lessons with narration.',
+  icon_name: 'play-circle',
+  radio_name: 'course[content_type]',
+  radio_value: 'video',
+  highlights: ['HD video generation', 'Auto narration', 'Scene editor'],
+  caption: 'Recommended for most courses',
+  selected: true
+)
+
+content_type_card_component(
+  title: 'Text Course',
+  description: 'Written lessons without video content.',
+  icon_name: 'document-text',
+  radio_name: 'course[content_type]',
+  radio_value: 'text',
+  highlights: ['Fast to create', 'Markdown support']
+)
+
+content_type_card_component(
+  title: 'Live Session',
+  description: 'Instructor-led sessions scheduled in real time.',
+  icon_name: 'camera',
+  radio_name: 'course[content_type]',
+  radio_value: 'live',
+  highlights: ['Calendar integration', 'Recording support'],
+  disabled: true
+)
+```
+
 ---
 
 ## Navigation


### PR DESCRIPTION
## Summary
Adds content_type_card_component to NeoComponent — a selectable radio card for content-type selection screens with default, hover, selected, and disabled states.

## Related Issue
Closes [#1382](https://github.com/openvitae-tech/blackboard-lms/issues/1382)

## Changes

- Added content_type_card_component helper (engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb)

- Added partial template (engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb)

- Registered the helper in UiHelper

- Added usage examples (default, with caption, disabled) to the cards index page

- Updated ui_manifest.md with full API docs and examples


## Screenshots / Visual Diffs
<img width="907" height="903" alt="Screenshot 2026-06-03 at 4 17 57 PM" src="https://github.com/user-attachments/assets/aa7257c0-08cb-45ed-86d7-65ed9818c498" />
<img width="396" height="789" alt="Screenshot 2026-06-03 at 4 18 14 PM" src="https://github.com/user-attachments/assets/6b6d9e36-803a-4cec-a58a-2ec047bb59ae" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
