### PR TITLE
Task/remove bg white my courses header

### DIFF
--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="courses">
-  <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40">
+  <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40 bg-white-light">
     <%= render 'filters', tags: tags, filter_url: manage_courses_path %>
     <div class="flex flex-row justify-between">
       <div class="flex items-center gap-3">

--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="courses">
-  <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40 bg-white">
+  <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40">
     <%= render 'filters', tags: tags, filter_url: manage_courses_path %>
     <div class="flex flex-row justify-between">
       <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
Replaced bg-white with bg-white-light on the sticky My Courses header so that when users scroll down, course cards are cleanly hidden behind the header instead of showing through a transparent background.

## Changes

- Replaced bg-white with bg-white-light on the sticky header in app/views/courses/list/_admin.html.erb

## Screenshots / Visual Diffs
 the background was like this
 
<img width="564" height="141" alt="Screenshot 2026-06-18 at 12 49 59 PM" src="https://github.com/user-attachments/assets/dfd5f9cf-cc58-4db2-bd01-8b588e9ffc90" />
so replaced white with white-light so it became like this
<img width="1256" height="181" alt="Screenshot 2026-06-18 at 4 38 30 PM" src="https://github.com/user-attachments/assets/891096a0-0182-4e85-906b-c410f93a68b9" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
