### PR TITLE
Add back button to Classroom Kits index page

### DIFF
--- a/app/views/classroom_kits/index.html.erb
+++ b/app/views/classroom_kits/index.html.erb
@@ -1,5 +1,8 @@
 <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4">
-  <h1 class="heading-xl"><%= t('classroom_kits.index.title') %></h1>
+  <div class="flex items-center gap-3">
+    <%= render 'shared/components/back_button', back_link: content_path %>
+    <h1 class="heading-xl"><%= t('classroom_kits.index.title') %></h1>
+  </div>
 </div>
 
 <% if @kits.empty? %>


### PR DESCRIPTION
Links back to My Content page, consistent with Courses and Programs pages.

## Summary
Adds a back button to the Classroom Kits index page so users can navigate back to My Content, consistent with the Courses and Programs pages.


## Changes
-Added shared/components/back_button pointing to content_path on the Classroom Kits index page (app/views/classroom_kits/index.html.erb)

## Screenshots / Visual Diffs
<img width="608" height="302" alt="Screenshot 2026-06-18 at 4 35 07 PM" src="https://github.com/user-attachments/assets/2fb617e1-bbdb-4e3c-ab1e-f0ffe076e790" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
