### PR TITLE
Bump crass 1.0.7, msgpack 1.8.3, yard 0.9.44 (bundle audit)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
@@ -282,7 +282,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.7.2)
+    msgpack (1.8.3)
     multipart-post (2.4.1)
     nenv (0.3.0)
     net-http (0.9.1)
@@ -553,7 +553,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.42)
+    yard (0.9.44)
     zeitwerk (2.7.5)
 
 PLATFORMS


### PR DESCRIPTION
Fixes #1456

Bumps three gems flagged by the `bundle audit` security check in CI:

| Gem | From | To | Advisory |
|-----|------|----|----------|
| crass | 1.0.6 | 1.0.7 | GHSA-6jxj-px6v-747w, GHSA-6wmf-3r64-vcwv, GHSA-8vfg-2r28-hvhj, GHSA-wwpr-jff3-395c |
| msgpack | 1.7.2 | 1.8.3 | CVE-2026-54522 |
| yard | 0.9.42 | 0.9.44 | CVE-2026-49342 |

`bundle audit check --update` reports no vulnerabilities after these bumps.