### PR TITLE
Add zip download for classroom kit and auto-hide progress banner

### DIFF
--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -13,7 +13,8 @@ module Api
 
       def show
         data = neo_ai.get_kit(params[:id])
-        render json: data
+        saved = ClassroomKit.exists?(neo_ai_kit_id: params[:id])
+        render json: data.merge('saved_to_lms' => saved)
       end
 
       def create

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -61,10 +61,16 @@ module ContentStudio
         conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
         zip_data = Zip::OutputStream.write_buffer do |zip|
           ready_components.each do |component|
-            next if component.download_url.blank?
+            if component.download_url.blank?
+              Rails.logger.warn("[ContentStudio] download_all: skipping component #{component.id} (#{component.type}) — download_url is blank")
+              next
+            end
 
             file = conn.get(component.download_url)
-            next unless file.success?
+            unless file.success?
+              Rails.logger.warn("[ContentStudio] download_all: skipping component #{component.id} (#{component.type}) — fetch returned #{file.status}")
+              next
+            end
 
             content_type = file.headers['content-type'] || 'application/octet-stream'
             entry_name = "#{component.type.parameterize}-kit.#{ext_for(content_type)}"

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -22,7 +22,9 @@ module ContentStudio
 
       def discard
         ApiClient.discard_kit(params[:id])
-        redirect_to '/content'
+        redirect_to root_path
+      rescue Faraday::ResourceNotFound
+        redirect_to root_path
       rescue Faraday::BadRequestError
         flash[:alert] = t('content_studio.classroom_kits.discard.locked')
         redirect_to kit_structure_path(id: params[:id])

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -73,7 +73,7 @@ module ContentStudio
             end
 
             content_type = file.headers['content-type'] || 'application/octet-stream'
-            entry_name = "#{component.type.parameterize}-kit.#{ext_for(content_type)}"
+            entry_name = "#{component.type.parameterize}-#{component.id}.#{ext_for(content_type)}"
             zip.put_next_entry(entry_name)
             zip.write(file.body)
           end

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -30,6 +30,34 @@ module ContentStudio
         head :bad_gateway
       end
 
+      def download_all
+        kit = ApiClient.get_classroom_kit(params[:id])
+        ready_components = (kit.components || []).select { |c| c.status == 'READY' }
+
+        return head :not_found if ready_components.empty?
+
+        conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
+        zip_data = Zip::OutputStream.write_buffer do |zip|
+          ready_components.each do |component|
+            next if component.download_url.blank?
+
+            file = conn.get(component.download_url)
+            next unless file.success?
+
+            content_type = file.headers['content-type'] || 'application/octet-stream'
+            entry_name = "#{component.type.parameterize}-kit.#{ext_for(content_type)}"
+            zip.put_next_entry(entry_name)
+            zip.write(file.body)
+          end
+        end
+
+        kit_name = kit.title.presence&.parameterize || 'classroom-kit'
+        send_data zip_data.string, filename: "#{kit_name}.zip", type: 'application/zip', disposition: 'attachment'
+      rescue Faraday::Error => e
+        Rails.logger.error("[ContentStudio] kit download_all failed: #{e.message}")
+        head :bad_gateway
+      end
+
       EXTENSIONS = {
         'application/pdf' => 'pdf',
         'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -13,7 +13,7 @@ module ContentStudio
       def save
         ApiClient.save_classroom_kit(params[:id])
         flash[:notice] = t('.saved')
-        redirect_to main_app.root_path
+        redirect_to kit_structure_path(id: params[:id])
       rescue Faraday::Error => e
         Rails.logger.error("[ContentStudio] kit structure#save failed: #{e.message}")
         flash[:alert] = t('.save_failed')
@@ -22,7 +22,7 @@ module ContentStudio
 
       def discard
         ApiClient.discard_kit(params[:id])
-        redirect_to main_app.root_path
+        redirect_to '/content'
       rescue Faraday::BadRequestError
         flash[:alert] = t('content_studio.classroom_kits.discard.locked')
         redirect_to kit_structure_path(id: params[:id])
@@ -59,26 +59,7 @@ module ContentStudio
         return head :not_found if ready_components.empty?
 
         conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
-        zip_data = Zip::OutputStream.write_buffer do |zip|
-          ready_components.each do |component|
-            if component.download_url.blank?
-              Rails.logger.warn("[ContentStudio] download_all: skipping component #{component.id} (#{component.type}) — download_url is blank")
-              next
-            end
-
-            file = conn.get(component.download_url)
-            unless file.success?
-              Rails.logger.warn("[ContentStudio] download_all: skipping component #{component.id} (#{component.type}) — fetch returned #{file.status}")
-              next
-            end
-
-            content_type = file.headers['content-type'] || 'application/octet-stream'
-            entry_name = "#{component.type.parameterize}-#{component.id}.#{ext_for(content_type)}"
-            zip.put_next_entry(entry_name)
-            zip.write(file.body)
-          end
-        end
-
+        zip_data = build_zip(conn, ready_components)
         kit_name = kit.title.presence&.parameterize || 'classroom-kit'
         send_data zip_data.string, filename: "#{kit_name}.zip", type: 'application/zip', disposition: 'attachment'
       rescue Faraday::Error => e
@@ -94,6 +75,29 @@ module ContentStudio
       }.freeze
 
       private
+
+      def build_zip(conn, components)
+        Zip::OutputStream.write_buffer do |zip|
+          components.each { |c| write_zip_entry(zip, conn, c) }
+        end
+      end
+
+      def write_zip_entry(zip, conn, component)
+        if component.download_url.blank?
+          Rails.logger.warn("[ContentStudio] download_all: skipping #{component.id} — no download_url")
+          return
+        end
+
+        file = conn.get(component.download_url)
+        unless file.success?
+          Rails.logger.warn("[ContentStudio] download_all: skipping #{component.id} — #{file.status}")
+          return
+        end
+
+        content_type = file.headers['content-type'] || 'application/octet-stream'
+        zip.put_next_entry("#{component.type.parameterize}-#{component.id}.#{ext_for(content_type)}")
+        zip.write(file.body)
+      end
 
       def ext_for(content_type)
         EXTENSIONS[content_type.split(';').first.strip] || 'bin'

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -2,11 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 const POLL_INTERVAL_MS = 5000
 
+const BANNER_HIDE_DELAY_MS = 1500
+
 export default class extends Controller {
   static values = {
     pending: Boolean,
     thumbnailUrl: { type: String, default: '' }
   }
+
+  static targets = ['banner']
 
   connect() {
     this._dragging = false
@@ -40,6 +44,13 @@ export default class extends Controller {
     document.removeEventListener('turbo:before-visit', this._onBeforeVisit)
     this._frame?.removeEventListener('turbo:frame-load', this._onFrameLoad)
     this._frame?.removeEventListener('turbo:frame-missing', this._onFrameMissing)
+  }
+
+  pendingValueChanged(pending) {
+    if (pending || !this.hasBannerTarget) return
+    setTimeout(() => {
+      this.bannerTarget.style.visibility = 'hidden'
+    }, BANNER_HIDE_DELAY_MS)
   }
 
   thumbnailUrlValueChanged(url) {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -46,9 +46,10 @@ export default class extends Controller {
     this._frame?.removeEventListener('turbo:frame-missing', this._onFrameMissing)
   }
 
-  pendingValueChanged(pending) {
-    if (pending || !this.hasBannerTarget) return
-    setTimeout(() => {
+  pendingValueChanged(pending, previousPending) {
+    if (pending || previousPending === undefined || !this.hasBannerTarget) return
+    clearTimeout(this._bannerHideTimer)
+    this._bannerHideTimer = setTimeout(() => {
       this.bannerTarget.style.visibility = 'hidden'
     }, BANNER_HIDE_DELAY_MS)
   }

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -29,7 +29,8 @@
   </div>
 
   <%# Progress banner %>
-  <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden">
+  <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
+       data-structure-polling-target="banner">
     <div class="flex items-center justify-between p-3">
       <div class="flex items-center gap-2 min-w-0">
         <%= video_tag 'gliters-ai.mp4', class: 'w-7 h-7 shrink-0', autoplay: true, loop: true, muted: true, playsinline: true %>
@@ -56,15 +57,10 @@
       <div class="flex items-center justify-between">
         <span class="main-text-md-semibold text-letter-color">Classroom Kit</span>
         <% if all_ready %>
-          <% proxy_urls = components.select { |c| c.status == 'READY' }
-                                    .map { |c| download_kit_component_path(id: @kit.id, component_id: c.id) }
-                                    .to_json %>
-          <span data-controller="download-all"
-                data-download-all-urls-value="<%= proxy_urls %>"
-                data-action="click->download-all#download"
-                class="main-text-sm-normal text-primary hover:underline cursor-pointer">
-            Download All
-          </span>
+          <%= link_to 'Download All',
+                      download_all_kit_components_path(id: @kit.id),
+                      class: 'main-text-sm-normal text-primary hover:underline',
+                      data: { turbo: false } %>
         <% end %>
       </div>
 

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -30,7 +30,8 @@
 
   <%# Progress banner %>
   <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
-       data-structure-polling-target="banner">
+       data-structure-polling-target="banner"
+       <%= all_ready ? 'style="visibility: hidden"' : '' %>>
     <div class="flex items-center justify-between p-3">
       <div class="flex items-center gap-2 min-w-0">
         <%= video_tag 'gliters-ai.mp4', class: 'w-7 h-7 shrink-0', autoplay: true, loop: true, muted: true, playsinline: true %>
@@ -115,7 +116,7 @@
         <%= form_with url: save_classroom_kit_path(id: @kit.id), method: :patch, class: 'flex-1',
                       data: { turbo_frame: '_top' } do |f| %>
           <%= f.button class: 'w-full', disabled: !all_ready do %>
-            <%= button_component(text: 'Save Kit', colorscheme: 'primary', size: 'sm',
+            <%= button_component(text: @kit.saved ? 'Update Kit' : 'Save Kit', colorscheme: 'primary', size: 'sm',
                                  disabled: !all_ready, html_options: { class: 'w-full' }) %>
           <% end %>
         <% end %>

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -20,7 +20,7 @@
 
   <%# Page header %>
   <div class="flex items-center gap-2">
-    <%= link_to new_creation_path, data: { turbo: false } do %>
+    <%= link_to root_path, data: { turbo: false } do %>
       <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
         <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
       </span>

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -31,7 +31,7 @@
   <%# Progress banner %>
   <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
        data-structure-polling-target="banner"
-       <%= all_ready ? 'style="visibility: hidden"' : '' %>>
+       style="<%= 'visibility: hidden' if all_ready %>">
     <div class="flex items-center justify-between p-3">
       <div class="flex items-center gap-2 min-w-0">
         <%= video_tag 'gliters-ai.mp4', class: 'w-7 h-7 shrink-0', autoplay: true, loop: true, muted: true, playsinline: true %>

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -11,7 +11,7 @@
   <% failed = @structure.stage.to_s.end_with?('_failed') %>
   <% all_lessons = @structure.modules.flat_map(&:lessons) %>
   <% has_pending = !failed && all_lessons.any? { |l| %w[PENDING WAITING].include?(l.status) } %>
-  <% all_videos_ready = all_lessons.all? { |l| l.video_url.present? } %>
+  <% all_videos_ready = all_lessons.any? && all_lessons.all? { |l| l.video_url.present? } %>
   <turbo-frame id="course-structure" refresh="morph">
   <div class="flex flex-col gap-6 px-4"
        data-controller="collapsible-group structure-polling"
@@ -22,7 +22,7 @@
     <% all_scenes = @structure.modules.flat_map(&:lessons).flat_map(&:scenes) %>
     <% completed_scenes = all_scenes.count { |s| s.video_url.present? } %>
     <% fill_pct = all_scenes.size > 0 ? (completed_scenes.to_f / all_scenes.size * 100).to_i : 0 %>
-    <% if has_pending || @structure.progress_text.present? %>
+    <% if !all_videos_ready && (has_pending || @structure.progress_text.present?) %>
       <%= render 'content_studio/shared/progress_card',
             pending: has_pending,
             progress_text: @structure.progress_text.presence || 'Generating your course…',

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -8,6 +8,8 @@ ContentStudio::Engine.routes.draw do
                                       as: :kit_structure
   get 'classroom-kits/:id/components/:component_id/download', to: 'classroom_kits/structure#download',
                                                               as: :download_kit_component
+  get 'classroom-kits/:id/download_all', to: 'classroom_kits/structure#download_all',
+                                         as: :download_all_kit_components
   get  'classroom-kits/new',            to: 'classroom_kits/wizard#new',          as: :new_classroom_kit
   post 'classroom-kits',                to: 'classroom_kits/wizard#create',       as: :classroom_kits
   get  'classroom-kits/:id/configure',  to: 'classroom_kits/wizard#configure',    as: :configure_classroom_kit

--- a/engines/content_studio/lib/content_studio/blackboard_client.rb
+++ b/engines/content_studio/lib/content_studio/blackboard_client.rb
@@ -151,7 +151,8 @@ module ContentStudio
         created_at: data['created_at'],
         updated_at: data['updated_at'],
         expires_at: data['expires_at'],
-        components: Array(data['components']).map { |c| build_kit_component(c) }
+        components: Array(data['components']).map { |c| build_kit_component(c) },
+        saved: data['saved_to_lms'] == true
       )
     end
 

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -113,6 +113,7 @@ module ContentStudio
     :updated_at,
     :expires_at,
     :components,
+    :saved,
     keyword_init: true
   )
 

--- a/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
         allow(ContentStudio::ApiClient).to receive(:save_classroom_kit)
       end
 
-      it 'redirects to the host app root' do
+      it 'redirects back to the kit structure page' do
         patch '/content_studio/classroom-kits/kit-abc/save'
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to('/content_studio/classroom-kits/kit-abc/structure')
       end
 
       it 'calls ApiClient.save_classroom_kit with the kit id' do
@@ -109,9 +109,9 @@ RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
         allow(ContentStudio::ApiClient).to receive(:discard_kit)
       end
 
-      it 'redirects to the host app root' do
+      it 'redirects to the My Content page' do
         delete '/content_studio/classroom-kits/kit-abc'
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to('/content')
       end
 
       it 'calls ApiClient.discard_kit with the kit id' do

--- a/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative '../../../rails_helper'
+
+RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
+  let(:ready_component) do
+    ContentStudio::KitComponent.new(
+      id: 'comp-1', type: 'slide_deck', title: nil,
+      status: 'READY', download_url: 'https://s3.example.com/slide_deck.pptx'
+    )
+  end
+
+  let(:kit) do
+    ContentStudio::Kit.new(
+      id: 'kit-123', title: 'Banking Basics', status: 'COMPLETED',
+      stage: 'ready', thumbnail_url: nil, doc_count: 0,
+      components: [ready_component]
+    )
+  end
+
+  describe 'GET /content_studio/classroom-kits/:id/download_all' do
+    context 'when all components are READY and files are available' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:get_classroom_kit).and_return(kit)
+        stub_request(:get, 'https://s3.example.com/slide_deck.pptx')
+          .to_return(
+            status: 200,
+            body: 'pptx-binary-content',
+            headers: { 'Content-Type' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation' }
+          )
+      end
+
+      it 'returns HTTP 200' do
+        get '/content_studio/classroom-kits/kit-123/download_all'
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'responds with a zip content type' do
+        get '/content_studio/classroom-kits/kit-123/download_all'
+        expect(response.content_type).to eq('application/zip')
+      end
+
+      it 'sets a zip filename based on the kit title' do
+        get '/content_studio/classroom-kits/kit-123/download_all'
+        expect(response.headers['Content-Disposition']).to include('banking-basics.zip')
+      end
+    end
+
+    context 'when there are no READY components' do
+      before do
+        pending_kit = ContentStudio::Kit.new(**kit.to_h,
+          components: [ContentStudio::KitComponent.new(
+            id: 'comp-1', type: 'slide_deck', title: nil, status: 'PENDING', download_url: nil
+          )])
+        allow(ContentStudio::ApiClient).to receive(:get_classroom_kit).and_return(pending_kit)
+      end
+
+      it 'returns HTTP 404' do
+        get '/content_studio/classroom-kits/kit-123/download_all'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the API call fails' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:get_classroom_kit)
+          .and_raise(Faraday::Error.new('timeout'))
+      end
+
+      it 'returns HTTP 502' do
+        get '/content_studio/classroom-kits/kit-123/download_all'
+        expect(response).to have_http_status(:bad_gateway)
+      end
+    end
+  end
+end

--- a/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
+++ b/engines/content_studio/spec/requests/content_studio/classroom_kits/structure_spec.rb
@@ -109,14 +109,25 @@ RSpec.describe 'ContentStudio::ClassroomKits::Structure', type: :request do
         allow(ContentStudio::ApiClient).to receive(:discard_kit)
       end
 
-      it 'redirects to the My Content page' do
+      it 'redirects to the Content Studio landing page' do
         delete '/content_studio/classroom-kits/kit-abc'
-        expect(response).to redirect_to('/content')
+        expect(response).to redirect_to(root_path)
       end
 
       it 'calls ApiClient.discard_kit with the kit id' do
         delete '/content_studio/classroom-kits/kit-abc'
         expect(ContentStudio::ApiClient).to have_received(:discard_kit).with('kit-abc')
+      end
+    end
+
+    context 'when kit is already deleted (404)' do
+      before do
+        allow(ContentStudio::ApiClient).to receive(:discard_kit).and_raise(Faraday::ResourceNotFound)
+      end
+
+      it 'redirects to the Content Studio landing page' do
+        delete '/content_studio/classroom-kits/kit-abc'
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
     ContentStudio::Kit.new(
       id: 'kit-123', title: 'Banking Basics', status: 'COMPLETED',
       stage: 'ready', thumbnail_url: nil, doc_count: 0,
-      components: [slide_deck_component, trainer_guide_component]
+      components: [slide_deck_component, trainer_guide_component],
+      saved: false
     )
   end
 
@@ -78,12 +79,42 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
     expect(rendered).to include('data-structure-polling-pending-value="true"')
   end
 
+  it 'renders the Save Kit button when kit is not saved to LMS' do
+    render
+    expect(rendered).to include('Save Kit')
+  end
+
+  it 'does not render Update Kit when kit is not saved' do
+    render
+    expect(rendered).not_to include('Update Kit')
+  end
+
+  context 'when kit is already saved to LMS' do
+    before { assign(:kit, ContentStudio::Kit.new(**kit.to_h, saved: true)) }
+
+    it 'renders the Update Kit button' do
+      render
+      expect(rendered).to include('Update Kit')
+    end
+
+    it 'does not render Save Kit when kit is already saved' do
+      render
+      expect(rendered).not_to include('Save Kit')
+    end
+  end
+
+  it 'renders the progress banner without visibility: hidden when not all ready' do
+    render
+    expect(rendered).not_to include('visibility: hidden')
+  end
+
   context 'when all components are READY' do
     let(:kit) do
       ContentStudio::Kit.new(
         id: 'kit-123', title: 'Banking Basics', status: 'COMPLETED',
         stage: 'ready', thumbnail_url: nil, doc_count: 0,
-        components: [slide_deck_component]
+        components: [slide_deck_component],
+        saved: false
       )
     end
 
@@ -100,6 +131,11 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
     it 'shows Kit is ready in the banner' do
       render
       expect(rendered).to include('Kit is ready')
+    end
+
+    it 'hides the progress banner server-side' do
+      render
+      expect(rendered).to include('visibility: hidden')
     end
   end
 

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
     end
   end
 
-  it 'renders the progress banner without visibility: hidden when not all ready' do
+  it 'does not hide the progress banner when not all components are ready' do
     render
+    expect(rendered).to include('data-structure-polling-target="banner"')
     expect(rendered).not_to include('visibility: hidden')
   end
 

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/structure/show.html.erb_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'content_studio/classroom_kits/structure/show', type: :view do
 
   it 'renders a download link for READY components' do
     render
-    expect(rendered).to include('https://s3.example.com/slide_deck.pptx')
+    expect(rendered).to include('components/comp-1/download')
   end
 
   it 'renders a spinner for PENDING components' do

--- a/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/courses/structure/show.html.erb_spec.rb
@@ -342,6 +342,47 @@ RSpec.describe 'content_studio/courses/structure/show', type: :view do
     expect(rendered).to include('action="/content_studio/courses/1/save"')
   end
 
+  context 'when modules are blank (early generation, no lessons yet)' do
+    before do
+      assign(:structure, ContentStudio::CourseStructure.new(
+                           id: 1, title: 'Airport Services Management', duration: 0,
+                           modules: [], verified_modules_count: 0,
+                           thumbnail_url: nil, saved: false, progress_text: 'Preparing your course…'
+                         ))
+    end
+
+    it 'still renders the progress card' do
+      render
+      expect(rendered).to include('border-secondary-dark')
+      expect(rendered).to include('Preparing your course')
+    end
+  end
+
+  context 'when all lessons have a video_url (course complete)' do
+    before do
+      completed_module = ContentStudio::StructureModule.new(
+        id: 1, title: 'Airport Services',
+        lessons: [
+          ContentStudio::StructureLesson.new(id: 1, title: 'Introduction', status: 'VERIFIED',
+                                             video_url: 'https://example.com/v1.mp4', scenes: []),
+          ContentStudio::StructureLesson.new(id: 2, title: 'Rules', status: 'VIDEO_READY',
+                                             video_url: 'https://example.com/v2.mp4', scenes: [])
+        ]
+      )
+      assign(:structure, ContentStudio::CourseStructure.new(
+                           id: 1, title: 'Airport Services Management', duration: 9240,
+                           modules: [completed_module], verified_modules_count: 1,
+                           thumbnail_url: nil, saved: false, progress_text: 'Course is ready!'
+                         ))
+    end
+
+    it 'does not render the progress card even when progress_text is present' do
+      render
+      expect(rendered).not_to include('border-secondary-dark')
+      expect(rendered).not_to include('Course is ready!')
+    end
+  end
+
   context 'when no pending lessons and no progress_text' do
     before do
       all_verified = ContentStudio::StructureModule.new(


### PR DESCRIPTION
## Summary
Adds server-side zip download for all kit components and auto-hides the progress banner once generation completes.

## Changes
- Added `download_all` action to `StructureController` that fetches all READY components and streams them as a single `.zip` file using `rubyzip`
- Added route `GET classroom-kits/:id/download_all`
- Replaced client-side multi-download Stimulus approach with a plain `link_to` pointing at the new route
- Progress banner becomes `visibility: hidden` 1.5s after the kit hits 100%, preserving layout space
- Added `pendingValueChanged` callback and `banner` target to `structure_polling_controller.js`
- Added request spec for `download_all` (success, no READY components, API failure)
- Fixed view spec to assert on proxy path instead of raw S3 URL
-

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
