### PR TITLE
Add back-to-My-Content navigation on Courses and Programs pages

### DIFF
--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -2,7 +2,10 @@
   <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40 bg-white">
     <%= render 'filters', tags: tags, filter_url: manage_courses_path %>
     <div class="flex flex-row justify-between">
-      <h1 class="heading-xl">My Courses</h1>
+      <div class="flex items-center gap-3">
+        <%= render 'shared/components/back_button', back_link: content_path %>
+        <h1 class="heading-xl">My Courses</h1>
+      </div>
       <% if policy(:course).new? %>
         <%= link_to new_course_path, data: { turbo_frame: "modal" }, class: "nav-link" do %>
           <%= button_component(text: 'Add course', icon_name: "plus") %>

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -1,5 +1,8 @@
 <div class="flex flex-col-reverse md:flex-row md:items-center justify-between mb-4 gap-3">
-  <%= heading_component(text: t("programs.label")) %>
+  <div class="flex items-center gap-3">
+    <%= render 'shared/components/back_button', back_link: content_path %>
+    <%= heading_component(text: t("programs.label")) %>
+  </div>
   <div class="flex gap-3 items-center w-full md:w-auto">
     <div class="w-full md:w-[340px] relative">
       <%= form_tag programs_path, method: :get do %>


### PR DESCRIPTION


## Summary
My Courses and Programs pages were missing a way to navigate back. Added the shared back_button component pointing to content_path on both pages.

## Changes
- Added `shared/components/back_button` pointing to `content_path` on the My Courses page (`courses/list/_admin.html.erb`)
- Added `shared/components/back_button` pointing to `content_path` on the Programs index page (`programs/index.html.erb`)

## Screenshots / Visual Diffs

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
