### PR TITLE
Classroom kit creation flow and landing page integration

### DIFF
--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -3,6 +3,14 @@
 module Api
   module Internal
     class ClassroomKitsController < BaseController
+      def index
+        kits = neo_ai.list_kits
+        filtered = filter_by_studio_status(kits, params[:studio_status])
+        limit = params[:limit]&.to_i
+        filtered = filtered.first(limit) if limit&.positive?
+        render json: filtered.map { |k| serialize_kit(k) }
+      end
+
       def show
         data = neo_ai.get_kit(params[:id])
         render json: data
@@ -34,6 +42,31 @@ module Api
           learning_partner_id: current_user.learning_partner_id
         )
         render json: { status: :ok }
+      end
+
+      private
+
+      def filter_by_studio_status(kits, status)
+        case status.presence
+        when 'completed'   then kits.select { |k| k['status']&.upcase == 'COMPLETED' }
+        when 'in_progress' then kits.reject { |k| k['status']&.upcase == 'COMPLETED' }
+        else kits
+        end
+      end
+
+      def serialize_kit(data)
+        {
+          id: data['kit_id'],
+          title: data['title'],
+          status: data['status'],
+          stage: data['stage'],
+          thumbnail_url: data['thumbnail_url'],
+          doc_count: data['num_components'].to_i,
+          created_at: data['created_at'],
+          updated_at: nil,
+          expires_at: data['expires_at'],
+          components: []
+        }
       end
     end
   end

--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -12,7 +12,8 @@ module Api
         title = params[:title]
         data = neo_ai.create_kit(
           files: params[:files],
-          components: Array(params[:components])
+          components: Array(params[:components]),
+          title: title
         )
         kit_id = data['kit_id']
         Rails.cache.write("kit_title_#{kit_id}", title, expires_in: 90.days) if title.present?

--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -20,6 +20,13 @@ module Api
         render json: { kit_id: kit_id }
       end
 
+      def destroy
+        neo_ai.delete_kit(params[:id])
+        head :no_content
+      rescue Faraday::BadRequestError
+        render json: { error: t('content_studio.classroom_kits.discard.locked') }, status: :unprocessable_entity
+      end
+
       def save
         authorize :classroom_kit, :save?
         NeoAi::ClassroomKitSaveService.new(neo_ai).call(

--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -3,6 +3,11 @@
 module Api
   module Internal
     class ClassroomKitsController < BaseController
+      def show
+        data = neo_ai.get_kit(params[:id])
+        render json: data
+      end
+
       def create
         title = params[:title]
         data = neo_ai.create_kit(
@@ -14,9 +19,13 @@ module Api
         render json: { kit_id: kit_id }
       end
 
-      def show
-        data = neo_ai.get_kit(params[:id])
-        render json: data
+      def save
+        authorize :classroom_kit, :save?
+        NeoAi::ClassroomKitSaveService.new(neo_ai).call(
+          params[:id],
+          learning_partner_id: current_user.learning_partner_id
+        )
+        render json: { status: :ok }
       end
     end
   end

--- a/app/controllers/api/internal/courses_controller.rb
+++ b/app/controllers/api/internal/courses_controller.rb
@@ -141,7 +141,8 @@ module Api
           enrollments_count: 0,
           team_enrollments_count: 0,
           modules: [],
-          progress: nil
+          progress: nil,
+          created_at: data['created_at']
         }
       end
 

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class ClassroomKitsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_kit, only: %i[show download]
+
+  def index
+    authorize :classroom_kit, :index?
+    @kits = ClassroomKit.where(learning_partner_id: current_user.learning_partner_id)
+                        .order(created_at: :desc)
+  end
+
+  def show
+    authorize @kit, :show?
+    @components = @kit.classroom_kit_components
+  end
+
+  def download
+    authorize @kit, :show?
+    data = neo_ai_client.get_kit(@kit.neo_ai_kit_id)
+    component = Array(data['components']).find { |c| c['id'] == params[:component_id] }
+    return head :not_found if component.nil? || component['download_url'].blank?
+
+    redirect_to component['download_url'], allow_other_host: true
+  end
+
+  private
+
+  def set_kit
+    @kit = ClassroomKit.find(params[:id])
+  end
+
+  def neo_ai_client
+    partner_id = if Rails.env.development?
+                   NEO_AI_PARTNER_ID
+                 else
+                   OpenSSL::HMAC.hexdigest('SHA256', NEO_AI_PARTNER_HMAC_SECRET,
+                                           current_user.learning_partner_id.to_s)
+                 end
+    NeoAi::Client.new(partner_id: partner_id)
+  end
+end

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -22,12 +22,16 @@ class ClassroomKitsController < ApplicationController
     return head :not_found if component.nil? || component['download_url'].blank?
 
     redirect_to component['download_url'], allow_other_host: true
+  rescue Faraday::Error => e
+    Rails.logger.warn("[ClassroomKits] download failed: #{e.message}")
+    flash[:alert] = t('classroom_kits.download.failed')
+    redirect_to classroom_kit_path(@kit)
   end
 
   private
 
   def set_kit
-    @kit = ClassroomKit.find(params[:id])
+    @kit = ClassroomKit.find_by!(id: params[:id], learning_partner_id: current_user.learning_partner_id)
   end
 
   def neo_ai_client

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -9,5 +9,6 @@ class ContentController < ApplicationController
       @courses_unpublished_count = Course.where(learning_partner_id: lp_id, is_published: false).count
     end
     @programs_count = Program.where(learning_partner_id: lp_id).count
+    @classroom_kits_count = ClassroomKit.where(learning_partner_id: lp_id).count if policy(:classroom_kit).index?
   end
 end

--- a/app/models/classroom_kit.rb
+++ b/app/models/classroom_kit.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ClassroomKit < ApplicationRecord
+  belongs_to :learning_partner
+  has_many :classroom_kit_components, dependent: :destroy
+
+  validates :neo_ai_kit_id, presence: true, uniqueness: true
+end

--- a/app/models/classroom_kit_component.rb
+++ b/app/models/classroom_kit_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ClassroomKitComponent < ApplicationRecord
+  belongs_to :classroom_kit
+
+  validates :neo_ai_component_id, :component_type, presence: true
+end

--- a/app/models/classroom_kit_component.rb
+++ b/app/models/classroom_kit_component.rb
@@ -3,5 +3,6 @@
 class ClassroomKitComponent < ApplicationRecord
   belongs_to :classroom_kit
 
-  validates :neo_ai_component_id, :component_type, presence: true
+  validates :neo_ai_component_id, presence: true, uniqueness: true
+  validates :component_type, presence: true
 end

--- a/app/policies/classroom_kit_policy.rb
+++ b/app/policies/classroom_kit_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ClassroomKitPolicy
+  attr_reader :user, :classroom_kit
+
+  def initialize(user, classroom_kit)
+    @user = user
+    @classroom_kit = classroom_kit
+  end
+
+  def index?
+    user.privileged_user?
+  end
+
+  def show?
+    user.privileged_user?
+  end
+
+  def save?
+    user.content_studio_creator?
+  end
+end

--- a/app/services/neo_ai/classroom_kit_save_service.rb
+++ b/app/services/neo_ai/classroom_kit_save_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module NeoAi
+  class ClassroomKitSaveService
+    def initialize(neo_ai_client)
+      @neo_ai = neo_ai_client
+    end
+
+    def call(neo_ai_kit_id, learning_partner_id:)
+      data = @neo_ai.get_kit(neo_ai_kit_id)
+      title = Rails.cache.read("kit_title_#{neo_ai_kit_id}") || data['title']
+
+      ActiveRecord::Base.transaction do
+        kit = ClassroomKit.find_or_initialize_by(neo_ai_kit_id: neo_ai_kit_id)
+        kit.update!(title: title, learning_partner_id: learning_partner_id)
+        save_components(kit, data['components'] || [])
+        kit
+      end
+    end
+
+    private
+
+    def save_components(kit, components)
+      components.each do |comp|
+        record = kit.classroom_kit_components
+                    .find_or_initialize_by(neo_ai_component_id: comp['id'])
+        record.update!(component_type: comp['type'], title: comp['title'])
+      end
+    end
+  end
+end

--- a/app/services/neo_ai/client.rb
+++ b/app/services/neo_ai/client.rb
@@ -62,6 +62,11 @@ module NeoAi
       JSON.parse(response.body)
     end
 
+    def list_kits
+      response = kit_get('/kit/list-kits')
+      JSON.parse(response.body).fetch('kits', [])
+    end
+
     def get_kit(kit_id)
       response = kit_get("/kit/#{kit_id}")
       JSON.parse(response.body)

--- a/app/services/neo_ai/client.rb
+++ b/app/services/neo_ai/client.rb
@@ -83,6 +83,14 @@ module NeoAi
     end
 
     # NeoAI declares these as FastAPI Query(...) params, not Body — must be query string.
+    def delete_kit(kit_id)
+      build_connection.post("#{API_PREFIX}/kit/delete-kit") do |req|
+        req.params[:kit_id] = kit_id
+        req.params[:partner_id] = partner_id
+      end
+    end
+
+    # NeoAI declares these as FastAPI Query(...) params, not Body — must be query string.
     def delete_course(course_id)
       build_connection.post("#{API_PREFIX}/course/delete-course") do |req|
         req.params[:course_id] = course_id

--- a/app/services/neo_ai/client.rb
+++ b/app/services/neo_ai/client.rb
@@ -55,8 +55,10 @@ module NeoAi
       JSON.parse(response.body)
     end
 
-    def create_kit(files:, components:)
-      response = kit_post('/kit/create-kit', { files: files, components: components })
+    def create_kit(files:, components:, title:)
+      body = { files: files, components: components }
+      body[:title] = title if title.present?
+      response = kit_post('/kit/create-kit', body)
       JSON.parse(response.body)
     end
 

--- a/app/views/classroom_kits/index.html.erb
+++ b/app/views/classroom_kits/index.html.erb
@@ -1,0 +1,22 @@
+<div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4">
+  <h1 class="heading-xl"><%= t('classroom_kits.index.title') %></h1>
+</div>
+
+<% if @kits.empty? %>
+  <div class="flex flex-col items-center gap-3 py-16 text-center">
+    <%= icon('academic-cap', css: 'w-12 h-12 text-letter-color-light') %>
+    <p class="main-text-md-medium text-letter-color"><%= t('classroom_kits.index.empty') %></p>
+  </div>
+<% else %>
+  <div class="flex flex-col gap-3">
+    <% @kits.each do |kit| %>
+      <%= link_to classroom_kit_path(kit), class: 'flex items-center gap-4 bg-white border border-line-colour-light rounded-2xl px-5 py-4 hover:bg-primary-light-50 transition-colors' do %>
+        <div class="flex-1 flex flex-col gap-1 min-w-0">
+          <span class="main-text-md-semibold text-letter-color truncate"><%= kit.title.presence || t('classroom_kits.untitled') %></span>
+          <span class="general-text-sm-normal text-letter-color-light"><%= l(kit.created_at, format: :short) %></span>
+        </div>
+        <%= icon('chevron-right', css: 'h-5 w-5 text-primary flex-shrink-0') %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/classroom_kits/show.html.erb
+++ b/app/views/classroom_kits/show.html.erb
@@ -1,0 +1,39 @@
+<%
+  component_labels = {
+    'slide_deck'       => t('classroom_kits.components.slide_deck'),
+    'trainer_guide'    => t('classroom_kits.components.trainer_guide'),
+    'learner_workbook' => t('classroom_kits.components.learner_workbook'),
+    'assessment'       => t('classroom_kits.components.assessment'),
+    'quiz'             => t('classroom_kits.components.quiz')
+  }
+%>
+
+<div class="flex flex-col gap-6 py-3">
+  <div class="flex items-center gap-2">
+    <%= link_to classroom_kits_path do %>
+      <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
+        <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
+      </span>
+    <% end %>
+    <span class="main-text-lg-semibold text-letter-color"><%= @kit.title.presence || t('classroom_kits.untitled') %></span>
+  </div>
+
+  <div class="bg-white border border-line-colour-light rounded-2xl p-6 flex flex-col gap-4">
+    <span class="main-text-md-semibold text-letter-color"><%= t('classroom_kits.show.components_heading') %></span>
+
+    <div class="flex flex-col gap-3">
+      <% @components.each do |component| %>
+        <div class="flex items-center gap-3">
+          <span class="flex-1 main-text-sm-normal text-letter-color bg-white-light border border-line-colour-light rounded-lg px-4 py-3">
+            <%= component_labels[component.component_type] || component.component_type.humanize %>
+          </span>
+          <%= link_to download_component_classroom_kit_path(@kit, component_id: component.neo_ai_component_id),
+                      class: 'flex-shrink-0 text-primary hover:text-primary-dark',
+                      data: { turbo: false } do %>
+            <%= icon 'arrow-down-tray', css: 'w-6 h-6' %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -22,10 +22,13 @@
     <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
   <% end %>
 
-  <% if APP_CONFIG.classroom_kit_enabled? %>
-    <div class="flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5">
+  <% if APP_CONFIG.classroom_kit_enabled? && policy(:classroom_kit).index? %>
+    <%= link_to classroom_kits_path, class: "flex items-center gap-3 border-b border-line-colour pl-2 pr-4 py-5 hover:bg-primary-light-50" do %>
       <span class="flex-1 text-base font-medium text-primary"><%= t('content.classroom_kit') %></span>
+      <div class="flex items-center gap-2">
+        <%= chip_component(text: @classroom_kits_count.to_s, colorscheme: 'transparent', pill: true) %>
+      </div>
       <%= icon('chevron-right', css: 'h-5 w-5 text-primary') %>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,3 +488,16 @@ en:
   llm:
     response:
       idontknow: "I'm unable to provide a response as the question appears outside the current scope."
+  classroom_kits:
+    untitled: "Untitled Kit"
+    index:
+      title: "Classroom Kits"
+      empty: "No classroom kits have been saved yet."
+    show:
+      components_heading: "Components"
+    components:
+      slide_deck: "Slide deck for learners"
+      trainer_guide: "Trainer guide"
+      learner_workbook: "Learner workbook"
+      assessment: "Assessment"
+      quiz: "Quiz"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,8 @@ en:
       idontknow: "I'm unable to provide a response as the question appears outside the current scope."
   classroom_kits:
     untitled: "Untitled Kit"
+    download:
+      failed: "Download failed. Please try again."
     index:
       title: "Classroom Kits"
       empty: "No classroom kits have been saved yet."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,11 @@ Rails.application.routes.draw do
   end
   resources :settings, only: :index
   get 'content', to: 'content#index'
+  resources :classroom_kits, only: %i[index show] do
+    member do
+      get 'components/:component_id/download', action: :download, as: :download_component
+    end
+  end
 
   resource :login, only: %i[new create] do
     collection do

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       post 'classroom_kits', to: 'classroom_kits#create'
       get  'classroom_kits/:id', to: 'classroom_kits#show'
       patch 'classroom_kits/:id/save', to: 'classroom_kits#save'
+      delete 'classroom_kits/:id', to: 'classroom_kits#destroy'
     end
   end
 end

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       delete 'courses/:course_id/lessons/:lesson_id', to: 'courses#delete_lesson'
       post 'courses/:course_id/lessons/:lesson_id/regenerate', to: 'courses#regenerate_lesson'
       get 'courses/:course_id/lessons/:id', to: 'courses/lessons#show'
+      get  'classroom_kits', to: 'classroom_kits#index'
       post 'classroom_kits', to: 'classroom_kits#create'
       get  'classroom_kits/:id', to: 'classroom_kits#show'
       patch 'classroom_kits/:id/save', to: 'classroom_kits#save'

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       get 'courses/:course_id/lessons/:id', to: 'courses/lessons#show'
       post 'classroom_kits', to: 'classroom_kits#create'
       get  'classroom_kits/:id', to: 'classroom_kits#show'
+      patch 'classroom_kits/:id/save', to: 'classroom_kits#save'
     end
   end
 end

--- a/db/migrate/20260618012046_create_classroom_kits.rb
+++ b/db/migrate/20260618012046_create_classroom_kits.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateClassroomKits < ActiveRecord::Migration[8.0]
   def change
     create_table :classroom_kits do |t|

--- a/db/migrate/20260618012046_create_classroom_kits.rb
+++ b/db/migrate/20260618012046_create_classroom_kits.rb
@@ -1,0 +1,13 @@
+class CreateClassroomKits < ActiveRecord::Migration[8.0]
+  def change
+    create_table :classroom_kits do |t|
+      t.string :title
+      t.string :neo_ai_kit_id, null: false
+      t.references :learning_partner, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :classroom_kits, :neo_ai_kit_id, unique: true
+  end
+end

--- a/db/migrate/20260618012101_create_classroom_kit_components.rb
+++ b/db/migrate/20260618012101_create_classroom_kit_components.rb
@@ -8,5 +8,7 @@ class CreateClassroomKitComponents < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
+
+    add_index :classroom_kit_components, :neo_ai_component_id, unique: true
   end
 end

--- a/db/migrate/20260618012101_create_classroom_kit_components.rb
+++ b/db/migrate/20260618012101_create_classroom_kit_components.rb
@@ -1,0 +1,12 @@
+class CreateClassroomKitComponents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :classroom_kit_components do |t|
+      t.references :classroom_kit, null: false, foreign_key: true
+      t.string :neo_ai_component_id, null: false
+      t.string :component_type, null: false
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260618012101_create_classroom_kit_components.rb
+++ b/db/migrate/20260618012101_create_classroom_kit_components.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateClassroomKitComponents < ActiveRecord::Migration[8.0]
   def change
     create_table :classroom_kit_components do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_18_012101) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_18_062854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_18_012101) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["classroom_kit_id"], name: "index_classroom_kit_components_on_classroom_kit_id"
+    t.index ["neo_ai_component_id"], name: "index_classroom_kit_components_on_neo_ai_component_id", unique: true
   end
 
   create_table "classroom_kits", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_02_033317) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_18_012101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -78,6 +78,26 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_02_033317) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["learning_partner_id"], name: "index_certificate_templates_on_learning_partner_id"
+  end
+
+  create_table "classroom_kit_components", force: :cascade do |t|
+    t.bigint "classroom_kit_id", null: false
+    t.string "neo_ai_component_id", null: false
+    t.string "component_type", null: false
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["classroom_kit_id"], name: "index_classroom_kit_components_on_classroom_kit_id"
+  end
+
+  create_table "classroom_kits", force: :cascade do |t|
+    t.string "title"
+    t.string "neo_ai_kit_id", null: false
+    t.bigint "learning_partner_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["learning_partner_id"], name: "index_classroom_kits_on_learning_partner_id"
+    t.index ["neo_ai_kit_id"], name: "index_classroom_kits_on_neo_ai_kit_id", unique: true
   end
 
   create_table "contact_leads", force: :cascade do |t|
@@ -425,6 +445,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_02_033317) do
   add_foreign_key "assessments", "courses"
   add_foreign_key "assessments", "users"
   add_foreign_key "certificate_templates", "learning_partners"
+  add_foreign_key "classroom_kit_components", "classroom_kits"
+  add_foreign_key "classroom_kits", "learning_partners"
   add_foreign_key "course_certificates", "courses"
   add_foreign_key "course_certificates", "users"
   add_foreign_key "course_modules", "courses"

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -10,6 +10,16 @@ module ContentStudio
         head :service_unavailable
       end
 
+      def save
+        ApiClient.save_classroom_kit(params[:id])
+        flash[:notice] = t('.saved')
+        redirect_to root_path
+      rescue Faraday::Error => e
+        Rails.logger.error("[ContentStudio] kit structure#save failed: #{e.message}")
+        flash[:alert] = t('.save_failed')
+        redirect_to kit_structure_path(id: params[:id])
+      end
+
       def download
         kit = ApiClient.get_classroom_kit(params[:id])
         component = kit.components.find { |c| c.id.to_s == params[:component_id].to_s }

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -13,7 +13,7 @@ module ContentStudio
       def save
         ApiClient.save_classroom_kit(params[:id])
         flash[:notice] = t('.saved')
-        redirect_to root_path
+        redirect_to main_app.root_path
       rescue Faraday::Error => e
         Rails.logger.error("[ContentStudio] kit structure#save failed: #{e.message}")
         flash[:alert] = t('.save_failed')
@@ -22,9 +22,13 @@ module ContentStudio
 
       def discard
         ApiClient.discard_kit(params[:id])
-        redirect_to root_path
+        redirect_to main_app.root_path
       rescue Faraday::BadRequestError
         flash[:alert] = t('content_studio.classroom_kits.discard.locked')
+        redirect_to kit_structure_path(id: params[:id])
+      rescue Faraday::Error => e
+        Rails.logger.error("[ContentStudio] kit structure#discard failed: #{e.message}")
+        flash[:alert] = t('.discard_failed')
         redirect_to kit_structure_path(id: params[:id])
       end
 

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -20,6 +20,14 @@ module ContentStudio
         redirect_to kit_structure_path(id: params[:id])
       end
 
+      def discard
+        ApiClient.discard_kit(params[:id])
+        redirect_to root_path
+      rescue Faraday::BadRequestError
+        flash[:alert] = t('content_studio.classroom_kits.discard.locked')
+        redirect_to kit_structure_path(id: params[:id])
+      end
+
       def download
         kit = ApiClient.get_classroom_kit(params[:id])
         component = kit.components.find { |c| c.id.to_s == params[:component_id].to_s }

--- a/engines/content_studio/app/controllers/content_studio/courses_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/courses_controller.rb
@@ -5,11 +5,21 @@ module ContentStudio
     def index
       clear_wizard_session
       @stats = ApiClient.course_stats
-      @in_progress = ApiClient.list_courses_by_status('in_progress')
-      @completed = ApiClient.list_courses_by_status('completed')
+
+      in_progress_courses = ApiClient.list_courses_by_status('in_progress')
+      in_progress_kits    = ApiClient.list_classroom_kits_by_status('in_progress')
+      completed_courses   = ApiClient.list_courses_by_status('completed')
+      completed_kits      = ApiClient.list_classroom_kits_by_status('completed')
+
+      @in_progress_creations = sort_creations(in_progress_courses + in_progress_kits)
+      @completed_creations   = sort_creations(completed_courses + completed_kits)
     end
 
     private
+
+    def sort_creations(items)
+      items.sort_by { |item| item.created_at.to_s }.reverse
+    end
 
     def clear_wizard_session
       session.delete(:wizard_file_urls)

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -83,9 +83,22 @@ module ContentStudio
         categories: course.categories || [],
         rating: course.rating,
         progress: course.progress,
-        badge: studio_badge(course.level)
+        badge: studio_badge(course.level),
+        type_tag: { label: 'Course', bg_color: 'bg-primary-light-200', text_color: 'text-letter-color' }
       )
       link_to(card, course_structure_path(id: course.id), class: 'block')
+    end
+
+    def studio_kit_card(kit)
+      card = course_card_component(
+        title: kit.title.presence || 'Untitled Kit',
+        banner_url: kit.thumbnail_url.presence,
+        modules_count: kit.doc_count || 0,
+        modules_label: 'Document',
+        categories: [],
+        type_tag: { label: 'Classroom Kit', bg_color: 'bg-secondary-light-200', text_color: 'text-letter-color' }
+      )
+      link_to(card, kit_structure_path(id: kit.id), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
@@ -12,8 +12,9 @@ export default class extends Controller {
 
   async connect() {
     if (this.startUrlValue) {
-      if (sessionStorage.getItem('kit_generation_started')) return
-      sessionStorage.setItem('kit_generation_started', '1')
+      const storageKey = `generation_started_${this.startUrlValue}`
+      if (sessionStorage.getItem(storageKey)) return
+      sessionStorage.setItem(storageKey, '1')
       // Run API call and phase transitions in parallel
       // Minimum display: 4s uploading + 4s crafting before redirect
       try {
@@ -21,6 +22,7 @@ export default class extends Controller {
           this.startGeneration(),
           this.runPhaseTransitions()
         ])
+        sessionStorage.removeItem(storageKey)
         if (result?.redirect_url) { window.location.href = result.redirect_url; return }
       } catch {
         // silent — error page only shown when server returns state=error

--- a/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
@@ -22,10 +22,11 @@ export default class extends Controller {
           this.startGeneration(),
           this.runPhaseTransitions()
         ])
-        sessionStorage.removeItem(storageKey)
         if (result?.redirect_url) { window.location.href = result.redirect_url; return }
       } catch {
         // silent — error page only shown when server returns state=error
+      } finally {
+        sessionStorage.removeItem(storageKey)
       }
       // status_url was set by startGeneration — begin polling
       if (this.statusUrlValue) {

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -105,8 +105,17 @@
 
       <%# Actions %>
       <div class="flex gap-3">
-        <%= button_component(text: 'Discard Kit', type: 'outline', colorscheme: 'danger', size: 'sm',
-                             html_options: { class: 'flex-1' }) %>
+        <%= link_to alert_modal_path(
+              title: t('content_studio.classroom_kits.discard.confirm.title'),
+              description: t('content_studio.classroom_kits.discard.confirm.description', title: @kit.title.presence || 'this kit'),
+              action_path: discard_kit_path(id: @kit.id),
+              method: 'delete',
+              action_text: t('content_studio.classroom_kits.discard.confirm.action'),
+              action_type: 'danger'
+            ), class: 'flex-1', data: { turbo_frame: 'modal' } do %>
+          <%= button_component(text: 'Discard Kit', type: 'outline', colorscheme: 'danger', size: 'sm',
+                               html_options: { class: 'w-full' }) %>
+        <% end %>
         <%= form_with url: save_classroom_kit_path(id: @kit.id), method: :patch, class: 'flex-1',
                       data: { turbo_frame: '_top' } do |f| %>
           <%= f.button class: 'w-full', disabled: !all_ready do %>

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -107,8 +107,13 @@
       <div class="flex gap-3">
         <%= button_component(text: 'Discard Kit', type: 'outline', colorscheme: 'danger', size: 'sm',
                              html_options: { class: 'flex-1' }) %>
-        <%= button_component(text: 'Save Kit', colorscheme: 'primary', size: 'sm', disabled: true,
-                             html_options: { class: 'flex-1' }) %>
+        <%= form_with url: save_classroom_kit_path(id: @kit.id), method: :patch, class: 'flex-1',
+                      data: { turbo_frame: '_top' } do |f| %>
+          <%= f.button class: 'w-full', disabled: !all_ready do %>
+            <%= button_component(text: 'Save Kit', colorscheme: 'primary', size: 'sm',
+                                 disabled: !all_ready, html_options: { class: 'w-full' }) %>
+          <% end %>
+        <% end %>
       </div>
     </div>
 

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -91,21 +91,25 @@
 
           <%# In Progress panel %>
           <div data-tabs-target="panelItem">
-            <% if @in_progress.any? %>
-              <% cards = @in_progress.map { |course| studio_course_card(course, 'in_progress') } %>
+            <% if @in_progress_creations.any? %>
+              <% cards = @in_progress_creations.map { |item|
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'in_progress')
+                 } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>
-              <p class="general-text-lg-normal text-letter-color-light py-8 text-center">No courses in progress.</p>
+              <p class="general-text-lg-normal text-letter-color-light py-8 text-center">No creations in progress.</p>
             <% end %>
           </div>
 
           <%# Completed panel %>
           <div class="hidden" data-tabs-target="panelItem">
-            <% if @completed.any? %>
-              <% cards = @completed.map { |course| studio_course_card(course, 'completed') } %>
+            <% if @completed_creations.any? %>
+              <% cards = @completed_creations.map { |item|
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'completed')
+                 } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>
-              <p class="general-text-lg-normal text-letter-color-light py-8 text-center">No completed courses yet.</p>
+              <p class="general-text-lg-normal text-letter-color-light py-8 text-center">No completed creations yet.</p>
             <% end %>
           </div>
 

--- a/engines/content_studio/config/locales/en.yml
+++ b/engines/content_studio/config/locales/en.yml
@@ -49,6 +49,10 @@ en:
           not_verified: "The lesson must be verified before it can be downloaded."
           expired: "The lesson video could not be downloaded. The link may have expired — please try again."
     classroom_kits:
+      structure:
+        save:
+          saved: "Classroom kit saved successfully."
+          save_failed: "Something went wrong while saving. Please try again."
       discard:
         locked: "Kit is currently being processed. Please wait before deleting."
         confirm:

--- a/engines/content_studio/config/locales/en.yml
+++ b/engines/content_studio/config/locales/en.yml
@@ -53,6 +53,8 @@ en:
         save:
           saved: "Classroom kit saved successfully."
           save_failed: "Something went wrong while saving. Please try again."
+        discard:
+          discard_failed: "Something went wrong while discarding. Please try again."
       discard:
         locked: "Kit is currently being processed. Please wait before deleting."
         confirm:

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -9,6 +9,7 @@ ContentStudio::Engine.routes.draw do
   get 'classroom-kits/:id/components/:component_id/download', to: 'classroom_kits/structure#download',
                                                               as: :download_kit_component
   patch 'classroom-kits/:id/save', to: 'classroom_kits/structure#save', as: :save_classroom_kit
+  delete 'classroom-kits/:id', to: 'classroom_kits/structure#discard', as: :discard_kit
   get  'classroom-kits/new',            to: 'classroom_kits/wizard#new',          as: :new_classroom_kit
   post 'classroom-kits',                to: 'classroom_kits/wizard#create',       as: :classroom_kits
   get  'classroom-kits/:id/configure',  to: 'classroom_kits/wizard#configure',    as: :configure_classroom_kit

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -8,6 +8,7 @@ ContentStudio::Engine.routes.draw do
                                       as: :kit_structure
   get 'classroom-kits/:id/components/:component_id/download', to: 'classroom_kits/structure#download',
                                                               as: :download_kit_component
+  patch 'classroom-kits/:id/save', to: 'classroom_kits/structure#save', as: :save_classroom_kit
   get  'classroom-kits/new',            to: 'classroom_kits/wizard#new',          as: :new_classroom_kit
   post 'classroom-kits',                to: 'classroom_kits/wizard#create',       as: :classroom_kits
   get  'classroom-kits/:id/configure',  to: 'classroom_kits/wizard#configure',    as: :configure_classroom_kit

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -93,6 +93,10 @@ module ContentStudio
         client.create_classroom_kit(files: files, components: components, title: title)
       end
 
+      def save_classroom_kit(kit_id) # rubocop:disable Rails/Delegate
+        client.save_classroom_kit(kit_id)
+      end
+
       delegate :get_classroom_kit, to: :client
 
       private

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -97,7 +97,7 @@ module ContentStudio
         client.save_classroom_kit(kit_id)
       end
 
-      delegate :get_classroom_kit, to: :client
+      delegate :get_classroom_kit, :discard_kit, to: :client
 
       private
 

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -93,6 +93,10 @@ module ContentStudio
         client.create_classroom_kit(files: files, components: components, title: title)
       end
 
+      def list_classroom_kits_by_status(status) # rubocop:disable Rails/Delegate
+        client.list_classroom_kits_by_status(status)
+      end
+
       def save_classroom_kit(kit_id) # rubocop:disable Rails/Delegate
         client.save_classroom_kit(kit_id)
       end

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -125,6 +125,10 @@ module ContentStudio
       build_kit(JSON.parse(response.body))
     end
 
+    def discard_kit(kit_id)
+      connection.delete("#{BASE_PATH}/classroom_kits/#{kit_id}")
+    end
+
     def save_classroom_kit(kit_id)
       connection.patch("#{BASE_PATH}/classroom_kits/#{kit_id}/save")
     end

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -125,6 +125,10 @@ module ContentStudio
       build_kit(JSON.parse(response.body))
     end
 
+    def save_classroom_kit(kit_id)
+      connection.patch("#{BASE_PATH}/classroom_kits/#{kit_id}/save")
+    end
+
     private
 
     def build_kit(data)

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -120,6 +120,11 @@ module ContentStudio
       JSON.parse(response.body)['kit_id']
     end
 
+    def list_classroom_kits_by_status(status)
+      response = connection.get("#{BASE_PATH}/classroom_kits", { studio_status: status, limit: 12 })
+      JSON.parse(response.body).map { |k| build_kit(k) }
+    end
+
     def get_classroom_kit(kit_id)
       response = connection.get("#{BASE_PATH}/classroom_kits/#{kit_id}")
       build_kit(JSON.parse(response.body))
@@ -186,7 +191,8 @@ module ContentStudio
         enrollments_count: data['enrollments_count'],
         team_enrollments_count: data['team_enrollments_count'],
         modules: (data['modules'] || []).map { |m| build_module(m) },
-        progress: data['progress']
+        progress: data['progress'],
+        created_at: data['created_at']
       )
     end
 

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -66,6 +66,7 @@ module ContentStudio
     :modules,         # Array<ContentStudio::CourseModule>
     :progress,        # Integer 0–100 or nil
     :thumbnail_url,
+    :created_at,
     keyword_init: true
   )
 

--- a/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
         allow(ContentStudio::ApiClient).to receive(:save_classroom_kit)
       end
 
-      it 'redirects to the content studio root' do
+      it 'redirects to the host app root' do
         patch '/content_studio/classroom-kits/kit-abc/save'
-        expect(response).to redirect_to('/content_studio/')
+        expect(response).to redirect_to('/')
       end
 
       it 'calls ApiClient.save_classroom_kit with the kit id' do
@@ -27,6 +27,46 @@ RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
 
       it 'redirects back to the structure page' do
         patch '/content_studio/classroom-kits/kit-abc/save'
+        expect(response).to redirect_to('/content_studio/classroom-kits/kit-abc/structure')
+      end
+    end
+  end
+
+  describe 'DELETE /content_studio/classroom-kits/:id' do
+    context 'when discard succeeds' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:discard_kit)
+      end
+
+      it 'redirects to the host app root' do
+        delete '/content_studio/classroom-kits/kit-abc'
+        expect(response).to redirect_to('/')
+      end
+
+      it 'calls ApiClient.discard_kit with the kit id' do
+        delete '/content_studio/classroom-kits/kit-abc'
+        expect(ContentStudio::ApiClient).to have_received(:discard_kit).with('kit-abc')
+      end
+    end
+
+    context 'when NeoAI returns 400 (kit locked)' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:discard_kit).and_raise(Faraday::BadRequestError)
+      end
+
+      it 'redirects back to the structure page' do
+        delete '/content_studio/classroom-kits/kit-abc'
+        expect(response).to redirect_to('/content_studio/classroom-kits/kit-abc/structure')
+      end
+    end
+
+    context 'when discard raises a generic Faraday error' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:discard_kit).and_raise(Faraday::Error)
+      end
+
+      it 'redirects back to the structure page' do
+        delete '/content_studio/classroom-kits/kit-abc'
         expect(response).to redirect_to('/content_studio/classroom-kits/kit-abc/structure')
       end
     end

--- a/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../../rails_helper'
+
+RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
+  describe 'PATCH /content_studio/classroom-kits/:id/save' do
+    context 'when save succeeds' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:save_classroom_kit)
+      end
+
+      it 'redirects to the content studio root' do
+        patch '/content_studio/classroom-kits/kit-abc/save'
+        expect(response).to redirect_to('/content_studio/')
+      end
+
+      it 'calls ApiClient.save_classroom_kit with the kit id' do
+        patch '/content_studio/classroom-kits/kit-abc/save'
+        expect(ContentStudio::ApiClient).to have_received(:save_classroom_kit).with('kit-abc')
+      end
+    end
+
+    context 'when save raises a Faraday error' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:save_classroom_kit).and_raise(Faraday::Error)
+      end
+
+      it 'redirects back to the structure page' do
+        patch '/content_studio/classroom-kits/kit-abc/save'
+        expect(response).to redirect_to('/content_studio/classroom-kits/kit-abc/structure')
+      end
+    end
+  end
+end

--- a/engines/content_studio/spec/requests/content_studio/courses_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/courses_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe 'ContentStudio::Courses', type: :request do
   end
 
   before do
-    allow(ContentStudio::ApiClient).to receive(:course_stats).and_return(stats)
+    allow(ContentStudio::ApiClient).to receive_messages(
+      course_stats: stats,
+      list_classroom_kits_by_status: []
+    )
     allow(ContentStudio::ApiClient).to receive(:list_courses_by_status)
       .with('in_progress').and_return([in_progress_course])
     allow(ContentStudio::ApiClient).to receive(:list_courses_by_status).with('completed').and_return([])
@@ -59,7 +62,7 @@ RSpec.describe 'ContentStudio::Courses', type: :request do
     end
 
     it 'shows empty state for the Completed tab' do
-      expect(response.body).to include('No completed courses yet.')
+      expect(response.body).to include('No completed creations yet.')
     end
 
     it 'does not render a Show all Creations button' do

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
 
   it 'renders a download link for READY components' do
     render
-    expect(rendered).to include('https://s3.example.com/slide_deck.pptx')
+    expect(rendered).to include('classroom-kits/kit-123/components/comp-1/download')
   end
 
   it 'renders a spinner for PENDING components' do

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../../../rails_helper'
 
 RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
   before do
+    view.singleton_class.define_method(:alert_modal_path) { |**_| '/alert_modal' }
     view.singleton_class.include ContentStudio::Engine.routes.url_helpers
     assign(:kit, kit)
   end
@@ -100,6 +101,12 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
       render
       expect(rendered).to include('Kit is ready')
     end
+  end
+
+  it 'renders the Discard Kit button as a modal link to the alert_modal' do
+    render
+    expect(rendered).to include('/alert_modal')
+    expect(rendered).to include('Discard Kit')
   end
 
   context 'when a component has FAILED' do

--- a/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/index.html.erb_spec.rb
@@ -20,15 +20,31 @@ RSpec.describe 'content_studio/courses/index', type: :view do
       levels: ['Beginner'],
       enrollments_count: 0,
       team_enrollments_count: 0,
-      modules: []
+      modules: [],
+      created_at: '2025-06-10T10:00:00Z'
+    )
+  end
+
+  let(:sample_kit) do
+    ContentStudio::Kit.new(
+      id: 'kit-1',
+      title: 'Banking Basics',
+      status: 'IN_PROGRESS',
+      stage: nil,
+      thumbnail_url: nil,
+      doc_count: 3,
+      created_at: '2025-06-17T12:00:00Z',
+      updated_at: nil,
+      expires_at: nil,
+      components: []
     )
   end
 
   before do
     view.singleton_class.include ContentStudio::Engine.routes.url_helpers
     assign(:stats, stats)
-    assign(:in_progress, [sample_course])
-    assign(:completed, [])
+    assign(:in_progress_creations, [sample_kit, sample_course])
+    assign(:completed_creations, [])
   end
 
   it 'renders the greeting' do
@@ -57,7 +73,6 @@ RSpec.describe 'content_studio/courses/index', type: :view do
     expect(rendered).to include('Recent Creations')
     expect(rendered).to include('In Progress')
     expect(rendered).to include('Completed')
-    expect(rendered).not_to include('No published courses yet.')
   end
 
   it 'renders a course card in the In Progress tab' do
@@ -70,12 +85,41 @@ RSpec.describe 'content_studio/courses/index', type: :view do
     expect(rendered).to include('href="/content_studio/courses/1/structure"')
   end
 
-  context 'when the Completed tab has no courses' do
-    before { assign(:completed, []) }
+  it 'renders a kit card in the In Progress tab' do
+    render
+    expect(rendered).to include('Banking Basics')
+  end
+
+  it 'wraps each kit card in a link to its structure page' do
+    render
+    expect(rendered).to include('href="/content_studio/classroom-kits/kit-1/structure"')
+  end
+
+  it 'renders the Course type tag on course cards' do
+    render
+    expect(rendered).to include('Course')
+  end
+
+  it 'renders the Classroom Kit type tag on kit cards' do
+    render
+    expect(rendered).to include('Classroom Kit')
+  end
+
+  context 'when the Completed tab has no creations' do
+    before { assign(:completed_creations, []) }
 
     it 'shows empty state for the Completed tab' do
       render
-      expect(rendered).to include('No completed courses yet.')
+      expect(rendered).to include('No completed creations yet.')
+    end
+  end
+
+  context 'when there are no in-progress creations' do
+    before { assign(:in_progress_creations, []) }
+
+    it 'shows empty state for the In Progress tab' do
+      render
+      expect(rendered).to include('No creations in progress.')
     end
   end
 

--- a/spec/factories/classroom_kits.rb
+++ b/spec/factories/classroom_kits.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :classroom_kit do
+    title { 'Test Classroom Kit' }
+    sequence(:neo_ai_kit_id) { |n| "neo-kit-#{n}" }
+    learning_partner { association :learning_partner }
+  end
+
+  factory :classroom_kit_component do
+    classroom_kit { association :classroom_kit }
+    sequence(:neo_ai_component_id) { |n| "neo-comp-#{n}" }
+    component_type { 'slide_deck' }
+    title { 'Slide deck for learners' }
+  end
+end

--- a/spec/models/classroom_kit_component_spec.rb
+++ b/spec/models/classroom_kit_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomKitComponent, type: :model do
+  let(:kit) { create(:classroom_kit) }
+
+  describe 'associations' do
+    it 'belongs to a classroom_kit' do
+      component = build(:classroom_kit_component, classroom_kit: kit)
+      expect(component.classroom_kit).to eq(kit)
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid without neo_ai_component_id' do
+      component = build(:classroom_kit_component, classroom_kit: kit, neo_ai_component_id: nil)
+      expect(component).not_to be_valid
+    end
+
+    it 'is invalid without component_type' do
+      component = build(:classroom_kit_component, classroom_kit: kit, component_type: nil)
+      expect(component).not_to be_valid
+    end
+  end
+end

--- a/spec/models/classroom_kit_spec.rb
+++ b/spec/models/classroom_kit_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomKit, type: :model do
+  let(:learning_partner) { create(:learning_partner) }
+
+  describe 'associations' do
+    it 'belongs to a learning_partner' do
+      kit = build(:classroom_kit, learning_partner: learning_partner)
+      expect(kit.learning_partner).to eq(learning_partner)
+    end
+
+    it 'has many classroom_kit_components, destroyed with the kit' do
+      kit = create(:classroom_kit, learning_partner: learning_partner)
+      create(:classroom_kit_component, classroom_kit: kit)
+      expect { kit.destroy }.to change(ClassroomKitComponent, :count).by(-1)
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid without neo_ai_kit_id' do
+      kit = build(:classroom_kit, learning_partner: learning_partner, neo_ai_kit_id: nil)
+      expect(kit).not_to be_valid
+    end
+
+    it 'requires neo_ai_kit_id to be unique' do
+      create(:classroom_kit, learning_partner: learning_partner, neo_ai_kit_id: 'kit-1')
+      duplicate = build(:classroom_kit, learning_partner: learning_partner, neo_ai_kit_id: 'kit-1')
+      expect(duplicate).not_to be_valid
+    end
+  end
+end

--- a/spec/policies/classroom_kit_policy_spec.rb
+++ b/spec/policies/classroom_kit_policy_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomKitPolicy, type: :policy do
+  subject { described_class.new(user, kit) }
+
+  let(:learning_partner) { create(:learning_partner) }
+  let(:team) { create(:team, learning_partner:) }
+  let(:kit) { create(:classroom_kit, learning_partner:) }
+
+  describe '#index? / #show?' do
+    context 'when user is a manager' do
+      let(:user) { create(:user, :manager, t_team: team) }
+
+      it { is_expected.to be_index }
+      it { is_expected.to be_show }
+    end
+
+    context 'when user is an owner' do
+      let(:user) { create(:user, :owner, t_team: team) }
+
+      it { is_expected.to be_index }
+      it { is_expected.to be_show }
+    end
+
+    context 'when user is an admin' do
+      let(:user) { create(:user, :admin) }
+
+      it { is_expected.not_to be_index }
+      it { is_expected.not_to be_show }
+    end
+
+    context 'when user is a learner' do
+      let(:user) { create(:user, :learner, t_team: team) }
+
+      it { is_expected.not_to be_index }
+      it { is_expected.not_to be_show }
+    end
+  end
+
+  describe '#save?' do
+    context 'when user is a content studio creator' do
+      let(:user) { create(:user, :manager, t_team: team, content_studio_creator: true) }
+
+      it { is_expected.to be_save }
+    end
+
+    context 'when user is a manager without creator flag' do
+      let(:user) { create(:user, :manager, t_team: team) }
+
+      it { is_expected.not_to be_save }
+    end
+
+    context 'when user is a learner' do
+      let(:user) { create(:user, :learner, t_team: team) }
+
+      it { is_expected.not_to be_save }
+    end
+  end
+end

--- a/spec/requests/api/internal/classroom_kits_spec.rb
+++ b/spec/requests/api/internal/classroom_kits_spec.rb
@@ -25,6 +25,35 @@ RSpec.describe 'Api::Internal::ClassroomKits', type: :request do
     end
   end
 
+  describe 'PATCH /api/internal/classroom_kits/:id/save' do
+    let(:creator) { create(:user, :owner, content_studio_creator: true) }
+    let(:save_service) { instance_double(NeoAi::ClassroomKitSaveService) }
+
+    before do
+      sign_in creator
+      allow(NeoAi::ClassroomKitSaveService).to receive(:new).and_return(save_service)
+      allow(save_service).to receive(:call)
+    end
+
+    it 'returns 200 and delegates to ClassroomKitSaveService' do
+      patch '/api/internal/classroom_kits/kit-abc/save'
+      expect(response).to have_http_status(:ok)
+      expect(save_service).to have_received(:call).with('kit-abc', learning_partner_id: creator.learning_partner_id)
+    end
+
+    it 'returns 403 for a user without content_studio_creator flag' do
+      sign_in privileged_user
+      patch '/api/internal/classroom_kits/kit-abc/save'
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 403 for a learner' do
+      sign_in learner
+      patch '/api/internal/classroom_kits/kit-abc/save'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe 'POST /api/internal/classroom_kits' do
     before { sign_in privileged_user }
 

--- a/spec/requests/api/internal/classroom_kits_spec.rb
+++ b/spec/requests/api/internal/classroom_kits_spec.rb
@@ -69,23 +69,26 @@ RSpec.describe 'Api::Internal::ClassroomKits', type: :request do
         expect(response.parsed_body['kit_id']).to eq('kit-abc')
       end
 
-      it 'passes files and components to neo_ai.create_kit' do
+      it 'passes files, components and title to neo_ai.create_kit' do
         allow(neo_ai).to receive(:create_kit).and_return({ 'kit_id' => 'kit-abc' })
         post '/api/internal/classroom_kits',
-             params: { files: ['https://example.com/doc.pdf'], components: %w[slide_deck trainer_guide] }
+             params: { title: 'Banking Basics', files: ['https://example.com/doc.pdf'],
+                       components: %w[slide_deck trainer_guide] }
         expect(neo_ai).to have_received(:create_kit).with(
           files: ['https://example.com/doc.pdf'],
-          components: %w[slide_deck trainer_guide]
+          components: %w[slide_deck trainer_guide],
+          title: 'Banking Basics'
         )
       end
 
       it 'wraps a single component string in an array' do
         allow(neo_ai).to receive(:create_kit).and_return({ 'kit_id' => 'kit-abc' })
         post '/api/internal/classroom_kits',
-             params: { files: [], components: 'slide_deck' }
+             params: { title: 'Banking Basics', files: [], components: 'slide_deck' }
         expect(neo_ai).to have_received(:create_kit).with(
           files: anything,
-          components: ['slide_deck']
+          components: ['slide_deck'],
+          title: 'Banking Basics'
         )
       end
 

--- a/spec/requests/classroom_kits_spec.rb
+++ b/spec/requests/classroom_kits_spec.rb
@@ -64,12 +64,23 @@ RSpec.describe 'ClassroomKits', type: :request do
       end
     end
 
+    context 'when signed in as a manager from another learning partner' do
+      let(:other_manager) { create(:user, :manager) }
+
+      before { sign_in other_manager }
+
+      it 'returns 404' do
+        get classroom_kit_path(kit)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'when signed in as an admin' do
       before { sign_in admin }
 
-      it 'returns 403' do
+      it 'returns 404' do
         get classroom_kit_path(kit)
-        expect(response).to redirect_to(error_401_path)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -113,6 +124,19 @@ RSpec.describe 'ClassroomKits', type: :request do
       it 'returns 404' do
         get download_component_classroom_kit_path(kit, component_id: component.neo_ai_component_id)
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when NeoAI is unavailable' do
+      before do
+        sign_in manager
+        allow(neo_ai_client).to receive(:get_kit).and_raise(Faraday::ConnectionFailed, 'connection refused')
+      end
+
+      it 'redirects back to the kit page with a flash alert' do
+        get download_component_classroom_kit_path(kit, component_id: component.neo_ai_component_id)
+        expect(response).to redirect_to(classroom_kit_path(kit))
+        expect(flash[:alert]).to eq(I18n.t('classroom_kits.download.failed'))
       end
     end
 

--- a/spec/requests/classroom_kits_spec.rb
+++ b/spec/requests/classroom_kits_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ClassroomKits', type: :request do
+  let(:learning_partner) { create(:learning_partner) }
+  let(:team) { create(:team, learning_partner:) }
+  let(:manager) { create(:user, :manager, t_team: team) }
+  let(:admin) { create(:user, :admin) }
+  let(:learner) { create(:user, :learner, t_team: team) }
+  let!(:kit) { create(:classroom_kit, learning_partner:) }
+  let!(:component) { create(:classroom_kit_component, classroom_kit: kit) }
+
+  describe 'GET /classroom_kits' do
+    context 'when signed in as a manager' do
+      before { sign_in manager }
+
+      it 'returns 200' do
+        get classroom_kits_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'only lists kits for the manager learning partner' do
+        other_kit = create(:classroom_kit, title: 'Other Partner Kit')
+        get classroom_kits_path
+        expect(response.body).to include(kit.title)
+        expect(response.body).not_to include(other_kit.title)
+      end
+    end
+
+    context 'when signed in as an admin' do
+      before { sign_in admin }
+
+      it 'returns 403' do
+        get classroom_kits_path
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+
+    context 'when signed in as a learner' do
+      before { sign_in learner }
+
+      it 'returns 403' do
+        get classroom_kits_path
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+
+    context 'when not signed in' do
+      it 'redirects to login' do
+        get classroom_kits_path
+        expect(response).to redirect_to(new_login_path)
+      end
+    end
+  end
+
+  describe 'GET /classroom_kits/:id' do
+    context 'when signed in as a manager' do
+      before { sign_in manager }
+
+      it 'returns 200' do
+        get classroom_kit_path(kit)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when signed in as an admin' do
+      before { sign_in admin }
+
+      it 'returns 403' do
+        get classroom_kit_path(kit)
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+
+    context 'when signed in as a learner' do
+      before { sign_in learner }
+
+      it 'returns 403' do
+        get classroom_kit_path(kit)
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+  end
+
+  describe 'GET /classroom_kits/:id/components/:component_id/download' do
+    let(:neo_ai_client) { instance_double(NeoAi::Client) }
+    let(:download_url) { 'https://s3.example.com/slide.pptx?token=xyz' }
+
+    before do
+      stub_const('NEO_AI_PARTNER_HMAC_SECRET', 'test-secret')
+      allow(NeoAi::Client).to receive(:new).and_return(neo_ai_client)
+      allow(neo_ai_client).to receive(:get_kit).and_return(
+        'components' => [{ 'id' => component.neo_ai_component_id, 'download_url' => download_url }]
+      )
+    end
+
+    context 'when signed in as a manager' do
+      before { sign_in manager }
+
+      it 'redirects to the pre-signed download URL' do
+        get download_component_classroom_kit_path(kit, component_id: component.neo_ai_component_id)
+        expect(response).to redirect_to(download_url)
+      end
+    end
+
+    context 'when component is not found in NeoAi response' do
+      before do
+        sign_in manager
+        allow(neo_ai_client).to receive(:get_kit).and_return({ 'components' => [] })
+      end
+
+      it 'returns 404' do
+        get download_component_classroom_kit_path(kit, component_id: component.neo_ai_component_id)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when signed in as a learner' do
+      before { sign_in learner }
+
+      it 'returns 403' do
+        get download_component_classroom_kit_path(kit, component_id: component.neo_ai_component_id)
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+  end
+end

--- a/spec/services/neo_ai/classroom_kit_save_service_spec.rb
+++ b/spec/services/neo_ai/classroom_kit_save_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NeoAi::ClassroomKitSaveService do
+  let(:neo_ai) { instance_double(NeoAi::Client) }
+  let(:service) { described_class.new(neo_ai) }
+  let(:learning_partner) { create(:learning_partner) }
+  let(:neo_ai_data) do
+    {
+      'id' => 'kit-123',
+      'title' => 'Leadership Fundamentals',
+      'status' => 'COMPLETED',
+      'components' => [
+        { 'id' => 'comp-1', 'type' => 'slide_deck', 'title' => 'Slide deck for learners', 'status' => 'READY',
+          'download_url' => 'https://s3.example.com/slide.pptx' },
+        { 'id' => 'comp-2', 'type' => 'trainer_guide', 'title' => 'Trainer guide', 'status' => 'READY',
+          'download_url' => 'https://s3.example.com/guide.docx' }
+      ]
+    }
+  end
+
+  before do
+    allow(neo_ai).to receive(:get_kit).with('kit-123').and_return(neo_ai_data)
+  end
+
+  describe '#call — initial save' do
+    it 'creates a ClassroomKit with the correct attributes' do
+      kit = service.call('kit-123', learning_partner_id: learning_partner.id)
+      expect(kit.neo_ai_kit_id).to eq('kit-123')
+      expect(kit.title).to eq('Leadership Fundamentals')
+      expect(kit.learning_partner_id).to eq(learning_partner.id)
+    end
+
+    it 'creates ClassroomKitComponents for each component' do
+      kit = service.call('kit-123', learning_partner_id: learning_partner.id)
+      expect(kit.classroom_kit_components.count).to eq(2)
+    end
+
+    it 'maps component type and title correctly' do
+      kit = service.call('kit-123', learning_partner_id: learning_partner.id)
+      slide = kit.classroom_kit_components.find_by(neo_ai_component_id: 'comp-1')
+      expect(slide.component_type).to eq('slide_deck')
+      expect(slide.title).to eq('Slide deck for learners')
+    end
+
+    it 'prefers the cached title over the NeoAi title when present' do
+      allow(Rails.cache).to receive(:read).with('kit_title_kit-123').and_return('Custom Title')
+      kit = service.call('kit-123', learning_partner_id: learning_partner.id)
+      expect(kit.title).to eq('Custom Title')
+    end
+  end
+
+  describe '#call — idempotent re-save' do
+    it 'updates the existing kit and components without duplicating' do
+      service.call('kit-123', learning_partner_id: learning_partner.id)
+      expect { service.call('kit-123', learning_partner_id: learning_partner.id) }
+        .not_to change(ClassroomKit, :count)
+    end
+
+    it 'does not duplicate components on re-save' do
+      service.call('kit-123', learning_partner_id: learning_partner.id)
+      expect { service.call('kit-123', learning_partner_id: learning_partner.id) }
+        .not_to change(ClassroomKitComponent, :count)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add classroom kit save API (`PATCH /api/internal/classroom_kits/:id/save`) with persistence via `NeoAi::ClassroomKitSaveService`
- Pass kit `title` through the creation flow to the NeoAI `create-kit` API
- Add Discard Kit confirmation modal on the kit structure page
- Mix classroom kits into the Content Studio landing page Recent Creations carousels alongside courses, sorted newest-first; courses show a "Course" type tag, kits show a "Classroom Kit" type tag
- Fix `generation_polling_controller.js` sessionStorage guard: URL-key the guard so kit and course use separate keys, and clear it after a successful generation start so subsequent creations in the same tab are not blocked