### PR TITLE
Fix kit progress banner visibility and reuse shared progress_card partial

### DIFF
--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -5,6 +5,7 @@ module ContentStudio
     class StructureController < ApplicationController
       def show
         @kit = ApiClient.get_classroom_kit(params[:id])
+        @show_progress = params[:source] != 'completed'
       rescue Faraday::Error => e
         Rails.logger.error("[ContentStudio] kit structure#show failed: #{e.message}")
         head :service_unavailable

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/structure_controller.rb
@@ -5,7 +5,6 @@ module ContentStudio
     class StructureController < ApplicationController
       def show
         @kit = ApiClient.get_classroom_kit(params[:id])
-        @show_progress = params[:source] != 'completed'
       rescue Faraday::Error => e
         Rails.logger.error("[ContentStudio] kit structure#show failed: #{e.message}")
         head :service_unavailable

--- a/engines/content_studio/app/controllers/content_studio/classroom_kits/wizard_controller.rb
+++ b/engines/content_studio/app/controllers/content_studio/classroom_kits/wizard_controller.rb
@@ -50,7 +50,7 @@ module ContentStudio
 
         kit_id = ApiClient.create_classroom_kit(files: file_urls, components: components, title: title)
         Rails.cache.write("kit_title_#{kit_id}", title, expires_in: 90.days) if title.present?
-        render json: { redirect_url: kit_structure_url(id: kit_id) }
+        render json: { redirect_url: kit_structure_url(id: kit_id, source: 'generation') }
       rescue Faraday::Error => e
         Rails.logger.error("[ContentStudio] kit start_generation failed: #{e.message}")
         render json: { redirect_url: generating_classroom_kit_url(id: :pending, state: 'error') },
@@ -63,7 +63,7 @@ module ContentStudio
 
         case status
         when 'COMPLETED'
-          render json: { status: 'complete', redirect_url: kit_structure_url(id: params[:id]) }
+          render json: { status: 'complete', redirect_url: kit_structure_url(id: params[:id], source: 'generation') }
         when 'FAILED'
           render json: { status: 'error', redirect_url: generating_classroom_kit_url(id: params[:id], state: 'error') }
         else

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -89,7 +89,7 @@ module ContentStudio
       link_to(card, course_structure_path(id: course.id), class: 'block')
     end
 
-    def studio_kit_card(kit)
+    def studio_kit_card(kit, source = nil)
       card = course_card_component(
         title: kit.title.presence || 'Untitled Kit',
         banner_url: kit.thumbnail_url.presence,
@@ -98,7 +98,7 @@ module ContentStudio
         categories: [],
         type_tag: { label: 'Classroom Kit', bg_color: 'bg-secondary-light-200', text_color: 'text-letter-color' }
       )
-      link_to(card, kit_structure_path(id: kit.id), class: 'block')
+      link_to(card, kit_structure_path(id: kit.id, source: source), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/generation_polling_controller.js
@@ -13,8 +13,9 @@ export default class extends Controller {
   async connect() {
     if (this.startUrlValue) {
       const storageKey = `generation_started_${this.startUrlValue}`
-      if (sessionStorage.getItem(storageKey)) return
-      sessionStorage.setItem(storageKey, '1')
+      const existing = sessionStorage.getItem(storageKey)
+      if (existing && (Date.now() - parseInt(existing)) < 60000) return
+      sessionStorage.setItem(storageKey, Date.now().toString())
       // Run API call and phase transitions in parallel
       // Minimum display: 4s uploading + 4s crafting before redirect
       try {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
           this.bannerTarget.style.display = ''
           if (prevSource === 'generation') {
             // Hide after 1 second for generation flow
-            setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+            this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
           }
           // in_progress: stays visible until next page refresh
         } else {
@@ -63,6 +63,7 @@ export default class extends Controller {
 
   disconnect() {
     clearTimeout(this.timer)
+    clearTimeout(this.hideTimer)
     window.removeEventListener('module-select:drag-start', this._onDragStart)
     window.removeEventListener('module-select:drag-end', this._onDragEnd)
     document.removeEventListener('turbo:before-visit', this._onBeforeVisit)
@@ -76,7 +77,7 @@ export default class extends Controller {
     sessionStorage.removeItem(this._storageKey)
     this.bannerTarget.style.display = ''
     if (this.sourceValue === 'generation') {
-      setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+      this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
     }
   }
 

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -25,7 +25,12 @@ export default class extends Controller {
         const prevSource = sessionStorage.getItem(this._storageKey)
         if (prevSource) {
           // Frame reloaded after reaching 100%
-          this._showBanner(prevSource)
+          sessionStorage.removeItem(this._storageKey)
+          this.bannerTarget.style.display = ''
+          if (prevSource === 'generation') {
+            // Hide after 1 second for generation flow
+            this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+          }
           // in_progress: stays visible until next page refresh
         } else {
           this.bannerTarget.style.display = 'none'
@@ -69,7 +74,11 @@ export default class extends Controller {
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
     if (!this._startedPending || this.sourceValue === 'completed') return
-    this._showBanner(this.sourceValue)
+    sessionStorage.removeItem(this._storageKey)
+    this.bannerTarget.style.display = ''
+    if (this.sourceValue === 'generation') {
+      this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+    }
   }
 
   thumbnailUrlValueChanged(url) {
@@ -84,14 +93,6 @@ export default class extends Controller {
     img.src = url
     img.classList.replace('object-contain', 'object-cover')
     img.dataset.loadedUrl = url
-  }
-
-  _showBanner(source) {
-    sessionStorage.removeItem(this._storageKey)
-    this.bannerTarget.style.display = ''
-    if (source === 'generation') {
-      this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
-    }
   }
 
   _schedulePoll() {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -25,12 +25,7 @@ export default class extends Controller {
         const prevSource = sessionStorage.getItem(this._storageKey)
         if (prevSource) {
           // Frame reloaded after reaching 100%
-          sessionStorage.removeItem(this._storageKey)
-          this.bannerTarget.style.display = ''
-          if (prevSource === 'generation') {
-            // Hide after 1 second for generation flow
-            this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
-          }
+          this._showBanner(prevSource)
           // in_progress: stays visible until next page refresh
         } else {
           this.bannerTarget.style.display = 'none'
@@ -74,11 +69,7 @@ export default class extends Controller {
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
     if (!this._startedPending || this.sourceValue === 'completed') return
-    sessionStorage.removeItem(this._storageKey)
-    this.bannerTarget.style.display = ''
-    if (this.sourceValue === 'generation') {
-      this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
-    }
+    this._showBanner(this.sourceValue)
   }
 
   thumbnailUrlValueChanged(url) {
@@ -93,6 +84,14 @@ export default class extends Controller {
     img.src = url
     img.classList.replace('object-contain', 'object-cover')
     img.dataset.loadedUrl = url
+  }
+
+  _showBanner(source) {
+    sessionStorage.removeItem(this._storageKey)
+    this.bannerTarget.style.display = ''
+    if (source === 'generation') {
+      this.hideTimer = setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+    }
   }
 
   _schedulePoll() {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -73,6 +73,7 @@ export default class extends Controller {
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
     if (!this._startedPending || this.sourceValue === 'completed') return
+    sessionStorage.removeItem(this._storageKey)
     this.bannerTarget.style.display = ''
     if (this.sourceValue === 'generation') {
       setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -2,8 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 const POLL_INTERVAL_MS = 5000
 
-const BANNER_HIDE_DELAY_MS = 1500
-
 export default class extends Controller {
   static values = {
     pending: Boolean,
@@ -13,6 +11,10 @@ export default class extends Controller {
   static targets = ['banner']
 
   connect() {
+    this._startedPending = this.pendingValue
+    if (!this._startedPending && this.hasBannerTarget) {
+      this.bannerTarget.style.display = 'none'
+    }
     this._dragging = false
     this._onDragStart = () => {
       this._dragging = true
@@ -48,10 +50,8 @@ export default class extends Controller {
 
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
-    clearTimeout(this._bannerHideTimer)
-    this._bannerHideTimer = setTimeout(() => {
-      this.bannerTarget.style.visibility = 'hidden'
-    }, BANNER_HIDE_DELAY_MS)
+    if (!this._startedPending) return
+    this.bannerTarget.style.display = ''
   }
 
   thumbnailUrlValueChanged(url) {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -5,7 +5,7 @@ const POLL_INTERVAL_MS = 5000
 export default class extends Controller {
   static values = {
     pending: Boolean,
-    showProgress: { type: Boolean, default: true },
+    source: { type: String, default: '' },
     thumbnailUrl: { type: String, default: '' }
   }
 
@@ -16,17 +16,25 @@ export default class extends Controller {
     this._storageKey = `kit-was-pending-${window.location.pathname}`
 
     if (this.hasBannerTarget) {
-      if (!this.showProgressValue) {
+      const source = this.sourceValue
+      if (source === 'completed') {
         this.bannerTarget.style.display = 'none'
       } else if (this._startedPending) {
-        sessionStorage.setItem(this._storageKey, '1')
-      } else if (sessionStorage.getItem(this._storageKey)) {
-        // Frame reloaded after reaching 100% — show for 1 second then hide
-        sessionStorage.removeItem(this._storageKey)
-        this.bannerTarget.style.display = ''
-        setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+        sessionStorage.setItem(this._storageKey, source || 'generation')
       } else {
-        this.bannerTarget.style.display = 'none'
+        const prevSource = sessionStorage.getItem(this._storageKey)
+        if (prevSource) {
+          // Frame reloaded after reaching 100%
+          sessionStorage.removeItem(this._storageKey)
+          this.bannerTarget.style.display = ''
+          if (prevSource === 'generation') {
+            // Hide after 1 second for generation flow
+            setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+          }
+          // in_progress: stays visible until next page refresh
+        } else {
+          this.bannerTarget.style.display = 'none'
+        }
       }
     }
     this._dragging = false
@@ -64,10 +72,11 @@ export default class extends Controller {
 
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
-    if (!this._startedPending || !this.showProgressValue) return
-    // Just reached 100% — show banner then hide after 1 second
+    if (!this._startedPending || this.sourceValue === 'completed') return
     this.bannerTarget.style.display = ''
-    setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+    if (this.sourceValue === 'generation') {
+      setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+    }
   }
 
   thumbnailUrlValueChanged(url) {

--- a/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
+++ b/engines/content_studio/app/javascript/content_studio/controllers/structure_polling_controller.js
@@ -5,6 +5,7 @@ const POLL_INTERVAL_MS = 5000
 export default class extends Controller {
   static values = {
     pending: Boolean,
+    showProgress: { type: Boolean, default: true },
     thumbnailUrl: { type: String, default: '' }
   }
 
@@ -12,8 +13,21 @@ export default class extends Controller {
 
   connect() {
     this._startedPending = this.pendingValue
-    if (!this._startedPending && this.hasBannerTarget) {
-      this.bannerTarget.style.display = 'none'
+    this._storageKey = `kit-was-pending-${window.location.pathname}`
+
+    if (this.hasBannerTarget) {
+      if (!this.showProgressValue) {
+        this.bannerTarget.style.display = 'none'
+      } else if (this._startedPending) {
+        sessionStorage.setItem(this._storageKey, '1')
+      } else if (sessionStorage.getItem(this._storageKey)) {
+        // Frame reloaded after reaching 100% — show for 1 second then hide
+        sessionStorage.removeItem(this._storageKey)
+        this.bannerTarget.style.display = ''
+        setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
+      } else {
+        this.bannerTarget.style.display = 'none'
+      }
     }
     this._dragging = false
     this._onDragStart = () => {
@@ -50,8 +64,10 @@ export default class extends Controller {
 
   pendingValueChanged(pending, previousPending) {
     if (pending || previousPending === undefined || !this.hasBannerTarget) return
-    if (!this._startedPending) return
+    if (!this._startedPending || !this.showProgressValue) return
+    // Just reached 100% — show banner then hide after 1 second
     this.bannerTarget.style.display = ''
+    setTimeout(() => { this.bannerTarget.style.display = 'none' }, 1000)
   }
 
   thumbnailUrlValueChanged(url) {

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -16,7 +16,8 @@
 <turbo-frame id="kit-structure" refresh="morph">
 <div class="flex flex-col gap-6 py-3"
      data-controller="structure-polling"
-     data-structure-polling-pending-value="<%= !all_ready %>">
+     data-structure-polling-pending-value="<%= !all_ready %>"
+     data-structure-polling-show-progress-value="<%= @show_progress %>">
 
   <%# Page header %>
   <div class="flex items-center gap-2">

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -17,7 +17,7 @@
 <div class="flex flex-col gap-6 py-3"
      data-controller="structure-polling"
      data-structure-polling-pending-value="<%= !all_ready %>"
-     data-structure-polling-show-progress-value="<%= @show_progress %>">
+     data-structure-polling-source-value="<%= params[:source].presence || '' %>">
 
   <%# Page header %>
   <div class="flex items-center gap-2">

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -36,7 +36,7 @@
         fill_pct:      progress_pct,
         completed:     completed,
         total:         total,
-        banner_target: true %>
+        html_options: { data: { 'structure-polling-target': 'banner' } } %>
 
   <%# Two-column body %>
   <div class="flex gap-6 items-start">

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -29,26 +29,13 @@
   </div>
 
   <%# Progress banner %>
-  <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
-       data-structure-polling-target="banner"
-       style="<%= 'visibility: hidden' if all_ready %>">
-    <div class="flex items-center justify-between p-3">
-      <div class="flex items-center gap-2 min-w-0">
-        <%= video_tag 'gliters-ai.mp4', class: 'w-7 h-7 shrink-0', autoplay: true, loop: true, muted: true, playsinline: true %>
-        <span class="general-text-sm-normal text-letter-color truncate">
-          <% if all_ready %>
-            Kit is ready
-          <% else %>
-            Generating <%= @kit.stage.presence || 'kit components' %><%= @kit.title.present? ? " for #{@kit.title}" : '' %>
-          <% end %>
-        </span>
-      </div>
-      <div class="flex items-center gap-3 flex-shrink-0 pl-3">
-        <span class="general-text-md-medium text-primary"><%= progress_pct %>%</span>
-      </div>
-    </div>
-    <%= progressbar_component(numerator: progress_pct, denominator: 100, full_width: true, animated: true, thin: true) %>
-  </div>
+  <%= render 'content_studio/shared/progress_card',
+        pending:       !all_ready,
+        progress_text: all_ready ? 'Kit is ready' : "Generating #{@kit.stage.presence || 'kit components'}#{@kit.title.present? ? " for #{@kit.title}" : ''}",
+        fill_pct:      progress_pct,
+        completed:     completed,
+        total:         total,
+        banner_target: true %>
 
   <%# Two-column body %>
   <div class="flex gap-6 items-start">

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -93,7 +93,7 @@
           <div data-tabs-target="panelItem">
             <% if @in_progress_creations.any? %>
               <% cards = @in_progress_creations.map { |item|
-                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'in_progress')
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item, 'in_progress') : studio_course_card(item, 'in_progress')
                  } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>
@@ -105,7 +105,7 @@
           <div class="hidden" data-tabs-target="panelItem">
             <% if @completed_creations.any? %>
               <% cards = @completed_creations.map { |item|
-                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'completed')
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item, 'completed') : studio_course_card(item, 'completed')
                  } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>

--- a/engines/content_studio/app/views/content_studio/shared/_progress_card.html.erb
+++ b/engines/content_studio/app/views/content_studio/shared/_progress_card.html.erb
@@ -1,8 +1,8 @@
 <% completed     = local_assigns.fetch(:completed, 0) %>
 <% total         = local_assigns.fetch(:total, 0) %>
-<% banner_target = local_assigns.fetch(:banner_target, false) %>
+<% html_options = local_assigns.fetch(:html_options, {}) %>
 <div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
-     <% if banner_target %>data-structure-polling-target="banner"<% end %>>
+     <%= tag.attributes(html_options) %>>
   <div class="flex items-center justify-between p-3">
     <div class="flex items-center gap-2 min-w-0">
       <%= image_tag 'image-ai.gif', class: 'w-7 h-7 shrink-0', alt: '' %>

--- a/engines/content_studio/app/views/content_studio/shared/_progress_card.html.erb
+++ b/engines/content_studio/app/views/content_studio/shared/_progress_card.html.erb
@@ -1,6 +1,8 @@
-<% completed = local_assigns.fetch(:completed, 0) %>
-<% total = local_assigns.fetch(:total, 0) %>
-<div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden">
+<% completed     = local_assigns.fetch(:completed, 0) %>
+<% total         = local_assigns.fetch(:total, 0) %>
+<% banner_target = local_assigns.fetch(:banner_target, false) %>
+<div class="max-w-2xl mx-auto w-full bg-white border border-secondary-dark rounded-lg overflow-hidden"
+     <% if banner_target %>data-structure-polling-target="banner"<% end %>>
   <div class="flex items-center justify-between p-3">
     <div class="flex items-center gap-2 min-w-0">
       <%= image_tag 'image-ai.gif', class: 'w-7 h-7 shrink-0', alt: '' %>


### PR DESCRIPTION
- Replace inline banner in classroom_kits/structure/show with the shared content_studio/shared/_progress_card partial (already used by courses)
- Extend _progress_card to accept optional banner_target local so the Stimulus target attribute can be applied from the caller
- Track _startedPending on connect() so the banner is hidden immediately when opening an already-complete kit, shown throughout generation when opened from in-progress, and stays visible at 100% until the user refreshes the page

**Summary**
Fix classroom kit progress banner visibility logic and replace the inline banner with the shared _progress_card partial already used by courses.

**Related Issue**
Closes [#1424](https://github.com/openvitae-tech/blackboard-lms/issues/1424)

**Changes**

- Reuse shared partial — replaced the 20-line inline banner in classroom_kits/structure/show.html.erb with render 'content_studio/shared/progress_card', eliminating duplication with the courses flow
- Extended _progress_card — added optional banner_target local (defaults to false) so the kit can wire up the Stimulus data-structure-polling-target="banner" attribute without affecting the existing courses usage
- Fixed banner visibility logic in structure_polling_controller.js — introduced this._startedPending on connect() to track the page's initial pending state:
- Opened from Completed → banner hidden immediately via display: none, never shown
- Opened from In Progress → banner visible throughout generation; stays visible at 100% after completion
- Refresh after completion → connect() re-fires, _startedPending = false, banner hidden again
- Removed BANNER_HIDE_DELAY_MS — auto-hide timer eliminated; banner now persists at 100% until the user navigates away or refreshesSummary
- Fix classroom kit progress banner visibility logic and replace the inline banner with the shared _progress_card partial already used by courses.


## Screenshots / Visual Diffs
<!-- Required for any UI or NeoComponent changes. Attach before/after screenshots or recordings. -->

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
