### PR TITLE
Content Studio UI fixes

### DIFF
--- a/app/controllers/api/internal/courses_controller.rb
+++ b/app/controllers/api/internal/courses_controller.rb
@@ -164,7 +164,8 @@ module Api
           progress_text: data['progress_text'],
           stage: data['stage'],
           verified_modules_count: modules.sum { |m| m[:lessons].count { |l| l[:verified] } },
-          modules: modules
+          modules: modules,
+          saved: Course.exists?(neo_ai_course_id: data['id'])
         }
       end
 

--- a/app/controllers/concerns/neo_ai_lesson_serializer.rb
+++ b/app/controllers/concerns/neo_ai_lesson_serializer.rb
@@ -13,7 +13,7 @@ module NeoAiLessonSerializer
       estimated_duration: data['estimated_duration'],
       video_url: video_url,
       verified: verified,
-      status: derive_lesson_status(scenes, video_url: video_url, verified: verified),
+      status: derive_lesson_status(scenes, verified: verified),
       scenes: scenes
     }
   end
@@ -31,10 +31,9 @@ module NeoAiLessonSerializer
     }
   end
 
-  def derive_lesson_status(scenes, video_url:, verified:)
+  def derive_lesson_status(scenes, verified:)
     return 'WAITING' if scenes.empty?
-    return 'VERIFIED' if verified && video_url.present?
-    return 'PENDING' if verified
+    return 'VERIFIED' if verified
     return 'VIDEO_READY' if scenes.all? { |s| s[:video_url].present? }
 
     'PENDING'

--- a/app/jobs/neo_ai/download_course_thumbnail_job.rb
+++ b/app/jobs/neo_ai/download_course_thumbnail_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+module NeoAi
+  class DownloadCourseThumbnailJob < BaseJob
+    def perform(course_id, thumbnail_url)
+      course = Course.find_by(id: course_id)
+      return if course.nil? || thumbnail_url.blank?
+
+      with_tracing "course_id=#{course_id}" do
+        URI.open(thumbnail_url, 'rb') do |file| # rubocop:disable Security/Open
+          ext = File.extname(URI.parse(thumbnail_url).path).presence || '.jpg'
+          course.banner.attach(
+            io: file,
+            filename: "course_#{course_id}_thumbnail#{ext}",
+            content_type: Marcel::MimeType.for(file)
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/neo_ai/course_save_service.rb
+++ b/app/services/neo_ai/course_save_service.rb
@@ -25,6 +25,7 @@ module NeoAi
           attach_level_tag(course, data['level'])
           module_ids = (data['modules'] || []).map { |m| save_module(course, m).id }
           course.update!(course_modules_in_order: module_ids)
+          enqueue_thumbnail_download(course, data['thumbnail_url'])
           course
         end
       end
@@ -47,6 +48,7 @@ module NeoAi
       bb_module_ids = course.course_modules.where(neo_ai_module_id: nil).order(:created_at).ids
 
       course.update!(course_modules_in_order: cs_module_ids + bb_module_ids)
+      enqueue_thumbnail_download(course, data['thumbnail_url'])
       course
     end
 
@@ -110,6 +112,12 @@ module NeoAi
 
     def enqueue_video_download(lesson)
       NeoAi::DownloadLessonVideoJob.perform_async(lesson.id)
+    end
+
+    def enqueue_thumbnail_download(course, thumbnail_url)
+      return if thumbnail_url.blank?
+
+      NeoAi::DownloadCourseThumbnailJob.perform_async(course.id, thumbnail_url)
     end
   end
 end

--- a/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/lessons_controller.rb
@@ -87,12 +87,22 @@ module ContentStudio
 
       def verify
         ApiClient.verify_lesson(params[:id], course_id: params[:course_id])
+        flash[:notice] = t('.success')
         next_id = params[:next_lesson_id]
         if next_id.present?
           redirect_to course_lesson_path(params[:course_id], next_id)
         else
           redirect_to course_structure_path(id: params[:course_id])
         end
+      rescue Faraday::ResourceNotFound
+        flash[:alert] = t('.not_found')
+        redirect_to course_structure_path(id: params[:course_id])
+      rescue Faraday::BadRequestError
+        flash[:alert] = t('.locked')
+        redirect_to course_lesson_path(params[:course_id], params[:id])
+      rescue Faraday::Error
+        flash[:alert] = t('.error')
+        redirect_to course_lesson_path(params[:course_id], params[:id])
       end
 
       def scene_status

--- a/engines/content_studio/app/controllers/content_studio/courses/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses/structure_controller.rb
@@ -11,6 +11,10 @@ module ContentStudio
 
       def save
         ApiClient.save_course(params[:id])
+        flash[:notice] = t('.success')
+        redirect_to course_structure_path(id: params[:id])
+      rescue Faraday::Error
+        flash[:alert] = t('.error')
         redirect_to course_structure_path(id: params[:id])
       end
 

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -26,7 +26,8 @@ export default class extends Controller {
     window.addEventListener('module-select:drag-start', this._onDragStart)
     window.addEventListener('module-select:drag-end', this._onDragEnd)
     document.addEventListener('turbo:before-visit', this._onBeforeVisit)
-    this.element.closest('turbo-frame').addEventListener('turbo:frame-load', this._onFrameLoad)
+    this._frame = this.element.closest('turbo-frame')
+    this._frame?.addEventListener('turbo:frame-load', this._onFrameLoad)
     this._schedulePoll()
   }
 
@@ -35,7 +36,7 @@ export default class extends Controller {
     window.removeEventListener('module-select:drag-start', this._onDragStart)
     window.removeEventListener('module-select:drag-end', this._onDragEnd)
     document.removeEventListener('turbo:before-visit', this._onBeforeVisit)
-    this.element.closest('turbo-frame')?.removeEventListener('turbo:frame-load', this._onFrameLoad)
+    this._frame?.removeEventListener('turbo:frame-load', this._onFrameLoad)
   }
 
   thumbnailUrlValueChanged(url) {
@@ -54,9 +55,9 @@ export default class extends Controller {
 
   _schedulePoll() {
     clearTimeout(this.timer)
-    if (!this.pendingValue || this._dragging) return
+    if (!this.pendingValue || this._dragging || !this._frame) return
     this.timer = setTimeout(() => {
-      this.element.closest('turbo-frame').src = window.location.href
+      this._frame.src = window.location.href
     }, POLL_INTERVAL_MS)
   }
 }

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -22,8 +22,10 @@ export default class extends Controller {
       this._applyThumbnail()
       this._schedulePoll()
     }
+    this._onBeforeVisit = () => clearTimeout(this.timer)
     window.addEventListener('module-select:drag-start', this._onDragStart)
     window.addEventListener('module-select:drag-end', this._onDragEnd)
+    document.addEventListener('turbo:before-visit', this._onBeforeVisit)
     this.element.closest('turbo-frame').addEventListener('turbo:frame-load', this._onFrameLoad)
     this._schedulePoll()
   }
@@ -32,6 +34,7 @@ export default class extends Controller {
     clearTimeout(this.timer)
     window.removeEventListener('module-select:drag-start', this._onDragStart)
     window.removeEventListener('module-select:drag-end', this._onDragEnd)
+    document.removeEventListener('turbo:before-visit', this._onBeforeVisit)
     this.element.closest('turbo-frame')?.removeEventListener('turbo:frame-load', this._onFrameLoad)
   }
 

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -18,8 +18,13 @@ export default class extends Controller {
       this._dragging = false
       this._schedulePoll()
     }
+    this._onFrameLoad = () => {
+      this._applyThumbnail()
+      this._schedulePoll()
+    }
     window.addEventListener('module-select:drag-start', this._onDragStart)
     window.addEventListener('module-select:drag-end', this._onDragEnd)
+    this.element.closest('turbo-frame').addEventListener('turbo:frame-load', this._onFrameLoad)
     this._schedulePoll()
   }
 
@@ -27,11 +32,15 @@ export default class extends Controller {
     clearTimeout(this.timer)
     window.removeEventListener('module-select:drag-start', this._onDragStart)
     window.removeEventListener('module-select:drag-end', this._onDragEnd)
+    this.element.closest('turbo-frame')?.removeEventListener('turbo:frame-load', this._onFrameLoad)
   }
 
-  // Updates the permanent thumbnail img only when the URL first becomes available.
-  // The loadedUrl guard prevents redundant updates (and re-fetches) on subsequent polls.
   thumbnailUrlValueChanged(url) {
+    this._applyThumbnail()
+  }
+
+  _applyThumbnail() {
+    const url = this.thumbnailUrlValue
     if (!url) return
     const img = document.getElementById('course-thumbnail-img')
     if (!img || img.dataset.loadedUrl === url) return

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -92,11 +92,6 @@
 
         </div>
 
-        <div class="w-fit">
-          <%= button_component(text: 'Show all Creations', type: 'outline', size: 'sm',
-                               icon_name: 'chevron-right', icon_position: 'right',
-                               html_options: { href: '#' }) %>
-        </div>
       </div>
     </div>
 

--- a/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
@@ -11,7 +11,7 @@
   <%# Header %>
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-2">
-      <%= link_to course_structure_path(id: @course_id), data: { turbo_frame: '_top' } do %>
+      <%= link_to course_structure_path(id: @course_id), data: { turbo: false } do %>
         <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
           <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
         </span>

--- a/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/lessons/show.html.erb
@@ -261,7 +261,8 @@
       <% end %>
     </span>
     <div class="flex items-center justify-center gap-2">
-      <%= link_to @prev_lesson_id ? course_lesson_path(@course_id, @prev_lesson_id) : '#' do %>
+      <%= link_to @prev_lesson_id ? course_lesson_path(@course_id, @prev_lesson_id) : '#',
+                  data: { turbo: 'false' } do %>
         <%= button_component(
               text: 'Previous',
               type: 'outline',
@@ -272,7 +273,8 @@
               disabled: @prev_lesson_id.nil?
             ) %>
       <% end %>
-      <%= link_to @next_lesson_id ? course_lesson_path(@course_id, @next_lesson_id) : '#' do %>
+      <%= link_to @next_lesson_id ? course_lesson_path(@course_id, @next_lesson_id) : '#',
+                  data: { turbo: 'false' } do %>
         <%= button_component(
               text: 'Next',
               type: 'outline',
@@ -303,7 +305,7 @@
         </div>
       <% else %>
         <%= form_with url: verify_lesson_path(@course_id, @lesson.id), method: :post,
-                      data: { turbo_frame: '_top' } do |f| %>
+                      data: { turbo: 'false' } do |f| %>
           <%= f.hidden_field :next_lesson_id, value: @next_lesson_id %>
           <%= f.button disabled: @lesson.status != 'VIDEO_READY' do %>
             <%= button_component(

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -253,9 +253,10 @@
             <%= button_component(text: 'Discard Course', type: 'outline', colorscheme: 'danger',
                                  html_options: { class: 'w-full' }) %>
           <% end %>
-          <%= form_with url: save_course_path(id: @structure.id), method: :patch, class: 'flex-1' do |f| %>
+          <%= form_with url: save_course_path(id: @structure.id), method: :patch, class: 'flex-1', data: { turbo_frame: '_top' } do |f| %>
             <%= f.button class: 'w-full', disabled: !all_videos_ready do %>
-              <%= button_component(text: 'Save Course', type: 'solid', colorscheme: 'primary',
+              <%= button_component(text: @structure.saved ? 'Update Course' : 'Save Course',
+                                   type: 'solid', colorscheme: 'primary',
                                    disabled: !all_videos_ready,
                                    html_options: { class: 'w-full' }) %>
             <% end %>

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-6 py-3">
   <div class="flex items-center gap-2">
-    <%= link_to root_path, data: { turbo_frame: '_top' } do %>
+    <%= link_to root_path, data: { turbo: false } do %>
       <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
         <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
       </span>

--- a/engines/content_studio/config/locales/en.yml
+++ b/engines/content_studio/config/locales/en.yml
@@ -35,6 +35,11 @@ en:
           locked: "Lesson is currently being processed and cannot be deleted."
           not_found: "Lesson not found."
           error: "Something went wrong. Please try again."
+        verify:
+          success: "Lesson verified."
+          locked: "Course is currently being processed. Please wait before verifying."
+          not_found: "Lesson not found."
+          error: "Something went wrong while verifying. Please try again."
         download:
           not_available: "The lesson video is not available yet. Please check back once processing is complete."
           not_verified: "The lesson must be verified before it can be downloaded."

--- a/engines/content_studio/config/locales/en.yml
+++ b/engines/content_studio/config/locales/en.yml
@@ -1,6 +1,10 @@
 en:
   content_studio:
     courses:
+      structure:
+        save:
+          success: "Course saved to LMS."
+          error: "Something went wrong while saving. Please try again."
       discard:
         locked: "Course is currently being processed. Please wait before deleting."
         confirm:

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -188,7 +188,8 @@ module ContentStudio
         verified_modules_count: data['verified_modules_count'].to_i,
         thumbnail_url: data['thumbnail_url'],
         progress_text: data['progress_text'],
-        stage: data['stage']
+        stage: data['stage'],
+        saved: data['saved'] == true
       )
     end
 

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -72,7 +72,7 @@ module ContentStudio
   CourseStats = Struct.new(:created, :published, :in_progress, keyword_init: true)
 
   CourseStructure = Struct.new(
-    :id, :title, :duration, :modules, :verified_modules_count, :thumbnail_url, :progress_text, :stage,
+    :id, :title, :duration, :modules, :verified_modules_count, :thumbnail_url, :progress_text, :stage, :saved,
     keyword_init: true
   ) do
     def script_writer_done?

--- a/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe 'ContentStudio::Courses::Lessons', type: :request do
         )
       ],
       verified_modules_count: 0,
-      thumbnail_url: nil
+      thumbnail_url: nil,
+      saved: false
     )
   end
 

--- a/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/lessons_spec.rb
@@ -146,6 +146,83 @@ RSpec.describe 'ContentStudio::Courses::Lessons', type: :request do
     end
   end
 
+  describe 'POST /content_studio/courses/:course_id/lessons/:id/verify' do
+    context 'when verification succeeds' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:verify_lesson)
+        post '/content_studio/courses/1/lessons/1/verify'
+      end
+
+      it 'calls ApiClient.verify_lesson with the correct ids' do
+        expect(ContentStudio::ApiClient).to have_received(:verify_lesson).with('1', course_id: '1')
+      end
+
+      it 'redirects to the course structure page when there is no next lesson' do
+        expect(response).to redirect_to('/content_studio/courses/1/structure')
+      end
+
+      it 'sets a success flash notice' do
+        expect(flash[:notice]).to eq('Lesson verified.')
+      end
+    end
+
+    context 'when a next_lesson_id is provided' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:verify_lesson)
+        post '/content_studio/courses/1/lessons/1/verify', params: { next_lesson_id: '2' }
+      end
+
+      it 'redirects to the next lesson' do
+        expect(response).to redirect_to('/content_studio/courses/1/lessons/2')
+      end
+    end
+
+    context 'when the lesson is not found' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:verify_lesson).and_raise(Faraday::ResourceNotFound)
+        post '/content_studio/courses/1/lessons/1/verify'
+      end
+
+      it 'redirects to the course structure page' do
+        expect(response).to redirect_to('/content_studio/courses/1/structure')
+      end
+
+      it 'sets an alert flash message' do
+        expect(flash[:alert]).to eq('Lesson not found.')
+      end
+    end
+
+    context 'when the course is locked' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:verify_lesson).and_raise(Faraday::BadRequestError)
+        post '/content_studio/courses/1/lessons/1/verify'
+      end
+
+      it 'redirects back to the lesson page' do
+        expect(response).to redirect_to('/content_studio/courses/1/lessons/1')
+      end
+
+      it 'sets an alert flash message' do
+        expect(flash[:alert]).to eq('Course is currently being processed. Please wait before verifying.')
+      end
+    end
+
+    context 'when an unexpected error occurs' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:verify_lesson).and_raise(Faraday::Error)
+        post '/content_studio/courses/1/lessons/1/verify'
+      end
+
+      it 'redirects back to the lesson page' do
+        expect(response).to redirect_to('/content_studio/courses/1/lessons/1')
+      end
+
+      it 'sets an alert flash message' do
+        expect(flash[:alert]).to eq('Something went wrong while verifying. Please try again.')
+      end
+    end
+  end
+
   describe 'POST /content_studio/courses/:course_id/lessons/:id/regenerate' do
     before do
       allow(ContentStudio::ApiClient).to receive(:regenerate_lesson)

--- a/engines/content_studio/spec/requests/content_studio/courses/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses/structure_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ContentStudio::Courses::Structure', type: :request do
   let(:structure) do
     ContentStudio::CourseStructure.new(
       id: 1, title: 'Test Course', duration: 3600,
-      modules: [], verified_modules_count: 0, thumbnail_url: nil
+      modules: [], verified_modules_count: 0, thumbnail_url: nil, saved: false
     )
   end
 
@@ -34,11 +34,34 @@ RSpec.describe 'ContentStudio::Courses::Structure', type: :request do
   end
 
   describe 'PATCH /content_studio/courses/:id/save' do
-    before { allow(ContentStudio::ApiClient).to receive(:save_course) }
+    context 'when save succeeds' do
+      before { allow(ContentStudio::ApiClient).to receive(:save_course) }
 
-    it 'redirects after save' do
-      patch '/content_studio/courses/1/save'
-      expect(response).to have_http_status(:redirect)
+      it 'redirects to the structure page' do
+        patch '/content_studio/courses/1/save'
+        expect(response).to redirect_to('/content_studio/courses/1/structure')
+      end
+
+      it 'sets a success flash notice' do
+        patch '/content_studio/courses/1/save'
+        expect(flash[:notice]).to eq('Course saved to LMS.')
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:save_course).and_raise(Faraday::Error)
+      end
+
+      it 'redirects to the structure page' do
+        patch '/content_studio/courses/1/save'
+        expect(response).to redirect_to('/content_studio/courses/1/structure')
+      end
+
+      it 'sets an alert flash message' do
+        patch '/content_studio/courses/1/save'
+        expect(flash[:alert]).to eq('Something went wrong while saving. Please try again.')
+      end
     end
   end
 

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
                          duration: 9240,
                          modules: [airport_services_module, wine_serving_module],
                          verified_modules_count: 1,
-                         thumbnail_url: nil
+                         thumbnail_url: nil, saved: false
                        ))
   end
 
@@ -65,7 +65,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
                            duration: 9240,
                            modules: [airport_services_module, wine_serving_module],
                            verified_modules_count: 1,
-                           thumbnail_url: nil,
+                           thumbnail_url: nil, saved: false,
                            stage: 'scene_writer_completed'
                          ))
     end
@@ -101,7 +101,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
       )
       assign(:structure, ContentStudio::CourseStructure.new(
                            id: 1, title: 'Airport Services Management', duration: 9240,
-                           modules: [mod], verified_modules_count: 1, thumbnail_url: nil
+                           modules: [mod], verified_modules_count: 1, thumbnail_url: nil, saved: false
                          ))
     end
 
@@ -149,7 +149,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     before do
       assign(:structure, ContentStudio::CourseStructure.new(
                            id: 1, title: 'Airport Services Management', duration: 9240,
-                           modules: [ready_module], verified_modules_count: 0, thumbnail_url: nil
+                           modules: [ready_module], verified_modules_count: 0, thumbnail_url: nil, saved: false
                          ))
     end
 
@@ -237,7 +237,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
                            duration: 9240,
                            modules: [airport_services_module],
                            verified_modules_count: 1,
-                           thumbnail_url: 'https://example.com/thumb.jpg'
+                           thumbnail_url: 'https://example.com/thumb.jpg', saved: false
                          ))
     end
 
@@ -287,7 +287,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
       )
       assign(:structure, ContentStudio::CourseStructure.new(
                            id: 1, title: 'Airport Services Management', duration: 9240,
-                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil,
+                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil, saved: false,
                            progress_text: 'Generating module 2 of 3'
                          ))
     end
@@ -299,9 +299,31 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     end
   end
 
-  it 'renders the Save Course button' do
-    render
-    expect(rendered).to include('Save Course')
+  context 'when the course is not yet saved to LMS' do
+    it 'renders the Save Course button' do
+      render
+      expect(rendered).to include('Save Course')
+      expect(rendered).not_to include('Update Course')
+    end
+  end
+
+  context 'when the course is already saved to LMS' do
+    before do
+      assign(:structure, ContentStudio::CourseStructure.new(
+                           id: 1,
+                           title: 'Airport Services Management',
+                           duration: 9240,
+                           modules: [airport_services_module, wine_serving_module],
+                           verified_modules_count: 1,
+                           thumbnail_url: nil, saved: true
+                         ))
+    end
+
+    it 'renders the Update Course button' do
+      render
+      expect(rendered).to include('Update Course')
+      expect(rendered).not_to include('Save Course')
+    end
   end
 
   it 'renders the Discard Course button' do
@@ -330,7 +352,7 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
       )
       assign(:structure, ContentStudio::CourseStructure.new(
                            id: 1, title: 'Airport Services Management', duration: 9240,
-                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil
+                           modules: [all_verified], verified_modules_count: 1, thumbnail_url: nil, saved: false
                          ))
     end
 

--- a/spec/jobs/neo_ai/download_course_thumbnail_job_spec.rb
+++ b/spec/jobs/neo_ai/download_course_thumbnail_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NeoAi::DownloadCourseThumbnailJob do
+  let(:course) { create(:course) }
+  let(:thumbnail_url) { 'https://neo.ai/thumb.jpg' }
+  let(:image_data) { 'fake-image-data' }
+
+  before do
+    stub_request(:get, thumbnail_url).to_return(body: image_data, status: 200)
+  end
+
+  describe '#perform' do
+    it 'attaches the downloaded image to course banner' do
+      described_class.new.perform(course.id, thumbnail_url)
+      expect(course.reload.banner).to be_attached
+    end
+
+    it 'does nothing when the course does not exist' do
+      expect { described_class.new.perform(-1, thumbnail_url) }.not_to raise_error
+    end
+
+    it 'does nothing when thumbnail_url is blank' do
+      described_class.new.perform(course.id, '')
+      expect(course.reload.banner).not_to be_attached
+    end
+  end
+end

--- a/spec/requests/api/internal/courses/lessons_spec.rb
+++ b/spec/requests/api/internal/courses/lessons_spec.rb
@@ -95,22 +95,21 @@ RSpec.describe 'Api::Internal::Courses::Lessons', type: :request do
       expect(response.parsed_body['status']).to eq('VIDEO_READY')
     end
 
-    it 'derives VERIFIED when verified and video_url present' do
+    it 'derives VERIFIED when verified is true regardless of video_url' do
+      data = course_data.deep_dup
+      data['modules'][0]['lessons'][0]['verified'] = true
+      allow(neo_ai).to receive(:find_course).with('c1').and_return(data)
+      get '/api/internal/courses/c1/lessons/l1'
+      expect(response.parsed_body['status']).to eq('VERIFIED')
+    end
+
+    it 'derives VERIFIED when verified is true and video_url is present' do
       data = course_data.deep_dup
       data['modules'][0]['lessons'][0]['verified'] = true
       data['modules'][0]['lessons'][0]['video_url'] = 'https://example.com/lesson.mp4'
       allow(neo_ai).to receive(:find_course).with('c1').and_return(data)
       get '/api/internal/courses/c1/lessons/l1'
       expect(response.parsed_body['status']).to eq('VERIFIED')
-    end
-
-    it 'derives PENDING when verified but video_url is blank' do
-      data = course_data.deep_dup
-      data['modules'][0]['lessons'][0]['verified'] = true
-      data['modules'][0]['lessons'][0]['scenes'][0]['video_url'] = 'https://example.com/s1.mp4'
-      allow(neo_ai).to receive(:find_course).with('c1').and_return(data)
-      get '/api/internal/courses/c1/lessons/l1'
-      expect(response.parsed_body['status']).to eq('PENDING')
     end
   end
 end

--- a/spec/requests/api/internal/courses_spec.rb
+++ b/spec/requests/api/internal/courses_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe 'Api::Internal::Courses', type: :request do
       get '/api/internal/courses/c1/structure'
       expect(response.parsed_body['verified_modules_count']).to eq(1)
     end
+
+    it 'returns saved: false when the course is not in the LMS' do
+      get '/api/internal/courses/c1/structure'
+      expect(response.parsed_body['saved']).to be(false)
+    end
+
+    context 'when a LMS course with the matching neo_ai_course_id exists' do
+      before { create(:course, neo_ai_course_id: 'c1') }
+
+      it 'returns saved: true' do
+        get '/api/internal/courses/c1/structure'
+        expect(response.parsed_body['saved']).to be(true)
+      end
+    end
   end
 
   describe 'POST /api/internal/courses' do

--- a/spec/services/neo_ai/course_save_service_spec.rb
+++ b/spec/services/neo_ai/course_save_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe NeoAi::CourseSaveService do
       'title' => 'Test Course Title',
       'description' => 'An AI generated course about a very interesting topic for learners',
       'level' => 'Beginner',
+      'thumbnail_url' => 'https://neo.ai/thumb.jpg',
       'modules' => [
         {
           'id' => 'm1',
@@ -32,6 +33,7 @@ RSpec.describe NeoAi::CourseSaveService do
   before do
     allow(neo_ai).to receive(:find_course).with('neo-c1').and_return(neo_ai_data)
     allow(NeoAi::DownloadLessonVideoJob).to receive(:perform_async)
+    allow(NeoAi::DownloadCourseThumbnailJob).to receive(:perform_async)
   end
 
   describe '#call — initial save' do
@@ -68,6 +70,17 @@ RSpec.describe NeoAi::CourseSaveService do
       course = service.call('neo-c1', learning_partner_id: learning_partner.id)
       lesson = course.course_modules.first.lessons.first
       expect(NeoAi::DownloadLessonVideoJob).to have_received(:perform_async).with(lesson.id)
+    end
+
+    it 'enqueues a thumbnail download job when thumbnail_url is present' do
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(NeoAi::DownloadCourseThumbnailJob).to have_received(:perform_async).with(course.id, 'https://neo.ai/thumb.jpg')
+    end
+
+    it 'does not enqueue a thumbnail download job when thumbnail_url is absent' do
+      neo_ai_data.delete('thumbnail_url')
+      service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(NeoAi::DownloadCourseThumbnailJob).not_to have_received(:perform_async)
     end
 
     it 'attaches the level tag from the API response' do
@@ -130,6 +143,12 @@ RSpec.describe NeoAi::CourseSaveService do
       course = service.call('neo-c1', learning_partner_id: learning_partner.id)
       expect(course.title).to eq('Updated Title')
       expect(course.description).to start_with('Updated description')
+    end
+
+    it 'enqueues a thumbnail download job with the updated thumbnail_url' do
+      neo_ai_data['thumbnail_url'] = 'https://neo.ai/new-thumb.jpg'
+      course = service.call('neo-c1', learning_partner_id: learning_partner.id)
+      expect(NeoAi::DownloadCourseThumbnailJob).to have_received(:perform_async).with(course.id, 'https://neo.ai/new-thumb.jpg')
     end
 
     it 'updates existing CS modules in place' do


### PR DESCRIPTION
## What

A batch of Content Studio UI fixes and improvements discovered during QA.

| Commit | Change |
|--------|--------|
| Download and attach NeoAI course thumbnail to banner on save | Background job fetches the NeoAI thumbnail and attaches it as the course banner when a course is saved to LMS |
| Fix lesson verified state not reflecting after verification | Verified/unverified state now reflects correctly after a lesson is verified |
| Show Update Course button and flash feedback on save | Save button toggles between "Save Course" and "Update Course" based on whether the course is already in the LMS; success/error flash shown after save |
| Fix thumbnail not appearing after poll without page refresh | Listens for `turbo:frame-load` to apply the thumbnail after each morph cycle — `data-turbo-permanent` was preventing the value callback from updating the image |
| Fix double render on back nav; remove Show all Creations button | Back buttons in structure and lesson pages use `data-turbo-false` to avoid a race where the poll timer fires after Turbo updates the URL, causing the landing page to render inside the frame and as the full page simultaneously. Removed the unimplemented "Show all Creations" button. |