### PR TITLE
Remove missing academic-cap icon from classroom kits empty state

### DIFF
--- a/app/views/classroom_kits/index.html.erb
+++ b/app/views/classroom_kits/index.html.erb
@@ -4,7 +4,6 @@
 
 <% if @kits.empty? %>
   <div class="flex flex-col items-center gap-3 py-16 text-center">
-    <%= icon('academic-cap', css: 'w-12 h-12 text-letter-color-light') %>
     <p class="main-text-md-medium text-letter-color"><%= t('classroom_kits.index.empty') %></p>
   </div>
 <% else %>


### PR DESCRIPTION
Fixes crash on classroom kits index when no kits exist.

The \`academic-cap\` icon is not present in the asset pipeline. Rendering it raised an error on the empty state of the classroom kits index page. Removed the icon — the empty state message still renders correctly.