### PR TITLE
Add "My Content" page for managers

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ContentController < ApplicationController
-  before_action :authenticate_user!
-
   def index
     authorize :content, :index?
     lp_id = current_user.learning_partner_id

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ContentController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    authorize :content, :index?
+    lp_id = current_user.learning_partner_id
+    if policy(:course).manage?
+      @courses_published_count = Course.where(learning_partner_id: lp_id).published.count
+      @courses_unpublished_count = Course.where(learning_partner_id: lp_id, is_published: false).count
+    end
+    @programs_count = Program.where(learning_partner_id: lp_id).count
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -232,10 +232,10 @@ class CoursesController < ApplicationController
   private
 
   def set_course_active_nav
-    @active_nav = if params[:mode] == Program::MANAGER_MODE
-                    'programs'
-                  elsif %w[index explore continue complete].include?(action_name)
+    @active_nav = if %w[index explore continue complete].include?(action_name)
                     'explore'
+                  elsif action_name == 'manage' || params[:mode] == Program::MANAGER_MODE
+                    'content'
                   else
                     'courses'
                   end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -7,7 +7,7 @@ class ProgramsController < ApplicationController
   before_action :set_learning_partner
   before_action :set_program, except: %i[new index explore create list choose]
   before_action :set_learner_mode, only: %i[show update add_courses create_courses bulk_destroy_courses]
-  before_action :set_programs_active_nav, only: %i[explore show]
+  before_action :set_programs_active_nav
 
   def new
     authorize :program
@@ -168,9 +168,10 @@ class ProgramsController < ApplicationController
 
   def set_programs_active_nav
     @active_nav = case action_name
-    when 'explore' then 'courses'
-    when 'show' then @learner_mode ? 'courses' : 'programs'
-    end
+                  when 'explore' then 'explore'
+                  when 'show' then @learner_mode ? 'explore' : 'content'
+                  else 'content'
+                  end
   end
 
   def set_learning_partner

--- a/app/policies/content_policy.rb
+++ b/app/policies/content_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ContentPolicy
+  attr_reader :user, :record
+
+  def initialize(user, _record)
+    @user = user
+  end
+
+  def index?
+    user.privileged_user?
+  end
+end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -7,8 +7,8 @@
     <%= link_to manage_courses_path, class: "flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5 hover:bg-primary-light-50" do %>
       <span class="flex-1 text-base font-medium text-primary"><%= t('content.courses') %></span>
       <div class="flex items-center gap-2">
-        <%= chip_component(text: "#{@courses_published_count} #{t('content.published')}", icon_name: 'eye', colorscheme: 'published') %>
-        <%= chip_component(text: "#{@courses_unpublished_count} #{t('content.unpublished')}", colorscheme: 'unpublished') %>
+        <%= chip_component(text: "#{@courses_published_count} #{t('content.published')}", icon_name: 'eye', colorscheme: 'published', pill: true) %>
+        <%= chip_component(text: "#{@courses_unpublished_count} #{t('content.unpublished')}", colorscheme: 'unpublished', pill: true) %>
       </div>
       <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
     <% end %>
@@ -17,7 +17,7 @@
   <%= link_to programs_path, class: "flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5 hover:bg-primary-light-50" do %>
     <span class="flex-1 text-base font-medium text-primary"><%= t('content.programs') %></span>
     <div class="flex items-center gap-2">
-      <%= chip_component(text: @programs_count.to_s, colorscheme: 'transparent') %>
+      <%= chip_component(text: @programs_count.to_s, colorscheme: 'transparent', pill: true) %>
     </div>
     <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
   <% end %>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -1,0 +1,31 @@
+<div class="mb-6">
+  <%= heading_component(text: t('sidebar.my_content')) %>
+</div>
+
+<div class="flex flex-col">
+  <% if policy(:course).manage? %>
+    <%= link_to manage_courses_path, class: "flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5 hover:bg-primary-light-50" do %>
+      <span class="flex-1 text-base font-medium text-primary"><%= t('content.courses') %></span>
+      <div class="flex items-center gap-2">
+        <%= chip_component(text: "#{@courses_published_count} #{t('content.published')}", icon_name: 'eye', colorscheme: 'published') %>
+        <%= chip_component(text: "#{@courses_unpublished_count} #{t('content.unpublished')}", colorscheme: 'unpublished') %>
+      </div>
+      <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
+    <% end %>
+  <% end %>
+
+  <%= link_to programs_path, class: "flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5 hover:bg-primary-light-50" do %>
+    <span class="flex-1 text-base font-medium text-primary"><%= t('content.programs') %></span>
+    <div class="flex items-center gap-2">
+      <%= chip_component(text: @programs_count.to_s, colorscheme: 'transparent') %>
+    </div>
+    <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
+  <% end %>
+
+  <% if APP_CONFIG.classroom_kit_enabled? %>
+    <div class="flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5">
+      <span class="flex-1 text-base font-medium text-primary"><%= t('content.classroom_kit') %></span>
+      <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -25,6 +25,13 @@
               icon_name: 'chart-bar',
               label: t('sidebar.dashboard') %>
         <% end %>
+        <% if policy(:content).index? %>
+          <%= render 'shared/components/sidebar_item',
+              nav_key: 'content',
+              url: content_path,
+              icon_name: 'grid',
+              label: t('sidebar.my_content') %>
+        <% end %>
         <% if policy(:program).index? %>
           <%= render 'shared/components/sidebar_item',
               nav_key: 'programs',

--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -32,6 +32,13 @@
               icon_name: 'rectangle-group',
               label: t('sidebar.my_content') %>
         <% end %>
+        <% if current_user.is_admin? %>
+          <%= render 'shared/components/sidebar_item',
+              nav_key: 'courses',
+              url: manage_courses_path,
+              icon_name: 'book-open',
+              label: t('sidebar.courses') %>
+        <% end %>
         <% if current_user.team.present? && policy(current_user.team).show? %>
           <%= render 'shared/components/sidebar_item',
               nav_key: 'teams',

--- a/app/views/shared/components/_sidebar.html.erb
+++ b/app/views/shared/components/_sidebar.html.erb
@@ -29,15 +29,8 @@
           <%= render 'shared/components/sidebar_item',
               nav_key: 'content',
               url: content_path,
-              icon_name: 'grid',
-              label: t('sidebar.my_content') %>
-        <% end %>
-        <% if policy(:program).index? %>
-          <%= render 'shared/components/sidebar_item',
-              nav_key: 'programs',
-              url: programs_path,
               icon_name: 'rectangle-group',
-              label: t('sidebar.programs') %>
+              label: t('sidebar.my_content') %>
         <% end %>
         <% if current_user.team.present? && policy(current_user.team).show? %>
           <%= render 'shared/components/sidebar_item',
@@ -52,13 +45,6 @@
               url: content_studio.root_path,
               icon_name: 'bolt',
               label: 'Content Studio' %>
-        <% end %>
-        <% if policy(:course).manage? %>
-          <%= render 'shared/components/sidebar_item',
-              nav_key: 'courses',
-              url: manage_courses_path,
-              icon_name: 'book-open',
-              label: t('sidebar.courses') %>
         <% end %>
         <% if policy(:learning_partner).show? %>
           <%= render 'shared/components/sidebar_item',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,6 +257,13 @@ en:
     assets: "Assets"
     explore: "Explore"
     courses: "Courses"
+    my_content: "My Content"
+  content:
+    courses: "Courses"
+    programs: "Programs"
+    classroom_kit: "Classroom Kit"
+    published: "Published"
+    unpublished: "Unpublished"
   dashboard:
     index:
       team_label: "Team:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,7 @@ Rails.application.routes.draw do
     end
   end
   resources :settings, only: :index
+  get 'content', to: 'content#index'
 
   resource :login, only: %i[new create] do
     collection do

--- a/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/lessons/show.html.erb_spec.rb
@@ -281,9 +281,9 @@ RSpec.describe 'content_studio/courses/lessons/show', type: :view do
       expect(rendered).to include('Verify &amp; Next')
     end
 
-    it 'renders the verify form targeting _top turbo frame' do
+    it 'renders the verify form with turbo disabled' do
       render
-      expect(rendered).to include('data-turbo-frame="_top"')
+      expect(rendered).to include('data-turbo="false"')
     end
   end
 

--- a/engines/neo_component/app/helpers/view_component/chip_component.rb
+++ b/engines/neo_component/app/helpers/view_component/chip_component.rb
@@ -44,6 +44,27 @@ module ViewComponent
         text-primary-dark
         text-primary-dark
         border-slate-grey-light
+      ],
+      'published' => %w[
+        bg-primary-light-200
+        text-black
+        text-black
+        text-black
+        border-line-colour
+      ],
+      'unpublished' => %w[
+        bg-line-colour-light
+        text-black
+        text-black
+        text-black
+        border-line-colour
+      ],
+      'transparent' => %w[
+        bg-transparent
+        text-black
+        text-black
+        text-black
+        border-line-colour
       ]
     }.freeze
 

--- a/engines/neo_component/app/helpers/view_component/chip_component.rb
+++ b/engines/neo_component/app/helpers/view_component/chip_component.rb
@@ -68,7 +68,7 @@ module ViewComponent
       ]
     }.freeze
 
-    def chip_component(text: '', icon_name: nil, close: false, colorscheme: 'primary')
+    def chip_component(text: '', icon_name: nil, close: false, colorscheme: 'primary', pill: false)
       styles = COLOR_SCHEMES[colorscheme]
       raise "Incorrect color scheme #{colorscheme}" unless styles
 
@@ -82,7 +82,8 @@ module ViewComponent
         text_style:,
         icon_style:,
         close_style:,
-        border_style:
+        border_style:,
+        pill:
       }
     end
   end

--- a/engines/neo_component/app/views/neo_components/ui/chips/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/chips/index.html.erb
@@ -14,14 +14,14 @@
   <%= chip_component(text: 'In Process', colorscheme: 'gold') %>
 <% end %>
 
-<%= doc_section_component(title: "Chip - published") do %>
-  <%= chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published') %>
+<%= doc_section_component(title: "Chip - published (pill)") do %>
+  <%= chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published', pill: true) %>
 <% end %>
 
-<%= doc_section_component(title: "Chip - unpublished") do %>
-  <%= chip_component(text: '3 Unpublished', colorscheme: 'unpublished') %>
+<%= doc_section_component(title: "Chip - unpublished (pill)") do %>
+  <%= chip_component(text: '3 Unpublished', colorscheme: 'unpublished', pill: true) %>
 <% end %>
 
-<%= doc_section_component(title: "Chip - transparent") do %>
-  <%= chip_component(text: '7', colorscheme: 'transparent') %>
+<%= doc_section_component(title: "Chip - transparent (pill)") do %>
+  <%= chip_component(text: '7', colorscheme: 'transparent', pill: true) %>
 <% end %>

--- a/engines/neo_component/app/views/neo_components/ui/chips/index.html.erb
+++ b/engines/neo_component/app/views/neo_components/ui/chips/index.html.erb
@@ -13,3 +13,15 @@
 <%= doc_section_component(title: "Chip - gold") do %>
   <%= chip_component(text: 'In Process', colorscheme: 'gold') %>
 <% end %>
+
+<%= doc_section_component(title: "Chip - published") do %>
+  <%= chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published') %>
+<% end %>
+
+<%= doc_section_component(title: "Chip - unpublished") do %>
+  <%= chip_component(text: '3 Unpublished', colorscheme: 'unpublished') %>
+<% end %>
+
+<%= doc_section_component(title: "Chip - transparent") do %>
+  <%= chip_component(text: '7', colorscheme: 'transparent') %>
+<% end %>

--- a/engines/neo_component/app/views/view_components/chip_component/_chip_component.html.erb
+++ b/engines/neo_component/app/views/view_components/chip_component/_chip_component.html.erb
@@ -1,4 +1,4 @@
-<div class="flex w-fit gap-1 items-center rounded h-5 px-1 py-0.5 border <%= border_style %> <%= bg_style %>">
+<div class="flex w-fit gap-1 items-center <%= pill ? 'rounded-full px-2 py-1' : 'rounded h-5 px-1 py-0.5' %> border <%= border_style %> <%= bg_style %>">
   <% if icon_name.present? %>
     <%= icon(icon_name, span_css: icon_style, css: 'h-4 w-4') %>
   <% end %>

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -249,7 +249,8 @@ chip_component(
   text: '',
   icon_name: nil,
   close: false,
-  colorscheme: 'primary'  # primary | primary_lite | danger | input | secondary | gold | published | unpublished | transparent
+  colorscheme: 'primary',  # primary | primary_lite | danger | input | secondary | gold | published | unpublished | transparent
+  pill: false              # true → rounded-full, px-2 py-1 (pill shape); false → rounded, px-1 py-0.5 (default)
 )
 ```
 
@@ -271,14 +272,14 @@ chip_component(
 # Standard tag
 chip_component(text: 'Design')
 
-# Published content badge with icon
-chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published')
+# Published content badge with icon (pill shape)
+chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published', pill: true)
 
-# Unpublished content badge
-chip_component(text: '3 Unpublished', colorscheme: 'unpublished')
+# Unpublished content badge (pill shape)
+chip_component(text: '3 Unpublished', colorscheme: 'unpublished', pill: true)
 
-# Count-only border badge
-chip_component(text: '7', colorscheme: 'transparent')
+# Count-only border badge (pill shape)
+chip_component(text: '7', colorscheme: 'transparent', pill: true)
 
 # Removable chip (e.g. multi-select)
 chip_component(text: 'Ruby', colorscheme: 'input', close: true)

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -255,6 +255,7 @@ chip_component(
 ```
 
 #### Colorschemes
+
 | Colorscheme | Background | Border | Typical use |
 |-------------|-----------|--------|-------------|
 | `primary` | `primary-light-100` | none | General tags |

--- a/engines/neo_component/ui_manifest.md
+++ b/engines/neo_component/ui_manifest.md
@@ -249,8 +249,39 @@ chip_component(
   text: '',
   icon_name: nil,
   close: false,
-  colorscheme: 'primary'  # primary | primary_lite | danger | input | secondary | gold
+  colorscheme: 'primary'  # primary | primary_lite | danger | input | secondary | gold | published | unpublished | transparent
 )
+```
+
+#### Colorschemes
+| Colorscheme | Background | Border | Typical use |
+|-------------|-----------|--------|-------------|
+| `primary` | `primary-light-100` | none | General tags |
+| `primary_lite` | `primary-light-50` | none | Subtle tags |
+| `danger` | `danger-light` | none | Error / warning |
+| `input` | `primary-light-50` | `slate-grey-light` | Multi-select input chips |
+| `secondary` | `secondary` | none | Success / positive |
+| `gold` | `gold-light` | `slate-grey-light` | Highlighted / featured |
+| `published` | `primary-light-200` | `line-colour` | Published content count badge |
+| `unpublished` | `line-colour-light` | `line-colour` | Unpublished content count badge |
+| `transparent` | transparent | `line-colour` | Count-only border badge |
+
+#### Examples
+```ruby
+# Standard tag
+chip_component(text: 'Design')
+
+# Published content badge with icon
+chip_component(text: '12 Published', icon_name: 'eye', colorscheme: 'published')
+
+# Unpublished content badge
+chip_component(text: '3 Unpublished', colorscheme: 'unpublished')
+
+# Count-only border badge
+chip_component(text: '7', colorscheme: 'transparent')
+
+# Removable chip (e.g. multi-select)
+chip_component(text: 'Ruby', colorscheme: 'input', close: true)
 ```
 
 ---

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe CoursesController, type: :controller do
 
   describe '#set_course_active_nav' do
     context 'when mode is manager' do
-      it 'sets @active_nav to programs' do
+      it 'sets @active_nav to content' do
         get :show, params: { id: course.id, mode: Program::MANAGER_MODE }
-        expect(assigns(:active_nav)).to eq('programs')
+        expect(assigns(:active_nav)).to eq('content')
       end
     end
 

--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -10,26 +10,26 @@ RSpec.describe ProgramsController, type: :controller do
 
   describe '#set_programs_active_nav' do
     context 'when on explore action' do
-      it 'sets @active_nav to courses' do
+      it 'sets @active_nav to explore' do
         get :explore
-        expect(assigns(:active_nav)).to eq('courses')
+        expect(assigns(:active_nav)).to eq('explore')
       end
     end
 
     context 'when on show action' do
-      it 'sets @active_nav to courses in learner mode' do
+      it 'sets @active_nav to explore in learner mode' do
         get :show, params: { id: program.id, mode: Program::LEARNER_MODE }
-        expect(assigns(:active_nav)).to eq('courses')
+        expect(assigns(:active_nav)).to eq('explore')
       end
 
-      it 'sets @active_nav to programs in manager mode' do
+      it 'sets @active_nav to content in manager mode' do
         get :show, params: { id: program.id, mode: Program::MANAGER_MODE }
-        expect(assigns(:active_nav)).to eq('programs')
+        expect(assigns(:active_nav)).to eq('content')
       end
 
-      it 'defaults @active_nav to courses when mode is blank' do
+      it 'defaults @active_nav to explore when mode is blank' do
         get :show, params: { id: program.id }
-        expect(assigns(:active_nav)).to eq('courses')
+        expect(assigns(:active_nav)).to eq('explore')
       end
     end
   end

--- a/spec/policies/content_policy_spec.rb
+++ b/spec/policies/content_policy_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentPolicy do
+  let(:learning_partner) { create(:learning_partner) }
+  let(:team) { create(:team, learning_partner:) }
+  let(:manager) { create(:user, :manager, t_team: team) }
+  let(:owner) { create(:user, :owner, t_team: team) }
+  let(:learner) { create(:user, :learner, t_team: team) }
+  let(:support) { create(:user, :owner, role: 'support', t_team: team) }
+  let(:record) { :content }
+
+  describe '#index?' do
+    it 'allows managers' do
+      expect(described_class.new(manager, record)).to be_index
+    end
+
+    it 'allows owners' do
+      expect(described_class.new(owner, record)).to be_index
+    end
+
+    it 'allows support users' do
+      expect(described_class.new(support, record)).to be_index
+    end
+
+    it 'denies learners' do
+      expect(described_class.new(learner, record)).not_to be_index
+    end
+  end
+end

--- a/spec/requests/content_spec.rb
+++ b/spec/requests/content_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Content', type: :request do
+  let(:learning_partner) { create(:learning_partner) }
+  let(:team) { create(:team, learning_partner:) }
+  let(:manager) { create(:user, :manager, t_team: team, learning_partner:) }
+  let(:learner) { create(:user, :learner, t_team: team) }
+
+  describe 'GET #index' do
+    context 'when signed in as a manager' do
+      before { sign_in manager }
+
+      it 'returns ok' do
+        get content_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders the index template' do
+        get content_path
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'when signed in as a learner' do
+      before { sign_in learner }
+
+      it 'redirects to 401 page' do
+        get content_path
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+
+    context 'when not signed in' do
+      it 'redirects to login' do
+        get content_path
+        expect(response).to redirect_to(new_login_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1407

## Summary
- New `GET /content` route → `ContentController#index` showing Courses (content-studio managers only), Programs, and Classroom Kit (feature-flagged) with count badges
- `ContentPolicy` gates the page on `privileged_user?`; the Courses row is additionally gated on `policy(:course).manage?`
- Sidebar: replaces the separate Programs and Courses nav items with a single **My Content** entry (`rectangle-group` icon); Courses item retained separately for admins
- `active_nav` propagated to `'content'` for all child pages (courses manage, program manage/show, course show in manager mode)
- `chip_component` extended with `published`, `unpublished`, and `transparent` colorschemes plus a `pill: true` option (`rounded-full`, `px-2 py-1`) matching the Figma badge spec
- Demo page and `ui_manifest.md` updated with new colorscheme table and examples

## Figma
https://www.figma.com/design/EI26SbXzbtis3zTnwLyHix/Manager-Pages-Redesign?node-id=1014-12616&m=dev