### PR TITLE
Add Download All to kit show page and titleize kit title on creation

### DIFF
--- a/app/concerns/zip_download_concern.rb
+++ b/app/concerns/zip_download_concern.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ZipDownloadConcern
+  extend ActiveSupport::Concern
+
+  EXTENSIONS = {
+    'application/pdf' => 'pdf',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx'
+  }.freeze
+
+  private
+
+  def build_zip(components)
+    conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
+    Zip::OutputStream.write_buffer do |zip|
+      components.each { |component| write_zip_entry(zip, conn, component) }
+    end
+  end
+
+  def write_zip_entry(zip, conn, component)
+    file = conn.get(component['download_url'])
+    unless file.success?
+      Rails.logger.warn("[ZipDownload] skipping #{component['id']} — #{file.status}")
+      return
+    end
+
+    content_type = file.headers['content-type'] || 'application/octet-stream'
+    ext = ext_for(content_type)
+    zip.put_next_entry("#{(component['type'] || 'component').parameterize}-#{component['id']}.#{ext}")
+    zip.write(file.body)
+  end
+
+  def ext_for(content_type)
+    EXTENSIONS[content_type.split(';').first.strip] || 'bin'
+  end
+end

--- a/app/controllers/api/internal/classroom_kits_controller.rb
+++ b/app/controllers/api/internal/classroom_kits_controller.rb
@@ -18,7 +18,7 @@ module Api
       end
 
       def create
-        title = params[:title]
+        title = params[:title].presence&.titleize
         data = neo_ai.create_kit(
           files: params[:files],
           components: Array(params[:components]),

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -2,7 +2,7 @@
 
 class ClassroomKitsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_kit, only: %i[show download]
+  before_action :set_kit, only: %i[show download download_all]
 
   def index
     authorize :classroom_kit, :index?
@@ -24,11 +24,51 @@ class ClassroomKitsController < ApplicationController
     redirect_to component['download_url'], allow_other_host: true
   rescue Faraday::Error => e
     Rails.logger.warn("[ClassroomKits] download failed: #{e.message}")
+    flash[:alert] = t('.failed')
+    redirect_to classroom_kit_path(@kit)
+  end
+
+  def download_all
+    authorize @kit, :show?
+    data = neo_ai_client.get_kit(@kit.neo_ai_kit_id)
+    components = Array(data['components']).select { |c| c['download_url'].present? }
+    return head :not_found if components.empty?
+
+    zip_data = build_zip(components)
+    kit_name = @kit.title.presence&.parameterize || 'classroom-kit'
+    send_data zip_data.string, filename: "#{kit_name}.zip", type: 'application/zip', disposition: 'attachment'
+  rescue Faraday::Error => e
+    Rails.logger.warn("[ClassroomKits] download_all failed: #{e.message}")
     flash[:alert] = t('classroom_kits.download.failed')
     redirect_to classroom_kit_path(@kit)
   end
 
+  EXTENSIONS = {
+    'application/pdf' => 'pdf',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx'
+  }.freeze
+
   private
+
+  def build_zip(components)
+    conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
+    Zip::OutputStream.write_buffer do |zip|
+      components.each do |component|
+        file = conn.get(component['download_url'])
+        unless file.success?
+          Rails.logger.warn("[ClassroomKits] skipping #{component['id']} — #{file.status}")
+          next
+        end
+
+        content_type = file.headers['content-type'] || 'application/octet-stream'
+        ext = EXTENSIONS[content_type.split(';').first.strip] || 'bin'
+        zip.put_next_entry("#{component['type'].parameterize}-#{component['id']}.#{ext}")
+        zip.write(file.body)
+      end
+    end
+  end
 
   def set_kit
     @kit = ClassroomKit.find_by!(id: params[:id], learning_partner_id: current_user.learning_partner_id)

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -65,7 +65,7 @@ class ClassroomKitsController < ApplicationController
 
         content_type = file.headers['content-type'] || 'application/octet-stream'
         ext = EXTENSIONS[content_type.split(';').first.strip] || 'bin'
-        zip.put_next_entry("#{component['type'].parameterize}-#{component['id']}.#{ext}")
+        zip.put_next_entry("#{(component['type'] || 'component').parameterize}-#{component['id']}.#{ext}")
         zip.write(file.body)
       end
     end

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ClassroomKitsController < ApplicationController
+  include ZipDownloadConcern
+
   before_action :authenticate_user!
   before_action { @active_nav = 'content' }
   before_action :set_kit, only: %i[show download download_all]
@@ -44,32 +46,7 @@ class ClassroomKitsController < ApplicationController
     redirect_to classroom_kit_path(@kit)
   end
 
-  EXTENSIONS = {
-    'application/pdf' => 'pdf',
-    'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx'
-  }.freeze
-
   private
-
-  def build_zip(components)
-    conn = Faraday.new(request: { open_timeout: 5, timeout: 60 })
-    Zip::OutputStream.write_buffer do |zip|
-      components.each do |component|
-        file = conn.get(component['download_url'])
-        unless file.success?
-          Rails.logger.warn("[ClassroomKits] skipping #{component['id']} — #{file.status}")
-          next
-        end
-
-        content_type = file.headers['content-type'] || 'application/octet-stream'
-        ext = EXTENSIONS[content_type.split(';').first.strip] || 'bin'
-        zip.put_next_entry("#{(component['type'] || 'component').parameterize}-#{component['id']}.#{ext}")
-        zip.write(file.body)
-      end
-    end
-  end
 
   def set_kit
     @kit = ClassroomKit.find_by!(id: params[:id], learning_partner_id: current_user.learning_partner_id)

--- a/app/controllers/classroom_kits_controller.rb
+++ b/app/controllers/classroom_kits_controller.rb
@@ -2,6 +2,7 @@
 
 class ClassroomKitsController < ApplicationController
   before_action :authenticate_user!
+  before_action { @active_nav = 'content' }
   before_action :set_kit, only: %i[show download download_all]
 
   def index

--- a/app/views/classroom_kits/show.html.erb
+++ b/app/views/classroom_kits/show.html.erb
@@ -19,7 +19,12 @@
   </div>
 
   <div class="bg-white border border-line-colour-light rounded-2xl p-6 flex flex-col gap-4">
-    <span class="main-text-md-semibold text-letter-color"><%= t('classroom_kits.show.components_heading') %></span>
+    <div class="flex items-center justify-between">
+      <span class="main-text-md-semibold text-letter-color"><%= t('classroom_kits.show.components_heading') %></span>
+      <%= link_to 'Download All', download_all_classroom_kit_path(@kit),
+                  class: 'main-text-sm-normal text-primary hover:underline',
+                  data: { turbo: false } %>
+    </div>
 
     <div class="flex flex-col gap-3">
       <% @components.each do |component| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,7 @@ Rails.application.routes.draw do
   resources :classroom_kits, only: %i[index show] do
     member do
       get 'components/:component_id/download', action: :download, as: :download_component
+      get 'download_all', action: :download_all, as: :download_all
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,7 @@ Rails.application.routes.draw do
   resources :classroom_kits, only: %i[index show] do
     member do
       get 'components/:component_id/download', action: :download, as: :download_component
-      get 'download_all', action: :download_all, as: :download_all
+      get 'download_all', action: :download_all
     end
   end
 

--- a/spec/requests/classroom_kits_spec.rb
+++ b/spec/requests/classroom_kits_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'ClassroomKits', type: :request do
       neo_ai_client = instance_double(NeoAi::Client)
       faraday_conn  = instance_double(Faraday::Connection)
       file_response = instance_double(Faraday::Response, success?: true, body: 'binary-content',
-                                                          headers: { 'content-type' => 'application/pdf' })
+                                                         headers: { 'content-type' => 'application/pdf' })
       allow(NeoAi::Client).to receive(:new).and_return(neo_ai_client)
       allow(Faraday).to receive(:new).and_return(faraday_conn)
       allow(faraday_conn).to receive(:get).and_return(file_response)

--- a/spec/requests/classroom_kits_spec.rb
+++ b/spec/requests/classroom_kits_spec.rb
@@ -149,4 +149,75 @@ RSpec.describe 'ClassroomKits', type: :request do
       end
     end
   end
+
+  describe 'GET /classroom_kits/:id/download_all' do
+    before do
+      stub_const('NEO_AI_PARTNER_HMAC_SECRET', 'test-secret')
+      neo_ai_client = instance_double(NeoAi::Client)
+      faraday_conn  = instance_double(Faraday::Connection)
+      file_response = instance_double(Faraday::Response, success?: true, body: 'binary-content',
+                                                          headers: { 'content-type' => 'application/pdf' })
+      allow(NeoAi::Client).to receive(:new).and_return(neo_ai_client)
+      allow(Faraday).to receive(:new).and_return(faraday_conn)
+      allow(faraday_conn).to receive(:get).and_return(file_response)
+      allow(neo_ai_client).to receive(:get_kit).and_return(
+        'components' => [{ 'id' => component.neo_ai_component_id,
+                           'type' => 'slide_deck',
+                           'download_url' => 'https://s3.example.com/slide.pdf?token=xyz' }]
+      )
+    end
+
+    context 'when signed in as a manager' do
+      before { sign_in manager }
+
+      it 'returns a zip file' do
+        get download_all_classroom_kit_path(kit)
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq('application/zip')
+      end
+
+      it 'uses the kit title as the zip filename' do
+        get download_all_classroom_kit_path(kit)
+        expect(response.headers['Content-Disposition']).to include('test-classroom-kit.zip')
+      end
+    end
+
+    context 'when no components have a download_url' do
+      before do
+        sign_in manager
+        client = instance_double(NeoAi::Client)
+        allow(NeoAi::Client).to receive(:new).and_return(client)
+        allow(client).to receive(:get_kit).and_return({ 'components' => [] })
+      end
+
+      it 'returns 404' do
+        get download_all_classroom_kit_path(kit)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when NeoAI is unavailable' do
+      before do
+        sign_in manager
+        client = instance_double(NeoAi::Client)
+        allow(NeoAi::Client).to receive(:new).and_return(client)
+        allow(client).to receive(:get_kit).and_raise(Faraday::ConnectionFailed, 'connection refused')
+      end
+
+      it 'redirects back to the kit page with a flash alert' do
+        get download_all_classroom_kit_path(kit)
+        expect(response).to redirect_to(classroom_kit_path(kit))
+        expect(flash[:alert]).to eq(I18n.t('classroom_kits.download.failed'))
+      end
+    end
+
+    context 'when signed in as a learner' do
+      before { sign_in learner }
+
+      it 'returns 403' do
+        get download_all_classroom_kit_path(kit)
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Adds a Download All button to the classroom kit show page, fixes the My Content sidebar not highlighting when inside Classroom Kit pages, and titleizes the kit title on creation.


## Changes

- Added download_all action to ClassroomKitsController that fetches all components and streams them as a single zip file
- Added Download All link to the classroom kit show page (app/views/classroom_kits/show.html.erb)
- Added GET classroom-kits/:id/download_all route
- Fixed My Content sidebar not highlighting when browsing Classroom Kit pages by setting @active_nav = 'content' in ClassroomKitsController
- Titleized the kit title when submitted via the internal create API (api/internal/classroom_kits_controller.rb)

