### PR TITLE
Ignore unpatched webrick CVE-2026-38969 in bundler-audit

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,2 +1,3 @@
 ignore:
   - CVE-2026-33658 # Rails Active Storage DoS via multi-range requests — tracked for fix via Dependabot
+  - CVE-2026-38969 # webrick WEBrick trailer reparsing — no patched release yet, bump and remove once one ships


### PR DESCRIPTION
Fixes #1463

## Summary
`bundler-audit` runs as the first step of the `lint` CI job, before Brakeman/RuboCop, and is currently failing on every PR due to `CVE-2026-38969` in `webrick` (a direct `Gemfile` dependency). The advisory covers every released version through the latest (`1.9.2`), so there's no patched version to bump to yet.

## Changes
- Add `CVE-2026-38969` to `.bundler-audit.yml`'s `ignore:` list, following the existing convention already used for `CVE-2026-33658`, with a comment noting it's pending a patched release.

## Plan
Wait for a patched `webrick` release rather than removing/replacing the gem now. Once a patch ships, bump `webrick` and remove this ignore entry.