### PR TITLE
Task/content type card UI fix

### DIFF
--- a/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
+++ b/engines/neo_component/app/helpers/view_component/card/content_type_card_component.rb
@@ -14,6 +14,11 @@ module ViewComponent
         selected: false,
         disabled: false
       )
+        radio_input = InputComponent::InputRadioComponent.new(
+          form: nil, name: radio_name, label: nil, value: radio_value,
+          disabled:, error: nil, label_position: 'right', html_options: {}
+        )
+
         render partial: 'view_components/cards/content_type_card_component', locals: {
           title:,
           description:,
@@ -24,6 +29,7 @@ module ViewComponent
           caption:,
           selected:,
           disabled:,
+          radio_input:,
           label_classes: if disabled
                            'opacity-40 pointer-events-none border-line-colour'
                          else

--- a/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
+++ b/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
@@ -12,8 +12,8 @@
       </p>
     </div>
 
-    <div class="w-5 h-5 flex-shrink-0 flex justify-center items-center rounded-full border mt-0.5 <%= radio_input.radio_circle_style %>">
-      <div class="w-2 h-2 inline-block rounded-full <%= radio_input.radio_dot_style %>"></div>
+    <div class="w-5 h-5 flex-shrink-0 flex justify-center items-center rounded-full border-2 mt-0.5 <%= radio_input.radio_circle_style %>">
+      <div class="w-2.5 h-2.5 inline-block rounded-full <%= radio_input.radio_dot_style %>"></div>
     </div>
   </div>
 

--- a/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
+++ b/engines/neo_component/app/views/view_components/cards/_content_type_card_component.html.erb
@@ -1,9 +1,9 @@
-<label class="group relative flex flex-col gap-4 rounded-xl border p-5 bg-white transition-all <%= label_classes %>">
+<label class="group relative flex flex-col gap-4 rounded-xl border border-primary-light-100 p-5 bg-white transition-all <%= label_classes %>">
 
   <%= radio_button_tag radio_name, radio_value, selected, class: 'hidden', disabled: disabled %>
 
   <div class="flex items-start justify-between gap-3">
-    <div class="flex items-center gap-3">
+    <div class="flex flex-col gap-3">
       <span class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary-light text-primary">
         <%= icon(icon_name, css: 'w-5 h-5') %>
       </span>
@@ -12,10 +12,9 @@
       </p>
     </div>
 
-    <span class="flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center mt-0.5
-      border-slate-grey-50 group-hover:border-primary group-has-[input:checked]:border-primary group-has-[input:checked]:bg-primary">
-      <span class="w-2 h-2 rounded-full bg-white hidden group-has-[input:checked]:block"></span>
-    </span>
+    <div class="w-5 h-5 flex-shrink-0 flex justify-center items-center rounded-full border mt-0.5 <%= radio_input.radio_circle_style %>">
+      <div class="w-2 h-2 inline-block rounded-full <%= radio_input.radio_dot_style %>"></div>
+    </div>
   </div>
 
   <p class="general-text-md-normal text-letter-color-light">


### PR DESCRIPTION
## Summary
Fix Content Type Card UI to match Figma design — stack title below icon, use InputRadioComponent styles for the radio circle, and correct the radio circle border thickness.


## Changes

- Changed icon + title layout from horizontal (flex-row) to vertical (flex-col) so the title renders below the icon as per design
- Replaced hardcoded radio circle <span> with InputRadioComponent style methods (radio_circle_style / radio_dot_style) for consistency with the design system
- Added default card border colour border-primary-light-100 to the label
- Increased radio circle border from border (1px) to border-2 (2px) and inner dot from w-2 h-2 to w-2.5 h-2.5 to match Figma spec

## Screenshots / Visual Diffs
<img width="867" height="723" alt="Screenshot 2026-06-08 at 1 02 06 PM" src="https://github.com/user-attachments/assets/f506aba5-8e2d-4801-b66b-39bf293d9ba7" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
