### PR TITLE
Restrict course management to view-only for managers; allow CS lesson navigation in manager mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   end
 
   def preload_learning_partner_plan
-    return unless current_user&.content_studio_creator?
+    return unless current_user&.privileged_user?
 
     lp = current_user.learning_partner
     return unless lp

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ContentController < ApplicationController
+  before_action :preload_learning_partner_plan, only: :index
+
   def index
     authorize :content, :index?
     lp_id = current_user.learning_partner_id

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,7 +3,7 @@
 class CoursesController < ApplicationController
   include CourseAssociationsPreloader
 
-  before_action :preload_learning_partner_plan
+  before_action :preload_learning_partner_plan, only: %i[manage show publish unpublish]
   before_action :set_course, only: %i[show edit update destroy enroll unenroll proceed publish unpublish]
   before_action :set_course_active_nav, only: %i[show index explore continue complete manage]
   before_action :set_tags, only: %i[new create edit update]

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -48,7 +48,7 @@ module CoursesHelper
 
     return if next_lesson.blank?
 
-    course_module_lesson_path(course, course_module, next_lesson)
+    course_module_lesson_path(course, course_module, next_lesson, mode: params[:mode])
   end
 
   def prev_lesson_path(course, course_module, current_lesson)
@@ -61,7 +61,7 @@ module CoursesHelper
 
     return if prev_lesson.blank?
 
-    course_module_lesson_path(course, course_module, prev_lesson)
+    course_module_lesson_path(course, course_module, prev_lesson, mode: params[:mode])
   end
 
   def enroll_count(course)

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -93,9 +93,22 @@ module LessonsHelper
     end
   end
 
+  def manage_mode?(course)
+    current_user.privileged_user? &&
+      params[:mode] == Program::MANAGER_MODE &&
+      course.neo_ai_course_id.present? &&
+      course.learning_partner_id == current_user.learning_partner_id &&
+      current_user.learning_partner.content_studio_enabled?
+  end
+
   def lesson_accessible?(lesson, course, enrollment)
+    return true if manage_mode?(course)
     return false unless enrollment
 
+    enrolled_lesson_accessible?(lesson, course, enrollment)
+  end
+
+  def enrolled_lesson_accessible?(lesson, course, enrollment)
     completed_lessons = enrollment.completed_lessons
 
     return course.first_module&.first_lesson&.id == lesson.id if completed_lessons.empty?

--- a/app/policies/course_module_policy.rb
+++ b/app/policies/course_module_policy.rb
@@ -9,23 +9,23 @@ class CourseModulePolicy
   end
 
   def new?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def show?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def create?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def update?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def edit?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def destroy?
@@ -33,11 +33,11 @@ class CourseModulePolicy
   end
 
   def moveup?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def movedown?
-    user.is_admin? || own_content_studio_module?
+    user.is_admin?
   end
 
   def summary?
@@ -46,11 +46,5 @@ class CourseModulePolicy
 
   def redo_quiz?
     true
-  end
-
-  private
-
-  def own_content_studio_module?
-    user.privileged_user? && CoursePolicy.new(user, course_module.course).edit?
   end
 end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -15,7 +15,7 @@ class CoursePolicy
   end
 
   def manage?
-    user.is_admin? || content_studio_access?
+    user.is_admin? || (user.privileged_user? && user.learning_partner.content_studio_enabled?)
   end
 
   def continue?
@@ -36,7 +36,7 @@ class CoursePolicy
 
   def show?
     return true if user.is_admin?
-    return true if user.privileged_user? && own_content_studio_course?
+    return true if user.privileged_user? && partner_cs_course?
 
     return false unless visible_course?(course)
 
@@ -44,16 +44,15 @@ class CoursePolicy
   end
 
   def update?
-    user.is_admin? || (user.privileged_user? && own_content_studio_course?)
+    user.is_admin?
   end
 
   def edit?
-    user.is_admin? || (user.privileged_user? && own_content_studio_course?)
+    user.is_admin?
   end
 
   def destroy?
-    (user.is_admin? || (user.privileged_user? && own_content_studio_course?)) &&
-      !course.published? && !course.enrollments_present?
+    user.is_admin? && !course.published? && !course.enrollments_present?
   end
 
   def enroll?
@@ -97,6 +96,12 @@ class CoursePolicy
   end
 
   private
+
+  def partner_cs_course?
+    user.learning_partner.content_studio_enabled? &&
+      course.neo_ai_course_id.present? &&
+      course.learning_partner_id == user.learning_partner_id
+  end
 
   def own_content_studio_course?
     content_studio_access? &&

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -36,7 +36,7 @@ class CoursePolicy
 
   def show?
     return true if user.is_admin?
-    return true if user.privileged_user? && partner_cs_course?
+    return true if user.privileged_user? && partner_content_studio_course?
 
     return false unless visible_course?(course)
 
@@ -97,7 +97,7 @@ class CoursePolicy
 
   private
 
-  def partner_cs_course?
+  def partner_content_studio_course?
     user.learning_partner.content_studio_enabled? &&
       course.neo_ai_course_id.present? &&
       course.learning_partner_id == user.learning_partner_id

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -13,7 +13,7 @@ class LessonPolicy
   end
 
   def show?
-    user.is_admin? || own_content_studio_lesson? || user.enrolled_for_course?(record.course_module.course)
+    user.is_admin? || partner_content_studio_lesson? || user.enrolled_for_course?(record.course_module.course)
   end
 
   def create?
@@ -50,6 +50,15 @@ class LessonPolicy
   end
 
   private
+
+  def partner_content_studio_lesson?
+    return false unless user.privileged_user?
+
+    course = record.course_module.course
+    user.learning_partner.content_studio_enabled? &&
+      course.neo_ai_course_id.present? &&
+      course.learning_partner_id == user.learning_partner_id
+  end
 
   def own_content_studio_lesson?
     return false unless user.privileged_user?

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -9,7 +9,7 @@ class LessonPolicy
   end
 
   def new?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def show?
@@ -17,15 +17,15 @@ class LessonPolicy
   end
 
   def create?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def update?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def edit?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def destroy?
@@ -38,11 +38,11 @@ class LessonPolicy
   end
 
   def moveup?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def movedown?
-    user.is_admin? || own_content_studio_lesson?
+    user.is_admin?
   end
 
   def transcribe?
@@ -58,11 +58,5 @@ class LessonPolicy
     user.learning_partner.content_studio_enabled? &&
       course.neo_ai_course_id.present? &&
       course.learning_partner_id == user.learning_partner_id
-  end
-
-  def own_content_studio_lesson?
-    return false unless user.privileged_user?
-
-    CoursePolicy.new(user, record.course_module.course).edit?
   end
 end

--- a/app/views/courses/_module_accordion_content.html.erb
+++ b/app/views/courses/_module_accordion_content.html.erb
@@ -20,13 +20,20 @@
               <% end %>             
           <% end %>
           <div class="flex items-center gap-2 w-44 md:w-fit">
-            <span class="main-text-lg-normal truncate md:whitespace-normal md:overflow-visible md:text-clip">
-              <%= lesson.title %>
-            </span>
+            <% if manage_mode?(course) %>
+              <%= link_to course_module_lesson_path(course, course_module, lesson, mode: params[:mode]),
+                          class: "main-text-lg-normal truncate md:whitespace-normal md:overflow-visible md:text-clip hover:underline" do %>
+                <%= lesson.title %>
+              <% end %>
+            <% else %>
+              <span class="main-text-lg-normal truncate md:whitespace-normal md:overflow-visible md:text-clip">
+                <%= lesson.title %>
+              </span>
+            <% end %>
           </div>
         </div>
         <div class="flex gap-6 items-center px-4 py-4 md:px-6">
-          <%= link_to course_module_lesson_path(course, course_module, lesson), class: "hover:cursor-pointer" do %>
+          <%= link_to course_module_lesson_path(course, course_module, lesson, mode: params[:mode]), class: "hover:cursor-pointer" do %>
             <div class="bg-primary-light-50 rounded-full p-1 md:p-[6px] flex items-center justify-center border border-slate-grey-light">
               <%= icon 'play', css: 'text-primary h-3 w-3 md:h-4 md:w-4' %>
             </div>

--- a/app/views/courses/_non_admin_actions.html.erb
+++ b/app/views/courses/_non_admin_actions.html.erb
@@ -3,7 +3,7 @@
     <%= button_component(text: "Drop", size:"sm", type: "outline", icon_name: "minus") %>
   <% end %>
 <% end %>
-<% if policy(course).enroll? %>
+<% if policy(course).enroll? && params[:mode] != Program::MANAGER_MODE %>
   <%= link_to enroll_course_path(course), data: { turbo_method: :put }  do %>
     <%= button_component(text: I18n.t('course.enroll.label'), size:"sm") %>
   <% end %>

--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -71,7 +71,7 @@
       <div class="flex flex-col gap-5 md:gap-6">
         <div class="flex flex-col gap-4 mt-3">
           <% courses.each do |course| %>
-            <%= link_to course_path(course) do %>
+            <%= link_to course_path(course, mode: link_mode) do %>
               <%= build_long_course_card(course, nil) %>
             <% end %>
           <% end %>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -1,1 +1,1 @@
-<%= render 'courses/list/admin', tags: @tags, type: @type, courses: @courses %>
+<%= render 'courses/list/admin', tags: @tags, type: @type, courses: @courses, link_mode: current_user.privileged_user? ? Program::MANAGER_MODE : nil %>

--- a/app/views/lessons/_lesson.html.erb
+++ b/app/views/lessons/_lesson.html.erb
@@ -32,9 +32,9 @@
       </div>
     <% end %>
 
-    <% if policy(lesson).complete? || current_user.is_admin? %>
+    <% if policy(lesson).complete? || current_user.is_admin? || manage_mode?(course) %>
       <div class="flex justify-end">
-        <% if lesson_completed?(enrollment, lesson) || current_user.is_admin? %>
+        <% if lesson_completed?(enrollment, lesson) || current_user.is_admin? || manage_mode?(course) %>
           <div class="flex items-center gap-2">
             <%= link_to prev_lesson_path(course, course_module, lesson) do %>
               <%= button_component(text: t('lesson.previous'), size: 'sm', type: 'outline', icon_name: 'chevron-left', disabled: prev_lesson_path(course, course_module, lesson).blank? ) %>

--- a/app/views/lessons/_play_list.html.erb
+++ b/app/views/lessons/_play_list.html.erb
@@ -23,7 +23,7 @@
       <ul>
         <% lessons_in_order(course_module).each do |lesson| %>
           <%= content_tag :li, class: "gap-4 border-t border-line-colour px-5 py-4 main-text-sm-normal" do %>
-            <%= link_to course_module_lesson_path(course, course_module, lesson),
+            <%= link_to course_module_lesson_path(course, course_module, lesson, mode: params[:mode]),
                         class: class_names("flex items-center justify-between",
                         'highlighted': active_lesson?(lesson.id, params[:id]),
                         'disabled': !current_user.is_admin? && !lesson_accessible?(lesson, course, enrollment)) do %>

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -5,7 +5,7 @@ if Rails.env.local? && defined?(Bullet)
   Bullet.bullet_logger = true
 
   Bullet.rails_logger = true
-  # Bullet.raise = true
+  Bullet.raise = true
 
   Bullet.n_plus_one_query_enable = true
   Bullet.unused_eager_loading_enable = true

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -5,7 +5,7 @@ if Rails.env.local? && defined?(Bullet)
   Bullet.bullet_logger = true
 
   Bullet.rails_logger = true
-  Bullet.raise = true
+  # Bullet.raise = true
 
   Bullet.n_plus_one_query_enable = true
   Bullet.unused_eager_loading_enable = true

--- a/spec/policies/course_module_policy_spec.rb
+++ b/spec/policies/course_module_policy_spec.rb
@@ -14,19 +14,14 @@ RSpec.describe CourseModulePolicy do
   let(:cs_course) { create :course, learning_partner:, neo_ai_course_id: 'neo-123' }
   let(:cs_module) { create :course_module, course: cs_course }
 
-  before do
-    manager.update!(content_studio_creator: true)
-    create :payment_plan, learning_partner:, content_studio_enabled: true
-  end
-
   %i[new? create? edit? update? show?].each do |action|
     describe "##{action}" do
       it 'permits admin' do
         expect(described_class.new(admin, course_module).public_send(action)).to be true
       end
 
-      it 'permits manager who owns the content studio course' do
-        expect(described_class.new(manager, cs_module).public_send(action)).to be true
+      it 'denies manager even on a content studio course' do
+        expect(described_class.new(manager, cs_module).public_send(action)).to be false
       end
 
       it 'denies manager on a non-content-studio course' do

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CoursePolicy do
+  let(:learning_partner) { create :learning_partner }
+  let(:team) { create :team, learning_partner: }
+  let(:admin) { create :user, :admin }
+  let(:manager) { create :user, :manager, team:, learning_partner: }
+  let(:creator_manager) { create :user, :manager, team:, learning_partner:, content_studio_creator: true }
+
+  let(:course) { create :course, learning_partner: }
+  let(:cs_course) { create :course, learning_partner:, neo_ai_course_id: 'neo-123' }
+  let(:other_lp_cs_course) { create :course, neo_ai_course_id: 'neo-456' }
+
+  before do
+    create :payment_plan, learning_partner:, content_studio_enabled: true
+  end
+
+  describe '#manage?' do
+    it 'permits admin' do
+      expect(described_class.new(admin, nil)).to be_manage
+    end
+
+    it 'permits manager of CS-enabled LP' do
+      expect(described_class.new(manager, nil)).to be_manage
+    end
+
+    it 'permits content_studio_creator manager of CS-enabled LP' do
+      expect(described_class.new(creator_manager, nil)).to be_manage
+    end
+
+    it 'denies manager whose LP does not have content studio enabled' do
+      other_lp = create :learning_partner
+      other_team = create :team, learning_partner: other_lp
+      non_cs_manager = create :user, :manager, team: other_team, learning_partner: other_lp
+      expect(described_class.new(non_cs_manager, nil)).not_to be_manage
+    end
+  end
+
+  describe '#show?' do
+    context 'with admin' do
+      it 'permits any course' do
+        expect(described_class.new(admin, course)).to be_show
+      end
+    end
+
+    context 'with manager of CS-enabled LP' do
+      it 'permits own LP CS course even when unpublished' do
+        expect(described_class.new(manager, cs_course)).to be_show
+      end
+
+      it 'permits creator manager on own LP CS course' do
+        expect(described_class.new(creator_manager, cs_course)).to be_show
+      end
+
+      it 'denies CS course from a different LP' do
+        expect(described_class.new(manager, other_lp_cs_course)).not_to be_show
+      end
+
+      it 'denies regular (non-CS) unpublished course' do
+        expect(described_class.new(manager, course)).not_to be_show
+      end
+    end
+  end
+
+  describe '#edit?' do
+    it 'permits admin' do
+      expect(described_class.new(admin, course)).to be_edit
+    end
+
+    it 'denies manager' do
+      expect(described_class.new(manager, course)).not_to be_edit
+    end
+
+    it 'denies content_studio_creator manager on own CS course' do
+      expect(described_class.new(creator_manager, cs_course)).not_to be_edit
+    end
+  end
+
+  describe '#update?' do
+    it 'permits admin' do
+      expect(described_class.new(admin, course)).to be_update
+    end
+
+    it 'denies manager' do
+      expect(described_class.new(manager, course)).not_to be_update
+    end
+
+    it 'denies content_studio_creator manager on own CS course' do
+      expect(described_class.new(creator_manager, cs_course)).not_to be_update
+    end
+  end
+
+  describe '#destroy?' do
+    it 'permits admin for unpublished course with no enrollments' do
+      expect(described_class.new(admin, course)).to be_destroy
+    end
+
+    it 'denies manager' do
+      expect(described_class.new(manager, course)).not_to be_destroy
+    end
+
+    it 'denies content_studio_creator manager on own CS course' do
+      expect(described_class.new(creator_manager, cs_course)).not_to be_destroy
+    end
+  end
+
+  describe '#publish?' do
+    it 'denies everyone when course is already published' do
+      published_course = create :course, :published, learning_partner: learning_partner
+      expect(described_class.new(admin, published_course).publish?).to be false
+      expect(described_class.new(creator_manager, published_course).publish?).to be false
+    end
+
+    it 'denies when course is not ready to publish' do
+      expect(described_class.new(admin, course).publish?).to be false
+    end
+
+    it 'permits content_studio_creator manager on own ready CS course' do
+      ready_cs_course = course_with_associations(published: false)
+      ready_cs_course.update!(neo_ai_course_id: 'neo-ready', learning_partner:)
+      expect(described_class.new(creator_manager, ready_cs_course).publish?).to be true
+    end
+
+    it 'denies plain manager on own LP CS course' do
+      ready_cs_course = course_with_associations(published: false)
+      ready_cs_course.update!(neo_ai_course_id: 'neo-ready', learning_partner:)
+      expect(described_class.new(manager, ready_cs_course).publish?).to be false
+    end
+  end
+
+  describe '#unpublish?' do
+    let(:published_cs_course) { create :course, :published, learning_partner:, neo_ai_course_id: 'neo-pub' }
+
+    it 'permits admin on published course' do
+      expect(described_class.new(admin, published_cs_course).unpublish?).to be true
+    end
+
+    it 'permits content_studio_creator manager on own published CS course' do
+      expect(described_class.new(creator_manager, published_cs_course).unpublish?).to be true
+    end
+
+    it 'denies plain manager on own LP published CS course' do
+      expect(described_class.new(manager, published_cs_course).unpublish?).to be false
+    end
+
+    it 'denies when course is not published' do
+      expect(described_class.new(admin, cs_course).unpublish?).to be false
+    end
+  end
+end

--- a/spec/policies/lesson_policy_spec.rb
+++ b/spec/policies/lesson_policy_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe LessonPolicy do
   let(:lesson) { create :lesson, course_module: }
 
   before do
-    manager.update!(content_studio_creator: true)
     create :payment_plan, learning_partner:, content_studio_enabled: true
   end
 
@@ -28,7 +27,7 @@ RSpec.describe LessonPolicy do
       expect(described_class.new(admin, lesson).show?).to be true
     end
 
-    it 'permits manager who owns the content studio course' do
+    it 'permits manager of a content studio learning partner' do
       expect(described_class.new(manager, cs_lesson).show?).to be true
     end
 
@@ -47,77 +46,41 @@ RSpec.describe LessonPolicy do
   end
 
   describe '#new?' do
-    let(:cs_lesson) do
-      cs_course = create :course, learning_partner:, neo_ai_course_id: 'neo-456'
-      create :lesson, course_module: (create :course_module, course: cs_course)
-    end
-
     it 'permits admin' do
       expect(described_class.new(admin, lesson).new?).to be true
     end
 
-    it 'permits manager who owns the content studio course' do
-      expect(described_class.new(manager, cs_lesson).new?).to be true
-    end
-
-    it 'denies manager on a non-content-studio course' do
+    it 'denies manager' do
       expect(described_class.new(manager, lesson).new?).to be false
     end
   end
 
   describe '#create?' do
-    let(:cs_lesson) do
-      cs_course = create :course, learning_partner:, neo_ai_course_id: 'neo-456'
-      create :lesson, course_module: (create :course_module, course: cs_course)
-    end
-
     it 'permits admin' do
       expect(described_class.new(admin, lesson).create?).to be true
     end
 
-    it 'permits manager who owns the content studio course' do
-      expect(described_class.new(manager, cs_lesson).create?).to be true
-    end
-
-    it 'denies manager on a non-content-studio course' do
+    it 'denies manager' do
       expect(described_class.new(manager, lesson).create?).to be false
     end
   end
 
   describe '#edit?' do
-    let(:cs_lesson) do
-      cs_course = create :course, learning_partner:, neo_ai_course_id: 'neo-456'
-      create :lesson, course_module: (create :course_module, course: cs_course)
-    end
-
     it 'permits admin' do
       expect(described_class.new(admin, lesson).edit?).to be true
     end
 
-    it 'permits manager who owns the content studio course' do
-      expect(described_class.new(manager, cs_lesson).edit?).to be true
-    end
-
-    it 'denies manager on a non-content-studio course' do
+    it 'denies manager' do
       expect(described_class.new(manager, lesson).edit?).to be false
     end
   end
 
   describe '#update?' do
-    let(:cs_lesson) do
-      cs_course = create :course, learning_partner:, neo_ai_course_id: 'neo-456'
-      create :lesson, course_module: (create :course_module, course: cs_course)
-    end
-
     it 'permits admin' do
       expect(described_class.new(admin, lesson).update?).to be true
     end
 
-    it 'permits manager who owns the content studio course' do
-      expect(described_class.new(manager, cs_lesson).update?).to be true
-    end
-
-    it 'denies manager on a non-content-studio course' do
+    it 'denies manager' do
       expect(described_class.new(manager, lesson).update?).to be false
     end
   end

--- a/spec/requests/courses/manage_spec.rb
+++ b/spec/requests/courses/manage_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Request spec for GET /courses/manage' do
         before do
           @team = create :team
           @user = create :user, role, team: @team
-          @user.update!(content_studio_creator: true)
           create :payment_plan, learning_partner: @user.learning_partner, content_studio_enabled: true
           sign_in @user
         end
@@ -37,6 +36,16 @@ RSpec.describe 'Request spec for GET /courses/manage' do
   end
 
   describe 'access control' do
+    %i[manager owner].each do |role|
+      it "redirects #{role} whose LP does not have content studio enabled" do
+        user = create :user, role
+        sign_in user
+
+        get(manage_courses_path)
+        expect(response).to redirect_to(error_401_path)
+      end
+    end
+
     it 'redirects learners away from manage page' do
       team = create :team
       learner = create :user, :learner, team: team


### PR DESCRIPTION
Fixes #1426

## Summary

Implements a tiered access model for managers in the LMS:

| Role | Create course | Edit/Delete course | Publish/Unpublish | View CS courses | View CS lessons |
|---|---|---|---|---|---|
| Admin | Manual (LMS) | ✓ | ✓ | ✗ (blocked by CS engine) | ✗ |
| Manager + `content_studio_creator` | Via CS wizard | ✗ | ✓ (own CS courses) | ✓ | ✓ |
| Manager (CS-enabled LP, no creator flag) | ✗ | ✗ | ✗ | ✓ | ✓ |
| Learner | ✗ | ✗ | ✗ | Published/enrolled | Enrolled only |

## Policy changes

- `CoursePolicy#manage?` — broadened to all managers of a CS-enabled learning partner (previously required `content_studio_creator` flag)
- `CoursePolicy#edit?`, `update?`, `destroy?` — restricted to admin only
- `CoursePolicy#show?` — allows any CS-LP manager to view CS courses via new `partner_content_studio_course?` helper
- `CoursePolicy#publish?`, `unpublish?` — unchanged; still requires `content_studio_creator`
- `CourseModulePolicy` — all write actions restricted to admin only
- `LessonPolicy#show?` — allows CS-LP managers to view lessons via `partner_content_studio_lesson?`

## Manager mode (My Content → course → lesson)

When a manager navigates from My Content (`manage_courses_path`), a `mode=manager` param is threaded through the course and lesson URLs. In this mode:

- Self-assign (enroll) button is hidden
- Lesson titles become clickable links
- Lesson sidebar is fully enabled (no enrollment required)
- Prev/Next navigation is unlocked

`manage_mode?` verifies the course is an LP-owned CS course to prevent URL param manipulation.