### PR TITLE
Fix Explore sidebar link resolving to engine route in Content Studio

### DIFF
--- a/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb
@@ -12,7 +12,7 @@
     ) %>
   </div>
 
-  <%= form_with url: courses_path, method: :post, multipart: true,
+  <%= form_with url: wizard_courses_path, method: :post, multipart: true,
                 class: 'flex flex-col gap-6',
                 data: { controller: 'wizard-upload',
                         action: 'file-selector:change->wizard-upload#onFilesChanged',

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -20,7 +20,7 @@ ContentStudio::Engine.routes.draw do
                                                as: :generating_classroom_kit
   post 'classroom-kits/start_generation',      to: 'classroom_kits/wizard#start_generation', as: :start_kit_generation
   get 'courses/new', to: 'courses/wizard#new', as: :new_course
-  post 'courses', to: 'courses/wizard#create', as: :courses
+  post 'courses', to: 'courses/wizard#create', as: :wizard_courses
   get 'courses/:id/configure_video', to: 'courses/wizard#configure_video', as: :configure_video
   patch 'courses/:id/configure_video', to: 'courses/wizard#update_video_config'
   get 'courses/:id/generating', to: 'courses/wizard#generating', as: :generating_course


### PR DESCRIPTION
Fixes #1420

## What changed

Renamed the Content Studio engine's `courses` route helper to `wizard_courses` to prevent it from shadowing the host app's `courses_path` in the engine's view context.

## Why

The engine defined `as: :courses` on its POST route, which created a `courses_path` helper visible inside the engine's view context. The sidebar's `url: courses_path` picked up this engine-scoped helper and generated `/content-studio/courses` (a 404) instead of the host app's `/courses`.

`HostRoutesHelper` uses `method_missing` to delegate to `main_app`, but that only fires for undefined methods — since `courses_path` was defined in the engine, it won. Renaming to `wizard_courses` removes the collision: `courses_path` is now undefined in the engine context, so `method_missing` correctly delegates to `main_app.courses_path`.

Two files changed:
- `engines/content_studio/config/routes.rb` — `as: :courses` → `as: :wizard_courses`
- `engines/content_studio/app/views/content_studio/courses/wizard/new.html.erb` — `courses_path` → `wizard_courses_path`