### PR TITLE
Uncheck all kit components by default on configure step

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/wizard_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/wizard_controller.rb
@@ -27,7 +27,7 @@ module ContentStudio
 
       def configure
         @kit_id = params[:id]
-        @selected_components = %w[slide_deck trainer_guide learner_workbook assessment quiz]
+        @selected_components = []
       end
 
       def update_config

--- a/engines/content_studio/spec/views/content_studio/classroom_kits/wizard/configure.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/classroom_kits/wizard/configure.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'content_studio/classroom_kits/wizard/configure', type: :view do
   before do
     view.singleton_class.include ContentStudio::Engine.routes.url_helpers
     assign(:kit_id, 'pending')
-    assign(:selected_components, all_components)
+    assign(:selected_components, [])
   end
 
   it 'renders all three wizard step labels' do
@@ -27,9 +27,9 @@ RSpec.describe 'content_studio/classroom_kits/wizard/configure', type: :view do
     expect(rendered).to include('Quiz')
   end
 
-  it 'renders all five checkboxes as checked by default' do
+  it 'renders no checkboxes as checked by default' do
     render
-    expect(rendered.scan('checked').size).to be >= 5
+    expect(rendered).not_to include('checked="checked"')
   end
 
   it 'renders the Back and Generate Kit Structure footer buttons' do
@@ -54,14 +54,14 @@ RSpec.describe 'content_studio/classroom_kits/wizard/configure', type: :view do
     expect(rendered).to include('data-kit-configure-target="submit"')
   end
 
-  context 'when no components are selected' do
+  context 'when all components are selected' do
     before do
-      assign(:selected_components, [])
+      assign(:selected_components, all_components)
     end
 
-    it 'renders no checkboxes as checked' do
+    it 'renders all five checkboxes as checked' do
       render
-      expect(rendered).not_to include('checked="checked"')
+      expect(rendered.scan('checked').size).to be >= 5
     end
   end
 


### PR DESCRIPTION
Fixes the configure kit page where all components were pre-checked on load. Components should start unchecked so users explicitly select what to include.

## Changes
- `WizardController#configure`: initialise `@selected_components` to `[]` instead of all five values
- View spec: update default assignment to `[]`, rename the "all checked" test to reflect it is a non-default state, and add a corresponding context for the all-selected case