### PR TITLE
Enable classroom kit in production

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -12,6 +12,7 @@ production:
   sidekiq_auth_enabled: true
   enable_chatwoot: true
   content_studio: true
+  classroom_kit_enabled: true
 
 staging:
   <<: *default


### PR DESCRIPTION
Fixes #N/A

Flips `classroom_kit_enabled: true` in the production environment config.

## Context
Classroom kit feature is fully built and staged. This is the production dark-launch switch. Staging and development already have this enabled.

## Pre-requisites before merging
- [ ] PR #1411 (zip download + banner hide fix) merged
- [ ] `rails db:migrate` run on production after deploy