### PR TITLE
Add kind discriminator column to courses table for microlesson support

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -27,7 +27,7 @@ class CoursesController < ApplicationController
                                        .includes(:tags, banner_attachment: :blob)
       @courses = @courses.page(filter_params[:page])
     else
-      @courses = Course.where(learning_partner_id: current_user.learning_partner_id)
+      @courses = Course.courses_only.where(learning_partner_id: current_user.learning_partner_id)
                        .where.not(neo_ai_course_id: nil)
                        .includes(:tags, banner_attachment: :blob)
                        .order(created_at: :desc)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,6 +8,9 @@ class Course < ApplicationRecord
   PER_PAGE_LIMIT = 12
 
   enum :visibility, { public: 'public', private: 'private' }, prefix: :visibility
+  enum :kind, { course: 'course', microlesson: 'microlesson' }, prefix: :kind
+
+  scope :courses_only, -> { where(kind: :course) }
 
   belongs_to :learning_partner, optional: true
 

--- a/app/services/courses/filter_service.rb
+++ b/app/services/courses/filter_service.rb
@@ -82,16 +82,16 @@ module Courses
 
     def base_course_scope(user, search_context)
       if search_context.search_enrolled_courses?
-        user.courses
+        user.courses.courses_only
       elsif search_context.search_incomplete_courses?
         completed_courses_ids = user.enrollments.completed.pluck(:course_id)
-        user.courses.where.not(id: completed_courses_ids).order(:id)
+        user.courses.courses_only.where.not(id: completed_courses_ids).order(:id)
       elsif search_context.search_complete_courses?
-        user.courses.where(id: user.enrollments.completed.select(:course_id)).order(:id)
+        user.courses.courses_only.where(id: user.enrollments.completed.select(:course_id)).order(:id)
       elsif search_context.search_unenrolled_courses?
-        Course.where.not(id: Enrollment.where(user_id: user.id).select(:course_id))
+        Course.courses_only.where.not(id: Enrollment.where(user_id: user.id).select(:course_id))
       else
-        Course.all
+        Course.courses_only
       end
     end
 

--- a/db/migrate/20260630094148_add_kind_to_courses.rb
+++ b/db/migrate/20260630094148_add_kind_to_courses.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddKindToCourses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :courses, :kind, :string, null: false, default: 'course'
+    add_index :courses, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_18_062854) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_30_094148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -153,6 +153,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_18_062854) do
     t.string "visibility", null: false
     t.string "neo_ai_course_id"
     t.bigint "learning_partner_id"
+    t.string "kind", default: "course", null: false
+    t.index ["kind"], name: "index_courses_on_kind"
     t.index ["learning_partner_id"], name: "index_courses_on_learning_partner_id"
     t.index ["neo_ai_course_id"], name: "index_courses_on_neo_ai_course_id", unique: true
   end


### PR DESCRIPTION
- Migration: add kind string column (null: false, default: 'course') with index
- Course model: add kind enum (course | microlesson) with :kind prefix
- Add courses_only scope to exclude microlessons from standard course queries

## Summary
- Adds `kind` string column to `courses` table (`null: false, default: 'course'`) with an index
- Adds `enum :kind` to the `Course` model with two values: `course` and `microlesson` (prefixed to avoid method name conflicts)
- Adds `courses_only` named scope to explicitly exclude microlessons from standard course queries

## Related Issue
Closes #1442

## Changes

- db/migrate/20260630094148_add_kind_to_courses.rb — migration adding kind column with default 'course' and index
- db/schema.rb — auto-updated to reflect the new column
- app/models/course.rb — added enum :kind and scope :courses_only-
- 

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing between standard courses and microlessons.
  * Course records now default to the standard course type, and the app can filter to show only full courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->