### PR TITLE
Always show Filter button on My Courses admin page

### DIFF
--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -46,14 +46,12 @@
             </div> 
           <% end %>
         </div>            
-        <% if type.present? || policy(:course).new? %>
-          <div data-action="click->courses#openFilter" class="cursor-pointer hidden md:block">
-            <%= button_component(text: 'Filter', type: "outline", icon_name: "funnel",) %>
-          </div>
-          <div data-action="click->courses#openFilter" class="cursor-pointer md:hidden">
-            <%= button_component(type: "outline", icon_name: "funnel",) %>
-          </div>
-        <% end %>
+        <div data-action="click->courses#openFilter" class="cursor-pointer hidden md:block">
+          <%= button_component(text: 'Filter', type: "outline", icon_name: "funnel") %>
+        </div>
+        <div data-action="click->courses#openFilter" class="cursor-pointer md:hidden">
+          <%= button_component(type: "outline", icon_name: "funnel") %>
+        </div>
       </div>
       <div class="space-x-2 flex flex-row">
         <% params[:tags]&.each do |tag| %>


### PR DESCRIPTION


## Summary
Always show the Filter button on the My Courses admin page regardless of user permissions or URL params.
## Closes
closes issue #1423
## Changes
- Removed the if type.present? || policy(:course).new? guard that was hiding the Filter button for users without course-create permission and no type param in the URL
- The courses/_filters.html.erb drawer was already being rendered — it simply had no button to open it for those users

## Screenshots / Visual Diffs
<img width="1685" height="337" alt="Screenshot 2026-06-19 at 1 35 58 PM" src="https://github.com/user-attachments/assets/3d5a511d-3f80-4055-a62d-a189fe57c12a" />
<img width="429" height="915" alt="Screenshot 2026-06-19 at 1 36 08 PM" src="https://github.com/user-attachments/assets/caa91ae5-5974-4ee0-adbb-62217729b615" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
