### PR TITLE
Add published/unpublished status filter to My Courses admin page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -22,7 +22,7 @@ class CoursesController < ApplicationController
     @type = params[:type]
     if current_user.is_admin?
       search_context = SearchContext.new(context: :home_page, tags: params[:tags], term: params[:term],
-                                         type: params[:type])
+                                         statuses: params[:status], type: params[:type])
       @courses = Courses::FilterService.new(current_user, search_context).filter.records
                                        .includes(:tags, banner_attachment: :blob)
     else
@@ -31,7 +31,7 @@ class CoursesController < ApplicationController
                        .includes(:tags, banner_attachment: :blob)
                        .order(created_at: :desc)
     end
-    @courses = apply_status_filter(@courses).page(filter_params[:page])
+    @courses = @courses.page(filter_params[:page])
     @tags = Tag.load_tags
   end
 
@@ -248,13 +248,6 @@ class CoursesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def course_params
     params.expect(course: %i[title description banner category_id level_id visibility])
-  end
-
-  def apply_status_filter(scope)
-    statuses = Array(params[:status]).map(&:to_s) & %w[published unpublished]
-    return scope if statuses.empty? || statuses.size == 2
-
-    statuses.include?('published') ? scope.published : scope.where(is_published: false)
   end
 
   def filter_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,14 +25,13 @@ class CoursesController < ApplicationController
                                          type: params[:type])
       @courses = Courses::FilterService.new(current_user, search_context).filter.records
                                        .includes(:tags, banner_attachment: :blob)
-      @courses = @courses.page(filter_params[:page])
     else
       @courses = Course.where(learning_partner_id: current_user.learning_partner_id)
                        .where.not(neo_ai_course_id: nil)
                        .includes(:tags, banner_attachment: :blob)
                        .order(created_at: :desc)
-                       .page(filter_params[:page])
     end
+    @courses = apply_status_filter(@courses).page(filter_params[:page])
     @tags = Tag.load_tags
   end
 
@@ -249,6 +248,13 @@ class CoursesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def course_params
     params.expect(course: %i[title description banner category_id level_id visibility])
+  end
+
+  def apply_status_filter(scope)
+    statuses = Array(params[:status]).map(&:to_s) & %w[published unpublished]
+    return scope if statuses.empty? || statuses.size == 2
+
+    statuses.include?('published') ? scope.published : scope.where(is_published: false)
   end
 
   def filter_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -26,8 +26,10 @@ class CoursesController < ApplicationController
       @courses = Courses::FilterService.new(current_user, search_context).filter.records
                                        .includes(:tags, banner_attachment: :blob)
     else
+      statuses = Array(params[:status]).map(&:to_s) & SearchContext::VALID_STATUSES
       @courses = Course.where(learning_partner_id: current_user.learning_partner_id)
                        .where.not(neo_ai_course_id: nil)
+                       .then { |s| apply_status_filter(s, statuses) }
                        .includes(:tags, banner_attachment: :blob)
                        .order(created_at: :desc)
     end
@@ -272,5 +274,11 @@ class CoursesController < ApplicationController
     SearchContext.new(context: SearchContext::HOME_PAGE,
                       type:,
                       tags:)
+  end
+
+  def apply_status_filter(scope, statuses)
+    return scope if statuses.empty? || statuses.size == SearchContext::VALID_STATUSES.size
+
+    statuses.include?('published') ? scope.published : scope.where(is_published: false)
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,7 +29,7 @@ class CoursesController < ApplicationController
       statuses = Array(params[:status]).map(&:to_s) & SearchContext::VALID_STATUSES
       @courses = Course.where(learning_partner_id: current_user.learning_partner_id)
                        .where.not(neo_ai_course_id: nil)
-                       .then { |s| apply_status_filter(s, statuses) }
+                       .then { |s| Courses::FilterService.filter_by_statuses(statuses, s) }
                        .includes(:tags, banner_attachment: :blob)
                        .order(created_at: :desc)
     end
@@ -274,11 +274,5 @@ class CoursesController < ApplicationController
     SearchContext.new(context: SearchContext::HOME_PAGE,
                       type:,
                       tags:)
-  end
-
-  def apply_status_filter(scope, statuses)
-    return scope if statuses.empty? || statuses.size == SearchContext::VALID_STATUSES.size
-
-    statuses.include?('published') ? scope.published : scope.where(is_published: false)
   end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -184,6 +184,10 @@ module CoursesHelper
     url_for(request.query_parameters.merge(tags: params[:tags] - [tag]))
   end
 
+  def updated_status_query_params(status)
+    url_for(request.query_parameters.merge(status: Array(params[:status]) - [status]))
+  end
+
   def score_earned_for_module(enrollment, course_module)
     enrollment.present? ? enrollment.score_earned_for(course_module) : 0
   end

--- a/app/services/courses/filter_service.rb
+++ b/app/services/courses/filter_service.rb
@@ -30,6 +30,12 @@ module Courses
       @result = SearchResult.new(course_scope, search_context)
     end
 
+    def self.filter_by_statuses(statuses, scope)
+      return scope if statuses.empty? || statuses.size == SearchContext::VALID_STATUSES.size
+
+      statuses.include?('published') ? scope.published : scope.where(is_published: false)
+    end
+
     private
 
     def filter_by_tags(tags, courses)
@@ -60,9 +66,7 @@ module Courses
     end
 
     def filter_by_statuses(statuses, scope)
-      return scope if statuses.empty? || statuses.size == SearchContext::VALID_STATUSES.size
-
-      statuses.include?('published') ? scope.published : scope.where(is_published: false)
+      self.class.filter_by_statuses(statuses, scope)
     end
 
     def filter_by_matching_term(scope, search_context)

--- a/app/services/courses/filter_service.rb
+++ b/app/services/courses/filter_service.rb
@@ -17,6 +17,7 @@ module Courses
       course_scope = filter_scope_for(user, search_context)
       course_scope = filter_by_matching_term(course_scope, search_context)
       course_scope = filter_by_tags(search_context.tags, course_scope)
+      course_scope = filter_by_statuses(search_context.statuses, course_scope)
 
       course_scope = if search_context.user_assign?
                        filter_out_user_enrolled_courses(course_scope, search_context)
@@ -56,6 +57,12 @@ module Courses
       else
         courses
       end
+    end
+
+    def filter_by_statuses(statuses, scope)
+      return scope if statuses.empty? || statuses.size == SearchContext::VALID_STATUSES.size
+
+      statuses.include?('published') ? scope.published : scope.where(is_published: false)
     end
 
     def filter_by_matching_term(scope, search_context)

--- a/app/value_objects/search_context.rb
+++ b/app/value_objects/search_context.rb
@@ -89,9 +89,10 @@ class SearchContext
     {
       term: @term,
       tags: @tags,
+      status: @statuses,
       context: @context,
       type: @type
-    }.filter { |_k, v| !v.empty? }.to_query
+    }.filter { |_k, v| v.respond_to?(:empty?) ? !v.empty? : v.present? }.to_query
   end
 
   private

--- a/app/value_objects/search_context.rb
+++ b/app/value_objects/search_context.rb
@@ -19,7 +19,9 @@ class SearchContext
   COMPLETE = :complete
   VALID_TYPES = [ANY, ENROLLED, UNENROLLED, INCOMPLETE, COMPLETE].freeze
 
-  attr_reader :term, :tags, :context, :team, :user, :type, :program
+  VALID_STATUSES = %w[published unpublished].freeze
+
+  attr_reader :term, :tags, :statuses, :context, :team, :user, :type, :program
 
   validates :context,
             inclusion: { in: VALID_CONTEXTS,
@@ -33,9 +35,10 @@ class SearchContext
     end
   end
 
-  def initialize(context:, term: '', tags: [], type: nil, options: {}) # rubocop:disable Metrics/CyclomaticComplexity
+  def initialize(context:, term: '', tags: [], statuses: [], type: nil, options: {}) # rubocop:disable Metrics/CyclomaticComplexity
     @term = sanitize_parameter(term, '')
     @tags = sanitize_parameter(tags, [])
+    @statuses = (Array(statuses).map(&:to_s) & VALID_STATUSES)
     @context = sanitize_parameter(context)&.to_sym
     @type = sanitize_parameter(type, ANY).to_sym
 

--- a/app/views/courses/_filters.html.erb
+++ b/app/views/courses/_filters.html.erb
@@ -18,7 +18,7 @@
                     label: 'Published',
                     value: 'published',
                     html_options: {
-                      checked: params[:status]&.include?('published'),
+                      checked: Array(params[:status]).include?('published'),
                       data: { courses_target: 'checkbox' }
                     }
                   ) %>
@@ -29,7 +29,7 @@
                     label: 'Unpublished',
                     value: 'unpublished',
                     html_options: {
-                      checked: params[:status]&.include?('unpublished'),
+                      checked: Array(params[:status]).include?('unpublished'),
                       data: { courses_target: 'checkbox' }
                     }
                   ) %>

--- a/app/views/courses/_filters.html.erb
+++ b/app/views/courses/_filters.html.erb
@@ -8,6 +8,35 @@
   <%= form_with url: local_assigns.fetch(:filter_url) { courses_path }, method: :get, local: true,class:"h-full flex flex-col justify-between", data: {action: "submit->courses#formSubmit"} do |form| %>
     <div class="overflow-y-auto max-h-[calc(100vh-220px)] py-2 ">
       <span class="main-text-sm-normal cursor-pointer flex justify-end px-8 text-primary" data-action="click->courses#clearFilters">Clear filter</span>
+      <% if local_assigns.fetch(:show_status_filter, false) %>
+        <div class="flex flex-col border-b border-line-colour px-8">
+          <h3 class="main-text-lg-medium text-primary py-1">Status</h3>
+          <ul class="flex flex-col">
+            <li class="py-2 flex items-center">
+              <%= input_checkbox_component(
+                    name: 'status[]',
+                    label: 'Published',
+                    value: 'published',
+                    html_options: {
+                      checked: params[:status]&.include?('published'),
+                      data: { courses_target: 'checkbox' }
+                    }
+                  ) %>
+            </li>
+            <li class="py-2 flex items-center">
+              <%= input_checkbox_component(
+                    name: 'status[]',
+                    label: 'Unpublished',
+                    value: 'unpublished',
+                    html_options: {
+                      checked: params[:status]&.include?('unpublished'),
+                      data: { courses_target: 'checkbox' }
+                    }
+                  ) %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
       <div class="flex flex-col border-b border-line-colour px-8">
         <h3 class="main-text-lg-medium text-primary py-1">Levels</h3>
         <ul class="flex flex-col">

--- a/app/views/courses/_filters.html.erb
+++ b/app/views/courses/_filters.html.erb
@@ -12,28 +12,19 @@
         <div class="flex flex-col border-b border-line-colour px-8">
           <h3 class="main-text-lg-medium text-primary py-1">Status</h3>
           <ul class="flex flex-col">
-            <li class="py-2 flex items-center">
-              <%= input_checkbox_component(
-                    name: 'status[]',
-                    label: 'Published',
-                    value: 'published',
-                    html_options: {
-                      checked: Array(params[:status]).include?('published'),
-                      data: { courses_target: 'checkbox' }
-                    }
-                  ) %>
-            </li>
-            <li class="py-2 flex items-center">
-              <%= input_checkbox_component(
-                    name: 'status[]',
-                    label: 'Unpublished',
-                    value: 'unpublished',
-                    html_options: {
-                      checked: Array(params[:status]).include?('unpublished'),
-                      data: { courses_target: 'checkbox' }
-                    }
-                  ) %>
-            </li>
+            <% [['Published', 'published'], ['Unpublished', 'unpublished']].each do |label, value| %>
+              <li class="py-2 flex items-center">
+                <%= input_checkbox_component(
+                      name: 'status[]',
+                      label: label,
+                      value: value,
+                      html_options: {
+                        checked: Array(params[:status]).include?(value),
+                        data: { courses_target: 'checkbox' }
+                      }
+                    ) %>
+              </li>
+            <% end %>
           </ul>
         </div>
       <% end %>

--- a/app/views/courses/list/_admin.html.erb
+++ b/app/views/courses/list/_admin.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="courses">
   <div class="pt-4 md:pt-5 pb-3 flex flex-col gap-4 sticky top-0 w-full z-40 bg-white-light">
-    <%= render 'filters', tags: tags, filter_url: manage_courses_path %>
+    <%= render 'filters', tags: tags, filter_url: manage_courses_path, show_status_filter: true %>
     <div class="flex flex-row justify-between">
       <div class="flex items-center gap-3">
         <%= render 'shared/components/back_button', back_link: content_path %>
@@ -57,6 +57,11 @@
         <% params[:tags]&.each do |tag| %>
           <%= link_to updated_tags_query_params(tag), method: :get do %>
             <%= chip_component(text: tag , colorscheme: 'input', close: true) %>
+          <% end %>
+        <% end %>
+        <% Array(params[:status]).each do |status| %>
+          <%= link_to updated_status_query_params(status), method: :get do %>
+            <%= chip_component(text: status.capitalize, colorscheme: 'input', close: true) %>
           <% end %>
         <% end %>
       </div>

--- a/spec/value_objects/search_context_spec.rb
+++ b/spec/value_objects/search_context_spec.rb
@@ -119,6 +119,39 @@ RSpec.describe SearchContext do
     end
   end
 
+  describe '#to_query_str' do
+    it 'includes statuses when present' do
+      ctx = SearchContext.new(
+        context: SearchContext::HOME_PAGE,
+        statuses: ['published'],
+        type: SearchContext::ANY
+      )
+
+      expect(CGI.parse(ctx.to_query_str)['status[]']).to eq(['published'])
+    end
+
+    it 'omits status key when statuses is empty' do
+      ctx = SearchContext.new(
+        context: SearchContext::HOME_PAGE,
+        type: SearchContext::ANY
+      )
+
+      expect(ctx.to_query_str).not_to include('status')
+    end
+
+    it 'omits blank term and empty tags' do
+      ctx = SearchContext.new(
+        context: SearchContext::HOME_PAGE,
+        term: '',
+        tags: [],
+        type: SearchContext::ANY
+      )
+
+      expect(ctx.to_query_str).not_to include('term')
+      expect(ctx.to_query_str).not_to include('tags')
+    end
+  end
+
   describe 'Sanitize the tags and term' do
     it 'sanitizes the tags' do
       ctx = SearchContext.new(


### PR DESCRIPTION
## Summary
Adds a Status filter (Published / Unpublished) to the existing course filter panel, visible only on the My Courses admin page, with chip removal support and controller-level filtering.
## Related Issue
<!-- Link the issue this PR resolves -->
Closes #1438

## Changes

- Added a Status section (Published / Unpublished checkboxes) to _filters.html.erb, conditionally rendered via a show_status_filter local — only shown on the My Courses admin page
- Added apply_status_filter private method in CoursesController that filters the course scope by params[:status]; no-ops when both or neither value is selected
- Added updated_status_query_params helper in CoursesHelper to generate the chip removal URL by stripping the given status from the current query string
- Moved .page(filter_params[:page]) after apply_status_filter so pagination applies to the already-filtered scope in both branches

## Screenshots / Visual Diffs
<img width="325" height="916" alt="Screenshot 2026-06-24 at 4 08 55 PM" src="https://github.com/user-attachments/assets/8450ebef-dbab-492e-ad9a-e93b4577821f" />

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course status filtering, letting you narrow results to published or unpublished courses.
  * Admin course lists now show status filter chips and keep filter selections in the URL.

* **Bug Fixes**
  * Improved course listing behavior so filters and pagination work together more consistently.
  * Search and list views now keep status selections in sync when updating filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->