### PR TITLE
Add MockClient and microlesson methods to ApiClient

### DIFF
--- a/engines/content_studio/lib/content_studio.rb
+++ b/engines/content_studio/lib/content_studio.rb
@@ -4,6 +4,7 @@ require 'content_studio/version'
 require 'content_studio/engine'
 require 'content_studio/types'
 require 'content_studio/blackboard_client'
+require 'content_studio/mock_client'
 require 'content_studio/api_client'
 
 module ContentStudio

--- a/engines/content_studio/lib/content_studio/api_client.rb
+++ b/engines/content_studio/lib/content_studio/api_client.rb
@@ -103,7 +103,37 @@ module ContentStudio
 
       delegate :get_classroom_kit, :discard_kit, to: :client
 
+      # Microlesson methods — delegated to MockClient until real NeoAI endpoint is available.
+      def create_microlesson(prompt:, document_urls:, template_id:, logo_url:)
+        microlesson_client.create_microlesson(
+          prompt: prompt,
+          document_urls: document_urls,
+          template_id: template_id,
+          logo_url: logo_url
+        )
+      end
+
+      def get_microlesson(microlesson_id) # rubocop:disable Rails/Delegate
+        microlesson_client.get_microlesson(microlesson_id)
+      end
+
+      def replan_microlesson(microlesson_id:, prompt: nil, document_urls: nil)
+        microlesson_client.replan_microlesson(
+          microlesson_id: microlesson_id,
+          prompt: prompt,
+          document_urls: document_urls
+        )
+      end
+
+      def generate_microlesson(microlesson_id:)
+        microlesson_client.generate_microlesson(microlesson_id: microlesson_id)
+      end
+
       private
+
+      def microlesson_client
+        MockClient.new
+      end
 
       def client
         if cached_client.nil? || cached_client_cookie != current_cookie

--- a/engines/content_studio/lib/content_studio/mock_client.rb
+++ b/engines/content_studio/lib/content_studio/mock_client.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module ContentStudio
+  # In-process stub for the NeoAI microlesson API.
+  # Used during development and testing before the real NeoAI endpoint is available.
+  # Stores microlesson state in a class-level hash so successive get_microlesson
+  # calls simulate the PLANNING → PLANNED → GENERATING → COMPLETED state machine.
+  class MockClient
+    MOCK_MICROLESSONS = {}.freeze
+
+    # Advance through states on each poll: first two calls return PLANNING,
+    # then PLANNED (with title/description), then two calls GENERATING, then COMPLETED.
+    POLL_SEQUENCE = %w[PLANNING PLANNING PLANNED PLANNED GENERATING GENERATING COMPLETED].freeze
+
+    class << self
+      def store
+        @store ||= {}
+      end
+
+      def reset!
+        @store = {}
+      end
+    end
+
+    def create_microlesson(prompt:, document_urls: [], template_id: nil, logo_url: nil) # rubocop:disable Lint/UnusedMethodArgument
+      id = "mock-ml-#{SecureRandom.hex(6)}"
+      self.class.store[id] = { poll_index: 0, prompt: prompt }
+      id
+    end
+
+    def get_microlesson(microlesson_id)
+      entry = self.class.store[microlesson_id] || { poll_index: 0 }
+      index = entry[:poll_index].to_i
+      status = POLL_SEQUENCE[index] || 'COMPLETED'
+
+      # Advance the poll index (capped at last entry so it stays COMPLETED)
+      self.class.store[microlesson_id] = entry.merge(poll_index: [index + 1, POLL_SEQUENCE.length - 1].min)
+
+      build_microlesson(microlesson_id, status)
+    end
+
+    def replan_microlesson(microlesson_id:, prompt: nil, document_urls: nil) # rubocop:disable Lint/UnusedMethodArgument
+      entry = self.class.store[microlesson_id] || {}
+      # Reset back to PLANNING so the wizard re-polls from the start
+      self.class.store[microlesson_id] = entry.merge(poll_index: 0, prompt: prompt)
+      nil
+    end
+
+    def generate_microlesson(microlesson_id:)
+      entry = self.class.store[microlesson_id] || {}
+      # Jump to GENERATING state
+      generating_index = POLL_SEQUENCE.index('GENERATING') || 4
+      self.class.store[microlesson_id] = entry.merge(poll_index: generating_index)
+      nil
+    end
+
+    private
+
+    def build_microlesson(id, status)
+      case status
+      when 'PLANNING' then Microlesson.new(id: id, status: 'PLANNING')
+      when 'PLANNED'  then planned_microlesson(id)
+      when 'GENERATING'
+        Microlesson.new(id: id, status: 'GENERATING', title: 'Banking and Basic Strategies')
+      when 'COMPLETED' then completed_microlesson(id)
+      when 'FAILED' then Microlesson.new(id: id, status: 'FAILED')
+      end
+    end
+
+    def planned_microlesson(id)
+      Microlesson.new(
+        id: id,
+        status: 'PLANNED',
+        title: 'Banking and Basic Strategies',
+        description: 'A concise overview of core banking operations and customer service principles for ' \
+                     'front-line staff, covering account management, transaction handling, and complaint resolution.'
+      )
+    end
+
+    def completed_microlesson(id)
+      Microlesson.new(
+        id: id,
+        status: 'COMPLETED',
+        title: 'Banking and Basic Strategies',
+        description: 'A concise overview of core banking operations and customer service principles for ' \
+                     'front-line staff, covering account management, transaction handling, and complaint resolution.',
+        video_url: 'https://example.com/mock-microlesson.mp4',
+        thumbnail_url: 'https://placehold.co/480x270?text=Microlesson',
+        duration: 120
+      )
+    end
+  end
+end

--- a/engines/content_studio/lib/content_studio/mock_client.rb
+++ b/engines/content_studio/lib/content_studio/mock_client.rb
@@ -48,8 +48,10 @@ module ContentStudio
 
     def replan_microlesson(microlesson_id:, prompt: nil, document_urls: nil) # rubocop:disable Lint/UnusedMethodArgument
       entry = self.class.store[microlesson_id] || {}
-      # Reset back to PLANNING so the wizard re-polls from the start
-      self.class.store[microlesson_id] = entry.merge(poll_index: 0, prompt: prompt)
+      # Reset back to PLANNING; only overwrite prompt/fail when a new prompt is given
+      updates = { poll_index: 0 }
+      updates.merge!(prompt: prompt, fail: prompt.to_s.start_with?('fail_')) if prompt
+      self.class.store[microlesson_id] = entry.merge(updates)
       nil
     end
 

--- a/engines/content_studio/lib/content_studio/mock_client.rb
+++ b/engines/content_studio/lib/content_studio/mock_client.rb
@@ -34,7 +34,8 @@ module ContentStudio
     end
 
     def get_microlesson(microlesson_id)
-      entry = self.class.store[microlesson_id] || { poll_index: 0 }
+      entry = self.class.store[microlesson_id] or
+        raise Faraday::ResourceNotFound, "MockClient: microlesson #{microlesson_id} not found"
       index = entry[:poll_index].to_i
       sequence = entry[:fail] ? FAIL_SEQUENCE : POLL_SEQUENCE
       status = sequence[index] || sequence.last

--- a/engines/content_studio/lib/content_studio/mock_client.rb
+++ b/engines/content_studio/lib/content_studio/mock_client.rb
@@ -5,12 +5,17 @@ module ContentStudio
   # Used during development and testing before the real NeoAI endpoint is available.
   # Stores microlesson state in a class-level hash so successive get_microlesson
   # calls simulate the PLANNING → PLANNED → GENERATING → COMPLETED state machine.
+  #
+  # Failure path: pass a prompt beginning with "fail_" to create_microlesson and
+  # the sequence will resolve to FAILED instead of COMPLETED, making the FAILED
+  # branch in build_microlesson reachable for UI/spec testing.
   class MockClient
     MOCK_MICROLESSONS = {}.freeze
 
     # Advance through states on each poll: first two calls return PLANNING,
     # then PLANNED (with title/description), then two calls GENERATING, then COMPLETED.
     POLL_SEQUENCE = %w[PLANNING PLANNING PLANNED PLANNED GENERATING GENERATING COMPLETED].freeze
+    FAIL_SEQUENCE = %w[PLANNING PLANNING PLANNED PLANNED GENERATING GENERATING FAILED].freeze
 
     class << self
       def store
@@ -24,17 +29,18 @@ module ContentStudio
 
     def create_microlesson(prompt:, document_urls: [], template_id: nil, logo_url: nil) # rubocop:disable Lint/UnusedMethodArgument
       id = "mock-ml-#{SecureRandom.hex(6)}"
-      self.class.store[id] = { poll_index: 0, prompt: prompt }
+      self.class.store[id] = { poll_index: 0, prompt: prompt, fail: prompt.to_s.start_with?('fail_') }
       id
     end
 
     def get_microlesson(microlesson_id)
       entry = self.class.store[microlesson_id] || { poll_index: 0 }
       index = entry[:poll_index].to_i
-      status = POLL_SEQUENCE[index] || 'COMPLETED'
+      sequence = entry[:fail] ? FAIL_SEQUENCE : POLL_SEQUENCE
+      status = sequence[index] || sequence.last
 
-      # Advance the poll index (capped at last entry so it stays COMPLETED)
-      self.class.store[microlesson_id] = entry.merge(poll_index: [index + 1, POLL_SEQUENCE.length - 1].min)
+      # Advance the poll index (capped at last entry so it stays in terminal state)
+      self.class.store[microlesson_id] = entry.merge(poll_index: [index + 1, sequence.length - 1].min)
 
       build_microlesson(microlesson_id, status)
     end

--- a/engines/content_studio/lib/content_studio/types.rb
+++ b/engines/content_studio/lib/content_studio/types.rb
@@ -125,4 +125,15 @@ module ContentStudio
     :download_url,
     keyword_init: true
   )
+
+  Microlesson = Struct.new(
+    :id,
+    :title,
+    :description,
+    :status,          # PLANNING | PLANNED | GENERATING | COMPLETED | FAILED
+    :video_url,
+    :thumbnail_url,
+    :duration,        # seconds
+    keyword_init: true
+  )
 end

--- a/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
+++ b/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe ContentStudio::MockClient do
       expect(result).to be_a(ContentStudio::Microlesson)
     end
 
+    it 'raises Faraday::ResourceNotFound for an unknown id' do
+      expect { client.get_microlesson('unknown-id') }.to raise_error(Faraday::ResourceNotFound)
+    end
+
     it 'starts in PLANNING status' do
       result = client.get_microlesson(microlesson_id)
       expect(result.status).to eq('PLANNING')

--- a/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
+++ b/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
@@ -53,6 +53,31 @@ RSpec.describe ContentStudio::MockClient do
     end
   end
 
+  describe 'failure path (fail_ prompt prefix)' do
+    let(:microlesson_id) do
+      client.create_microlesson(prompt: 'fail_test', document_urls: [], template_id: '1', logo_url: nil)
+    end
+
+    it 'eventually reaches FAILED status' do
+      result = nil
+      7.times { result = client.get_microlesson(microlesson_id) }
+      expect(result.status).to eq('FAILED')
+    end
+
+    it 'stays in FAILED on further polls' do
+      8.times { client.get_microlesson(microlesson_id) }
+      result = client.get_microlesson(microlesson_id)
+      expect(result.status).to eq('FAILED')
+    end
+
+    it 'returns a Microlesson with only id and status set' do
+      result = nil
+      7.times { result = client.get_microlesson(microlesson_id) }
+      expect(result.video_url).to be_nil
+      expect(result.title).to be_nil
+    end
+  end
+
   describe '#replan_microlesson' do
     let(:microlesson_id) do
       client.create_microlesson(prompt: 'original', document_urls: [], template_id: '1', logo_url: nil)

--- a/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
+++ b/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative '../../rails_helper'
+
+RSpec.describe ContentStudio::MockClient do
+  subject(:client) { described_class.new }
+
+  before { described_class.reset! }
+
+  describe '#create_microlesson' do
+    it 'returns a unique microlesson id string' do
+      id = client.create_microlesson(prompt: 'test', document_urls: [], template_id: '1', logo_url: nil)
+      expect(id).to be_a(String).and start_with('mock-ml-')
+    end
+
+    it 'returns a different id on each call' do
+      id1 = client.create_microlesson(prompt: 'a', document_urls: [], template_id: '1', logo_url: nil)
+      id2 = client.create_microlesson(prompt: 'b', document_urls: [], template_id: '1', logo_url: nil)
+      expect(id1).not_to eq(id2)
+    end
+  end
+
+  describe '#get_microlesson' do
+    let(:microlesson_id) do
+      client.create_microlesson(prompt: 'test', document_urls: [], template_id: '1', logo_url: nil)
+    end
+
+    it 'returns a Microlesson struct' do
+      result = client.get_microlesson(microlesson_id)
+      expect(result).to be_a(ContentStudio::Microlesson)
+    end
+
+    it 'starts in PLANNING status' do
+      result = client.get_microlesson(microlesson_id)
+      expect(result.status).to eq('PLANNING')
+    end
+
+    it 'eventually reaches PLANNED status with title and description' do
+      results = Array.new(7) { client.get_microlesson(microlesson_id) }
+      planned = results.find { |r| r.status == 'PLANNED' }
+      expect(planned).not_to be_nil
+      expect(planned.title).to be_present
+      expect(planned.description).to be_present
+    end
+
+    it 'eventually reaches COMPLETED status with video and thumbnail urls' do
+      result = nil
+      7.times { result = client.get_microlesson(microlesson_id) }
+      expect(result.status).to eq('COMPLETED')
+      expect(result.video_url).to be_present
+      expect(result.thumbnail_url).to be_present
+      expect(result.duration).to be_positive
+    end
+  end
+
+  describe '#replan_microlesson' do
+    let(:microlesson_id) do
+      client.create_microlesson(prompt: 'original', document_urls: [], template_id: '1', logo_url: nil)
+    end
+
+    it 'resets the microlesson back to PLANNING' do
+      # Advance state a few times
+      3.times { client.get_microlesson(microlesson_id) }
+      client.replan_microlesson(microlesson_id: microlesson_id, prompt: 'revised')
+      result = client.get_microlesson(microlesson_id)
+      expect(result.status).to eq('PLANNING')
+    end
+  end
+
+  describe '#generate_microlesson' do
+    let(:microlesson_id) do
+      client.create_microlesson(prompt: 'test', document_urls: [], template_id: '1', logo_url: nil)
+    end
+
+    it 'jumps state to GENERATING' do
+      client.generate_microlesson(microlesson_id: microlesson_id)
+      result = client.get_microlesson(microlesson_id)
+      expect(result.status).to eq('GENERATING')
+    end
+  end
+end

--- a/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
+++ b/engines/content_studio/spec/lib/content_studio/mock_client_spec.rb
@@ -88,11 +88,28 @@ RSpec.describe ContentStudio::MockClient do
     end
 
     it 'resets the microlesson back to PLANNING' do
-      # Advance state a few times
       3.times { client.get_microlesson(microlesson_id) }
       client.replan_microlesson(microlesson_id: microlesson_id, prompt: 'revised')
       result = client.get_microlesson(microlesson_id)
       expect(result.status).to eq('PLANNING')
+    end
+
+    it 'preserves the existing prompt when no new prompt is given' do
+      3.times { client.get_microlesson(microlesson_id) }
+      client.replan_microlesson(microlesson_id: microlesson_id)
+      expect(described_class.store[microlesson_id][:prompt]).to eq('original')
+    end
+
+    it 'preserves the fail flag when no new prompt is given' do
+      fail_id = client.create_microlesson(prompt: 'fail_test', document_urls: [], template_id: '1', logo_url: nil)
+      client.replan_microlesson(microlesson_id: fail_id)
+      expect(described_class.store[fail_id][:fail]).to be true
+    end
+
+    it 'updates the prompt and fail flag when a new prompt is given' do
+      client.replan_microlesson(microlesson_id: microlesson_id, prompt: 'fail_revised')
+      expect(described_class.store[microlesson_id][:prompt]).to eq('fail_revised')
+      expect(described_class.store[microlesson_id][:fail]).to be true
     end
   end
 


### PR DESCRIPTION
- Add Microlesson struct to types.rb (id, title, description, status, video_url, thumbnail_url, duration)
- Create MockClient with in-process state machine simulating PLANNING → PLANNED → GENERATING → COMPLETED
- Implement create_microlesson, get_microlesson, replan_microlesson, generate_microlesson on MockClient
- Add matching method signatures to ApiClient delegating to MockClient
- Require mock_client in engine loader
- Add 8 specs covering full state machine lifecycle

## Summary

- Adds Microlesson struct to types.rb with fields: id, title, description, status, video_url, thumbnail_url, duration
- Creates ContentStudio::MockClient — an in-process stub that simulates the NeoAI state machine (PLANNING → PLANNED    → GENERATING → COMPLETED) using a class-level store
- Adds 4 methods to ApiClient delegating to MockClient: create_microlesson, get_microlesson, replan_microlesson,    generate_microlesson

## Related Issue
Closes #1443

## Changes

- lib/content_studio/types.rb — Microlesson struct added
- lib/content_studio/mock_client.rb — new file
- lib/content_studio/api_client.rb — 4 microlesson methods added
- lib/content_studio.rb — mock_client required
- spec/lib/content_studio/mock_client_spec.rb — 8 specs covering full lifecycle

## Screenshots / Visual Diffs
<!-- Required for any UI or NeoComponent changes. Attach before/after screenshots or recordings. -->

## Checklist
- [ ] RSpec passes (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] View spec added for any new views
- [ ] System spec added for any new user flows
- [ ] ui_manifest.md updated if a NeoComponent helper was added or changed
