### PR TITLE
Restore active tab on back-navigation from course/kit structure

### DIFF
--- a/app/javascript/controllers/auto_click_controller.js
+++ b/app/javascript/controllers/auto_click_controller.js
@@ -2,12 +2,12 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["tabItem"];
+  static values = { index: { type: Number, default: 0 } };
 
   connect() {
     requestAnimationFrame(() => {
-      if (this.hasTabItemTarget) {
-        this.tabItemTarget.click()
-      }
-    })    
+      const target = this.tabItemTargets[this.indexValue] ?? this.tabItemTargets[0];
+      if (target) target.click();
+    });
   }
 }

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -73,7 +73,7 @@ module ContentStudio
       end
     end
 
-    def studio_course_card(course, _status)
+    def studio_course_card(course, status = nil)
       card = course_card_component(
         title: course.title,
         banner_url: course.thumbnail_url.presence,
@@ -86,10 +86,10 @@ module ContentStudio
         badge: studio_badge(course.level),
         type_tag: { label: 'Course', bg_color: 'bg-primary-light-200', text_color: 'text-letter-color' }
       )
-      link_to(card, course_structure_path(id: course.id), class: 'block')
+      link_to(card, course_structure_path(id: course.id, tab: status), class: 'block')
     end
 
-    def studio_kit_card(kit)
+    def studio_kit_card(kit, source = nil)
       card = course_card_component(
         title: kit.title.presence || 'Untitled Kit',
         banner_url: kit.thumbnail_url.presence,
@@ -98,7 +98,8 @@ module ContentStudio
         categories: [],
         type_tag: { label: 'Classroom Kit', bg_color: 'bg-secondary-light-200', text_color: 'text-letter-color' }
       )
-      link_to(card, kit_structure_path(id: kit.id), class: 'block')
+
+      link_to(card, kit_structure_path(id: kit.id, source: source, tab: source), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -73,7 +73,7 @@ module ContentStudio
       end
     end
 
-    def studio_course_card(course, status = nil)
+    def studio_course_card(course, tab = nil)
       card = course_card_component(
         title: course.title,
         banner_url: course.thumbnail_url.presence,
@@ -86,10 +86,10 @@ module ContentStudio
         badge: studio_badge(course.level),
         type_tag: { label: 'Course', bg_color: 'bg-primary-light-200', text_color: 'text-letter-color' }
       )
-      link_to(card, course_structure_path(id: course.id, tab: status), class: 'block')
+      link_to(card, course_structure_path(id: course.id, tab: tab), class: 'block')
     end
 
-    def studio_kit_card(kit, source = nil)
+    def studio_kit_card(kit, tab = nil)
       card = course_card_component(
         title: kit.title.presence || 'Untitled Kit',
         banner_url: kit.thumbnail_url.presence,
@@ -98,7 +98,7 @@ module ContentStudio
         categories: [],
         type_tag: { label: 'Classroom Kit', bg_color: 'bg-secondary-light-200', text_color: 'text-letter-color' }
       )
-      link_to(card, kit_structure_path(id: kit.id, tab: source, source: source), class: 'block')
+      link_to(card, kit_structure_path(id: kit.id, tab: tab, source: tab), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/helpers/content_studio/application_helper.rb
+++ b/engines/content_studio/app/helpers/content_studio/application_helper.rb
@@ -99,7 +99,7 @@ module ContentStudio
         type_tag: { label: 'Classroom Kit', bg_color: 'bg-secondary-light-200', text_color: 'text-letter-color' }
       )
 
-      link_to(card, kit_structure_path(id: kit.id, source: source, tab: source), class: 'block')
+      link_to(card, kit_structure_path(id: kit.id, tab: source), class: 'block')
     end
 
     def lesson_status_label(status)

--- a/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/classroom_kits/structure/show.html.erb
@@ -20,7 +20,7 @@
 
   <%# Page header %>
   <div class="flex items-center gap-2">
-    <%= link_to root_path, data: { turbo: false } do %>
+    <%= link_to root_path(tab: params[:tab]), data: { turbo: false } do %>
       <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
         <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
       </span>

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -97,7 +97,7 @@
           <div data-tabs-target="panelItem">
             <% if @in_progress_creations.any? %>
               <% cards = @in_progress_creations.map { |item|
-                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'in_progress')
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item, 'in_progress') : studio_course_card(item, 'in_progress')
                  } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>
@@ -109,7 +109,7 @@
           <div class="hidden" data-tabs-target="panelItem">
             <% if @completed_creations.any? %>
               <% cards = @completed_creations.map { |item|
-                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item) : studio_course_card(item, 'completed')
+                   item.is_a?(ContentStudio::Kit) ? studio_kit_card(item, 'completed') : studio_course_card(item, 'completed')
                  } %>
               <%= carousel_component(cards: cards, loop: false) %>
             <% else %>

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -71,19 +71,23 @@
     <div class="flex flex-col gap-3">
       <p class="heading-xl text-primary px-2">Recent Creations</p>
 
+      <% active_tab_index = params[:tab] == 'completed' ? 1 : 0 %>
       <div class="bg-white border-2 border-line-colour-light rounded-xl pt-4 pb-5 px-5 flex flex-col gap-4">
-        <div data-controller="tabs"
+        <div data-controller="auto-click tabs"
+             data-auto-click-index-value="<%= active_tab_index %>"
              data-tabs-active-class="text-letter-color border-b-2 border-slate-grey">
 
           <%# Tab headers %>
           <div class="flex gap-5 border-b border-line-colour mb-4">
             <div class="py-1 cursor-pointer general-text-md-medium text-letter-color-light"
                  data-tabs-target="tabItem"
+                 data-auto-click-target="tabItem"
                  data-action="click->tabs#select">
               In Progress
             </div>
             <div class="py-1 cursor-pointer general-text-md-medium text-letter-color-light"
                  data-tabs-target="tabItem"
+                 data-auto-click-target="tabItem"
                  data-action="click->tabs#select">
               Completed
             </div>

--- a/engines/content_studio/app/views/content_studio/courses/index.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/index.html.erb
@@ -71,13 +71,14 @@
     <div class="flex flex-col gap-3">
       <p class="heading-xl text-primary px-2">Recent Creations</p>
 
-      <% active_tab_index = params[:tab] == 'completed' ? 1 : 0 %>
+      <% tab_order = %w[in_progress completed] %>
+      <% active_tab_index = tab_order.index(params[:tab]) || 0 %>
       <div class="bg-white border-2 border-line-colour-light rounded-xl pt-4 pb-5 px-5 flex flex-col gap-4">
         <div data-controller="auto-click tabs"
              data-auto-click-index-value="<%= active_tab_index %>"
              data-tabs-active-class="text-letter-color border-b-2 border-slate-grey">
 
-          <%# Tab headers %>
+          <%# Tab headers — order must match tab_order above %>
           <div class="flex gap-5 border-b border-line-colour mb-4">
             <div class="py-1 cursor-pointer general-text-md-medium text-letter-color-light"
                  data-tabs-target="tabItem"

--- a/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
+++ b/engines/content_studio/app/views/content_studio/courses/structure/show.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-6 py-3">
   <div class="flex items-center gap-2">
-    <%= link_to root_path, data: { turbo: false } do %>
+    <%= link_to root_path(tab: params[:tab]), data: { turbo: false } do %>
       <span class="flex items-center justify-center w-7 h-7 rounded-full bg-white border border-primary-light-100">
         <%= icon 'arrow-left', css: 'w-4 h-4 text-primary' %>
       </span>


### PR DESCRIPTION
When a user opens a course or classroom kit from the Content Studio Recent Creations section and presses the back button, the index page now re-activates the tab (In Progress or Completed) they came from instead of always defaulting to In Progress.

- Pass `tab` param in course/kit structure URLs (in_progress/completed)
- Back buttons on both structure pages preserve the tab param via root_path(tab:)
- auto_click_controller gains an `index` value so it can activate any tab on connect
- Content Studio index reads params[:tab] and passes the correct index to auto-click

## Summary
Fixes a bug where navigating back from a course or classroom kit structure page always reset the Recent Creations section to the "In Progress" tab, regardless of which tab the user came from.

## Related Issue
Closes #1439

## Changes
- `auto_click_controller.js` — added `index` value (default `0`); on connect now clicks `tabItemTargets[indexValue]` instead of always the first tab
- `application_helper.rb` — `studio_course_card` and `studio_kit_card` now embed a `tab` param in their structure URL links (`in_progress` or `completed`)
- `courses/structure/show.html.erb` — back button updated to `root_path(tab: params[:tab])` to carry the tab context back
- `classroom_kits/structure/show.html.erb` — same back button fix as course structure
- `courses/index.html.erb` — Recent Creations section reads `params[:tab]`, computes active tab index, and passes it to `auto-click` controller via `data-auto-click-index-value`


## Screenshots / Visual Diffs

https://github.com/user-attachments/assets/85e7c381-14c8-4a94-9f8c-9744856ec283


## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
