### PR TITLE
Upgrade puma to 8.0.2 to fix CVE-2026-47736 and CVE-2026-47737

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.4.3)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Fixes #1394

## Summary

- Upgrades puma from `6.4.3` to `8.0.2` to patch two high-severity PROXY Protocol v1 vulnerabilities
- CVE-2026-47736: remote memory exhaustion via malformed PROXY header
- CVE-2026-47737: persistent connection abuse via repeated protocol headers
- `config/puma.rb` is fully compatible with puma 8 — no config changes needed