### PR TITLE
Enable microlesson feature flag and wire up creation picker card

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -13,7 +13,6 @@ production:
   enable_chatwoot: true
   content_studio: true
   classroom_kit_enabled: true
-  microlesson_enabled: true
 
 staging:
   <<: *default
@@ -22,7 +21,6 @@ staging:
   enable_chatwoot: true
   content_studio: true
   classroom_kit_enabled: true
-  microlesson_enabled: true
 
 development:
   <<: *default

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -13,6 +13,7 @@ production:
   enable_chatwoot: true
   content_studio: true
   classroom_kit_enabled: true
+  microlesson_enabled: true
 
 staging:
   <<: *default
@@ -21,11 +22,13 @@ staging:
   enable_chatwoot: true
   content_studio: true
   classroom_kit_enabled: true
+  microlesson_enabled: true
 
 development:
   <<: *default
   content_studio: true
   classroom_kit_enabled: true
+  microlesson_enabled: true
 
 test:
   <<: *default

--- a/engines/content_studio/app/views/content_studio/creations/new.html.erb
+++ b/engines/content_studio/app/views/content_studio/creations/new.html.erb
@@ -35,7 +35,7 @@
           ) %>
     </div>
 
-    <div class="flex-1">
+    <div data-url="<%= new_microlesson_path %>" class="flex-1">
       <%= content_type_card_component(
             title: 'Microlesson',
             description: 'A single-concept video with a quick check — perfect for refreshers and just-in-time training.',

--- a/engines/content_studio/config/routes.rb
+++ b/engines/content_studio/config/routes.rb
@@ -19,6 +19,7 @@ ContentStudio::Engine.routes.draw do
   get  'classroom-kits/:id/generating',        to: 'classroom_kits/wizard#generating',
                                                as: :generating_classroom_kit
   post 'classroom-kits/start_generation',      to: 'classroom_kits/wizard#start_generation', as: :start_kit_generation
+  get 'microlessons/new', to: 'microlessons/wizard#new', as: :new_microlesson
   get 'courses/new', to: 'courses/wizard#new', as: :new_course
   post 'courses', to: 'courses/wizard#create', as: :wizard_courses
   get 'courses/:id/configure_video', to: 'courses/wizard#configure_video', as: :configure_video

--- a/engines/content_studio/spec/views/content_studio/creations/new.html.erb_spec.rb
+++ b/engines/content_studio/spec/views/content_studio/creations/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../rails_helper'
 RSpec.describe 'content_studio/creations/new', type: :view do
   before do
     view.singleton_class.include ContentStudio::Engine.routes.url_helpers
-    allow(APP_CONFIG).to receive_messages(classroom_kit_enabled?: false, microlesson_enabled?: false)
+    allow(APP_CONFIG).to receive_messages(classroom_kit_enabled?: false, microlesson_enabled?: true)
     render
   end
 
@@ -27,8 +27,10 @@ RSpec.describe 'content_studio/creations/new', type: :view do
     expect(rendered).to include('trainer-led offline pack')
   end
 
-  it 'renders the Microlesson card' do
+  it 'renders the Microlesson card enabled with a data-url' do
     expect(rendered).to include('Microlesson')
+    expect(rendered).to have_selector('input[type="radio"][value="microlesson"]:not([disabled])')
+    expect(rendered).to have_selector('[data-url*="microlessons"]')
   end
 
   it 'renders the Online Course radio input as enabled' do


### PR DESCRIPTION
- Enable microlesson_enabled in production, staging, and development configs
- Add data-url and stub route (microlessons/wizard#new) so the card is selectable and the Continue button navigates correctly
- Update view spec to assert card is enabled with a data-url

Closes #1451

## Summary

- Enables microlesson_enabled: true in production, staging, and development (mirrors the classroom_kit_enabled pattern — stays false in default/test/docker)

- Adds data-url="<%= new_microlesson_path %>" to the microlesson card so the Stimulus controller can navigate on Continue
 
- Adds a stub route GET microlessons/new so new_microlesson_path resolves without error (full wizard controller comes in [#1444](https://github.com/openvitae-tech/blackboard-lms/issues/1444))

- Updates view spec: mock flipped to microlesson_enabled?: true, assertion added that card is enabled with a data-urlEnables microlesson_enabled: true in production, staging, and development (mirrors the classroom_kit_enabled pattern stays false in default/test/docker)
 
## Changes

- config/app_config.yml — flag enabled for production/staging/development
- engines/content_studio/config/routes.rb — stub route added
- engines/content_studio/app/views/content_studio/creations/new.html.erb — data-url wired up
- engines/content_studio/spec/views/content_studio/creations/new.html.erb_spec.rb — spec updated

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
