### PR TITLE
Fix Content Studio sidebar item not highlighting when active

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/application_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/application_controller.rb
@@ -14,6 +14,7 @@ module ContentStudio
   class ApplicationController < ContentStudio.parent_controller.constantize
     helper HostRoutesHelper
     before_action :require_content_studio_access!
+    before_action { @active_nav = 'content_studio' }
     before_action { ApiClient.current_cookie = request.env['HTTP_COOKIE'] }
     after_action { ApiClient.current_cookie = ApiClient.cached_client = ApiClient.cached_client_cookie = nil }
 


### PR DESCRIPTION

## Summary
Sets `@active_nav` to `'content_studio'` in the engine's `ApplicationController` so the sidebar correctly highlights the Content Studio item on all Content Studio pages.

## Changes

- Added `before_action { @active_nav = 'content_studio' }` to `ContentStudio::ApplicationController` — applies to every controller in the engine

## Screenshots / Visual Diffs
<img width="1315" height="996" alt="Screenshot 2026-06-18 at 12 58 26 PM" src="https://github.com/user-attachments/assets/ede8089e-2300-400d-ab12-bcd386c62f20" />
<img width="1319" height="993" alt="Screenshot 2026-06-18 at 12 58 41 PM" src="https://github.com/user-attachments/assets/66f8f74d-6ed5-4d8c-9d60-8403ce483c6d" />
<img width="1157" height="940" alt="Screenshot 2026-06-18 at 12 59 18 PM" src="https://github.com/user-attachments/assets/0260989f-8e4a-482c-813f-4a56ff7bcccb" />
<img width="1317" height="982" alt="Screenshot 2026-06-18 at 12 59 27 PM" src="https://github.com/user-attachments/assets/5c99d797-c40e-4a3f-808c-ed3db24c8015" />
<img width="1168" height="744" alt="Screenshot 2026-06-18 at 12 59 44 PM" src="https://github.com/user-attachments/assets/33a0bec7-bbb9-4b15-9357-3d8156e8d321" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
